### PR TITLE
Fix typo _MCS_VER -> _MSC_VER and only add pragma warning when it's actually defined

### DIFF
--- a/include/units.h
+++ b/include/units.h
@@ -50,7 +50,7 @@
 #ifndef units_h__
 #define units_h__
 
-#if _MCS_VER < 1800
+#if defined(_MSC_VER) && _MSC_VER < 1800
 #	pragma warning(push)
 #	pragma warning(disable : 4520)
 #endif
@@ -4140,7 +4140,7 @@ namespace units
 
 };	// end namespace units
 
-#if _MCS_VER < 1800
+#if defined(_MSC_VER) && _MSC_VER < 1800
 #	pragma warning(pop)
 #endif
 


### PR DESCRIPTION
Trying to compile on GCC-ARM 5.4.1, the `#pragma warning` generates a warning that the pragma is being ignored, presumably because this only applies to MSVC. I've corrected the existing typo and added another check for the macro actually being defined. This gets rid of the warnings related to the pragma.

Note though I'm still unable to build on GCC-ARM due to unrelated errors/warnings which I'll be fixing later.