### PR TITLE
Fix error from GCC 4.8.5 on RHEL/Centos 7

### DIFF
--- a/include/units.h
+++ b/include/units.h
@@ -171,11 +171,11 @@
 	#define UNIT_ADD_LITERALS(namespaceName, nameSingular, abbreviation)\
 	namespace literals\
 	{\
-		inline constexpr namespaceName::nameSingular ## _t operator""_ ## abbreviation(long double d)\
+		inline constexpr namespaceName::nameSingular ## _t operator"" _ ## abbreviation(long double d)\
 		{\
 			return namespaceName::nameSingular ## _t(d);\
 		}\
-		inline constexpr namespaceName::nameSingular ## _t operator""_ ## abbreviation (unsigned long long d)\
+		inline constexpr namespaceName::nameSingular ## _t operator"" _ ## abbreviation (unsigned long long d)\
 		{\
 			return namespaceName::nameSingular ## _t(static_cast<namespaceName::nameSingular ## _t::underlying_type>(d));\
 		}\


### PR DESCRIPTION
On GCC 4.8.5 from RHEL 7 I get:
error: missing space between '""' and suffix identifer