### PR TITLE
Remove an unused parameter warning for clang

### DIFF
--- a/include/units.h
+++ b/include/units.h
@@ -2393,7 +2393,7 @@ namespace units
 	//------------------------------
 
 	template<class UnitTypeLhs, class UnitTypeRhs, std::enable_if_t<!traits::is_same_scale<UnitTypeLhs, UnitTypeRhs>::value, int> = 0>
-	constexpr inline int operator+(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
+	constexpr inline int operator+(const UnitTypeLhs& /* lhs */, const UnitTypeRhs& /* rhs */) noexcept
 	{
 		static_assert(traits::is_same_scale<UnitTypeLhs, UnitTypeRhs>::value, "Cannot add units with different linear/non-linear scales.");
 		return 0;


### PR DESCRIPTION
When using clang with `-Wall` and `-Wextra` it complains because of unused parameters.
Since the parameter do not get used with any configuration I removed the parameter names instead of using the attribute `[[maybe_unused]]`.