### PR TITLE
Support integral underlying types

### DIFF
--- a/include/units.h
+++ b/include/units.h
@@ -2001,7 +2001,8 @@ namespace units
 		template<class UnitTypeRhs, typename Ty, template<typename> class NlsRhs>
 		inline constexpr bool operator<(const unit<UnitTypeRhs, Ty, NlsRhs>& rhs) const noexcept
 		{
-			return (nls::m_value < units::convert<unit>(rhs).m_value);
+			using CommonUnit = std::common_type_t<unit, unit<UnitTypeRhs, Ty, NlsRhs>>;
+			return (CommonUnit(*this).m_value < CommonUnit(rhs).m_value);
 		}
 
 		/**
@@ -2013,7 +2014,8 @@ namespace units
 		template<class UnitTypeRhs, typename Ty, template<typename> class NlsRhs>
 		inline constexpr bool operator<=(const unit<UnitTypeRhs, Ty, NlsRhs>& rhs) const noexcept
 		{
-			return (nls::m_value <= units::convert<unit>(rhs).m_value);
+			using CommonUnit = std::common_type_t<unit, unit<UnitTypeRhs, Ty, NlsRhs>>;
+			return (CommonUnit(*this).m_value <= CommonUnit(rhs).m_value);
 		}
 
 		/**
@@ -2025,7 +2027,8 @@ namespace units
 		template<class UnitTypeRhs, typename Ty, template<typename> class NlsRhs>
 		inline constexpr bool operator>(const unit<UnitTypeRhs, Ty, NlsRhs>& rhs) const noexcept
 		{
-			return (nls::m_value > units::convert<unit>(rhs).m_value);
+			using CommonUnit = std::common_type_t<unit, unit<UnitTypeRhs, Ty, NlsRhs>>;
+			return (CommonUnit(*this).m_value > CommonUnit(rhs).m_value);
 		}
 
 		/**
@@ -2037,7 +2040,8 @@ namespace units
 		template<class UnitTypeRhs, typename Ty, template<typename> class NlsRhs>
 		inline constexpr bool operator>=(const unit<UnitTypeRhs, Ty, NlsRhs>& rhs) const noexcept
 		{
-			return (nls::m_value >= units::convert<unit>(rhs).m_value);
+			using CommonUnit = std::common_type_t<unit, unit<UnitTypeRhs, Ty, NlsRhs>>;
+			return (CommonUnit(*this).m_value >= CommonUnit(rhs).m_value);
 		}
 
 		/**
@@ -2814,56 +2818,96 @@ namespace units
 	constexpr std::enable_if_t<units::traits::is_dimensionless_unit_v<UnitConversion> && std::is_arithmetic_v<T>, bool>
 	operator>=(const T& lhs, const UnitConversion& rhs) noexcept
 	{
-		return std::isgreaterequal(lhs, static_cast<UNIT_LIB_DEFAULT_TYPE>(rhs));
+		using CommonUnderlying = std::common_type_t<T, typename UnitConversion::underlying_type>;
+
+		if constexpr(std::is_integral_v<CommonUnderlying>)
+		{
+			return lhs >= static_cast<CommonUnderlying>(rhs);
+		}
+		else
+		{
+			return std::isgreaterequal(lhs, static_cast<CommonUnderlying>(rhs));
+		}
 	}
 
 	template<typename UnitConversion, typename T>
 	constexpr std::enable_if_t<units::traits::is_dimensionless_unit_v<UnitConversion> && std::is_arithmetic_v<T>, bool>
 	operator>=(const UnitConversion& lhs, const T& rhs) noexcept
 	{
-		return std::isgreaterequal(static_cast<UNIT_LIB_DEFAULT_TYPE>(lhs), rhs);
+		using CommonUnderlying = std::common_type_t<typename UnitConversion::underlying_type, T>;
+
+		if constexpr(std::is_integral_v<CommonUnderlying>)
+		{
+			return static_cast<CommonUnderlying>(lhs) >= rhs;
+		}
+		else
+		{
+			return std::isgreaterequal(static_cast<CommonUnderlying>(lhs), rhs);
+		}
 	}
 
 	template<typename UnitConversion, typename T>
 	constexpr std::enable_if_t<units::traits::is_dimensionless_unit_v<UnitConversion> && std::is_arithmetic_v<T>, bool>
 	operator>(const T& lhs, const UnitConversion& rhs) noexcept
 	{
-		return lhs > static_cast<UNIT_LIB_DEFAULT_TYPE>(rhs);
+		using CommonUnderlying = std::common_type_t<T, typename UnitConversion::underlying_type>;
+		return lhs > static_cast<CommonUnderlying>(rhs);
 	}
 
 	template<typename UnitConversion, typename T>
 	constexpr std::enable_if_t<units::traits::is_dimensionless_unit_v<UnitConversion> && std::is_arithmetic_v<T>, bool>
 	operator>(const UnitConversion& lhs, const T& rhs) noexcept
 	{
-		return static_cast<UNIT_LIB_DEFAULT_TYPE>(lhs) > rhs;
+		using CommonUnderlying = std::common_type_t<typename UnitConversion::underlying_type, T>;
+		return static_cast<CommonUnderlying>(lhs) > rhs;
 	}
 
 	template<typename UnitConversion, typename T>
 	constexpr std::enable_if_t<units::traits::is_dimensionless_unit_v<UnitConversion> && std::is_arithmetic_v<T>, bool>
 	operator<=(const T& lhs, const UnitConversion& rhs) noexcept
 	{
-		return std::islessequal(lhs, static_cast<UNIT_LIB_DEFAULT_TYPE>(rhs));
+		using CommonUnderlying = std::common_type_t<T, typename UnitConversion::underlying_type>;
+
+		if constexpr(std::is_integral_v<CommonUnderlying>)
+		{
+			return lhs <= static_cast<CommonUnderlying>(rhs);
+		}
+		else
+		{
+			return std::islessequal(lhs, static_cast<CommonUnderlying>(rhs));
+		}
 	}
 
 	template<typename UnitConversion, typename T>
 	constexpr std::enable_if_t<units::traits::is_dimensionless_unit_v<UnitConversion> && std::is_arithmetic_v<T>, bool>
 	operator<=(const UnitConversion& lhs, const T& rhs) noexcept
 	{
-		return std::islessequal(static_cast<UNIT_LIB_DEFAULT_TYPE>(lhs), rhs);
+		using CommonUnderlying = std::common_type_t<typename UnitConversion::underlying_type, T>;
+
+		if constexpr(std::is_integral_v<CommonUnderlying>)
+		{
+			return static_cast<CommonUnderlying>(lhs) <= rhs;
+		}
+		else
+		{
+			return std::islessequal(static_cast<CommonUnderlying>(lhs), rhs);
+		}
 	}
 
 	template<typename UnitConversion, typename T>
 	constexpr std::enable_if_t<units::traits::is_dimensionless_unit_v<UnitConversion> && std::is_arithmetic_v<T>, bool>
 	operator<(const T& lhs, const UnitConversion& rhs) noexcept
 	{
-		return lhs < static_cast<UNIT_LIB_DEFAULT_TYPE>(rhs);
+		using CommonUnderlying = std::common_type_t<T, typename UnitConversion::underlying_type>;
+		return lhs < static_cast<CommonUnderlying>(rhs);
 	}
 
 	template<typename UnitConversion, typename T>
 	constexpr std::enable_if_t<units::traits::is_dimensionless_unit_v<UnitConversion> && std::is_arithmetic_v<T>, bool>
 	operator<(const UnitConversion& lhs, const T& rhs) noexcept
 	{
-		return static_cast<UNIT_LIB_DEFAULT_TYPE>(lhs) < rhs;
+		using CommonUnderlying = std::common_type_t<typename UnitConversion::underlying_type, T>;
+		return static_cast<CommonUnderlying>(lhs) < rhs;
 	}
 
 	//----------------------------------

--- a/include/units.h
+++ b/include/units.h
@@ -1597,7 +1597,7 @@ namespace units
 			// constexpr pi in denominator
 			else if constexpr(PiRatio::num / PiRatio::den <= -1 && PiRatio::num % PiRatio::den == 0)
 			{
-				return static_cast<To>((static_cast<CommonUnderlying>(value) * static_cast<CommonUnderlying>(Ratio::num)) / (static_cast<CommonUnderlying>(Ratio::den) * static_cast<CommonUnderlying>(pow(constants::detail::PI_VAL, -PiRatio::num / PiRatio::den))));
+				return static_cast<To>(normal_convert(static_cast<CommonUnderlying>(value) / static_cast<CommonUnderlying>(pow(constants::detail::PI_VAL, -PiRatio::num / PiRatio::den))));
 			}
 			// non-constexpr pi in numerator. This case (only) isn't actually constexpr.
 			else if constexpr(PiRatio::num / PiRatio::den < 1 && PiRatio::num / PiRatio::den > -1)
@@ -1986,7 +1986,7 @@ namespace units
 		 * @details		enable implicit conversions from std::chrono::duration types ONLY for time units
 		 * @param[in]	value value of the unit
 		 */
-		template<class Rep, class Period, class = std::enable_if_t<std::is_arithmetic_v<Rep>>>
+		template<class Rep, class Period, class = std::enable_if_t<detail::is_non_lossy_convertible<Rep, T>>>
 		inline constexpr unit(const std::chrono::duration<Rep, Period>& value) noexcept : 
 		nls(units::convert<unit>(units::unit<units::unit_conversion<Period, dimension::time>, Rep>(value.count()))())
 		{
@@ -2191,7 +2191,7 @@ namespace units
 		 * @brief		chrono implicit type conversion.
 		 * @details		only enabled for time unit types.
 		 */
-		template<class Rep, class Period, typename U = UnitType, std::enable_if_t<units::traits::is_convertible_unit_conversion_v<U, units::unit_conversion<std::ratio<1>, dimension::time>> && std::is_arithmetic_v<Rep>, int> = 0>
+		template<class Rep, class Period, typename U = UnitType, std::enable_if_t<units::traits::is_convertible_unit_conversion_v<U, units::unit_conversion<std::ratio<1>, dimension::time>> && detail::is_non_lossy_convertible<T, Rep>, int> = 0>
 		inline constexpr operator std::chrono::duration<Rep, Period>() const noexcept
 		{
 			return std::chrono::duration<Rep, Period>(units::convert<units::unit<units::unit_conversion<Period, dimension::time>, Rep>>(*this)());

--- a/include/units.h
+++ b/include/units.h
@@ -2194,7 +2194,7 @@ namespace units
 		template<class Rep, class Period, typename U = UnitType, std::enable_if_t<units::traits::is_convertible_unit_conversion_v<U, units::unit_conversion<std::ratio<1>, dimension::time>> && detail::is_non_lossy_convertible<T, Rep>, int> = 0>
 		inline constexpr operator std::chrono::duration<Rep, Period>() const noexcept
 		{
-			return std::chrono::duration<Rep, Period>(units::convert<units::unit<units::unit_conversion<Period, dimension::time>, Rep>>(*this)());
+			return std::chrono::duration<Rep, Period>(units::unit<units::unit_conversion<Period, dimension::time>, Rep>(*this)());
 		}
 
 		/**
@@ -2272,7 +2272,7 @@ namespace units
 	inline std::ostream& operator<<(std::ostream& os, const unit<UnitConversion, T, NonLinearScale>& obj)
 	{
 		using BaseUnit = unit_conversion<std::ratio<1>, typename traits::unit_conversion_traits<UnitConversion>::dimension_type>;
-		os << convert<unit<BaseUnit, T, NonLinearScale>>(obj)();
+		os << unit<BaseUnit, T, NonLinearScale>(obj)();
 
 		using DimType = typename traits::dimension_of_t<UnitConversion>;
 		if constexpr(!DimType::empty)

--- a/include/units.h
+++ b/include/units.h
@@ -2155,14 +2155,15 @@ namespace units
 		 *				implicitly, but this can be used in cases where explicit notation of a conversion
 		 *				is beneficial, or where an r-value container is needed.
 		 * @tparam		U unit (not unit) to convert to
+		 * @tparam		Ty underlying type to convert to
 		 * @returns		a unit container with the specified units containing the equivalent value to
 		 *				*this.
 		 */
-		template<class U>
-		inline constexpr unit<U> convert() const noexcept
+		template<class U, typename Ty = T>
+		inline constexpr unit<U, Ty> convert() const noexcept
 		{
 			static_assert(traits::is_unit_conversion_v<U>, "Template parameter `U` must be a unit tag type.");
-			return unit<U>(*this);
+			return unit<U, Ty>(*this);
 		}
 
 		/**

--- a/include/units.h
+++ b/include/units.h
@@ -3006,65 +3006,72 @@ namespace units
 
 	/// Addition for convertible unit types with a decibel_scale
 	template<class UnitTypeLhs, class UnitTypeRhs,
-		std::enable_if_t<traits::has_decibel_scale_v<UnitTypeLhs, UnitTypeRhs>, int> = 0>
-	inline constexpr auto operator+(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept -> unit<compound_unit_conversion<squared<typename units::traits::unit_traits<UnitTypeLhs>::unit_conversion>>, typename units::traits::unit_traits<UnitTypeLhs>::underlying_type, decibel_scale>
+		std::enable_if_t<traits::is_convertible_unit_v<UnitTypeLhs, UnitTypeRhs> && traits::has_decibel_scale_v<UnitTypeLhs, UnitTypeRhs>, int> = 0>
+	constexpr auto operator+(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept -> unit<squared<typename units::traits::unit_traits<std::common_type_t<UnitTypeLhs, UnitTypeRhs>>::unit_conversion>, typename std::common_type_t<UnitTypeLhs, UnitTypeRhs>::underlying_type, decibel_scale>
 	{
-		using LhsUnitConversion = typename units::traits::unit_traits<UnitTypeLhs>::unit_conversion;
-		using underlying_type = typename units::traits::unit_traits<UnitTypeLhs>::underlying_type;
+		using CommonUnit		= std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
+		using CommonUnderlying	= typename CommonUnit::underlying_type;
 
-		return unit<compound_unit_conversion<squared<LhsUnitConversion>>, underlying_type, decibel_scale>
-			(lhs.template toLinearized<underlying_type>() * convert<UnitTypeLhs>(rhs).template toLinearized<underlying_type>(), std::true_type());
+		return unit<squared<typename CommonUnit::unit_conversion>, CommonUnderlying, decibel_scale>
+			(CommonUnit(lhs).template toLinearized<CommonUnderlying>() * CommonUnit(rhs).template toLinearized<CommonUnderlying>(), std::true_type());
 	}
 
 	/// Addition between unit types with a decibel_scale and dimensionless dB units
-	template<class UnitTypeLhs>
-	inline constexpr std::enable_if_t<traits::has_decibel_scale_v<UnitTypeLhs> && !traits::is_dimensionless_unit_v<UnitTypeLhs>, UnitTypeLhs>
-	operator+(const UnitTypeLhs& lhs, const dB_t& rhs) noexcept
+	template<class UnitTypeLhs, class UnitTypeRhs,
+		std::enable_if_t<traits::has_decibel_scale_v<UnitTypeLhs, UnitTypeRhs> && !traits::is_dimensionless_unit_v<UnitTypeLhs> && traits::is_dimensionless_unit_v<UnitTypeRhs>, int> = 0>
+	constexpr unit<typename UnitTypeLhs::unit_conversion, std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>, decibel_scale>
+	operator+(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using underlying_type = typename units::traits::unit_traits<UnitTypeLhs>::underlying_type;
-		return UnitTypeLhs(lhs.template toLinearized<underlying_type>() * rhs.template toLinearized<underlying_type>(), std::true_type());
+		using CommonUnderlying = std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>;
+		return unit<typename UnitTypeLhs::unit_conversion, CommonUnderlying, decibel_scale>
+			(lhs.template toLinearized<CommonUnderlying>() * rhs.template toLinearized<CommonUnderlying>(), std::true_type());
 	}
 
 	/// Addition between unit types with a decibel_scale and dimensionless dB units
-	template<class UnitTypeRhs>
-	inline constexpr std::enable_if_t<traits::has_decibel_scale_v<UnitTypeRhs> && !traits::is_dimensionless_unit_v<UnitTypeRhs>, UnitTypeRhs>
-	operator+(const dB_t& lhs, const UnitTypeRhs& rhs) noexcept
+	template<class UnitTypeLhs, class UnitTypeRhs,
+		std::enable_if_t<traits::has_decibel_scale_v<UnitTypeLhs, UnitTypeRhs> && traits::is_dimensionless_unit_v<UnitTypeLhs> && !traits::is_dimensionless_unit_v<UnitTypeRhs>, int> = 0>
+	constexpr unit<typename UnitTypeRhs::unit_conversion, std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>, decibel_scale>
+	operator+(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using underlying_type = typename units::traits::unit_traits<UnitTypeRhs>::underlying_type;
-		return UnitTypeRhs(lhs.template toLinearized<underlying_type>() * rhs.template toLinearized<underlying_type>(), std::true_type());
+		using CommonUnderlying = std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>;
+		return unit<typename UnitTypeRhs::unit_conversion, CommonUnderlying, decibel_scale>
+			(lhs.template toLinearized<CommonUnderlying>() * rhs.template toLinearized<CommonUnderlying>(), std::true_type());
 	}
 
 	/// Subtraction for convertible unit types with a decibel_scale
-	template<class UnitTypeLhs, class UnitTypeRhs, std::enable_if_t<traits::has_decibel_scale_v<UnitTypeLhs, UnitTypeRhs>, int> = 0>
-	inline constexpr auto operator-(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept -> unit<compound_unit_conversion<typename units::traits::unit_traits<UnitTypeLhs>::unit_conversion, inverse<typename units::traits::unit_traits<UnitTypeRhs>::unit_conversion>>, typename units::traits::unit_traits<UnitTypeLhs>::underlying_type, decibel_scale>
+	template<class UnitTypeLhs, class UnitTypeRhs, std::enable_if_t<traits::is_convertible_unit_v<UnitTypeLhs, UnitTypeRhs> && traits::has_decibel_scale_v<UnitTypeLhs, UnitTypeRhs>, int> = 0>
+	constexpr auto operator-(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept -> unit<compound_unit_conversion<typename units::traits::unit_traits<UnitTypeLhs>::unit_conversion, inverse<typename units::traits::unit_traits<UnitTypeRhs>::unit_conversion>>, typename std::common_type_t<UnitTypeLhs, UnitTypeRhs>::underlying_type, decibel_scale>
 	{
-		using LhsUnitConversion = typename units::traits::unit_traits<UnitTypeLhs>::unit_conversion;
-		using RhsUnitConversion = typename units::traits::unit_traits<UnitTypeRhs>::unit_conversion;
-		using underlying_type = typename units::traits::unit_traits<UnitTypeLhs>::underlying_type;
+		using UnitConversionLhs	= typename units::traits::unit_traits<UnitTypeLhs>::unit_conversion;
+		using UnitConversionRhs	= typename units::traits::unit_traits<UnitTypeRhs>::unit_conversion;
+		using CommonUnit		= std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
+		using CommonUnderlying	= typename CommonUnit::underlying_type;
 
-		return unit<compound_unit_conversion<LhsUnitConversion, inverse<RhsUnitConversion>>, underlying_type, decibel_scale>
-			(lhs.template toLinearized<underlying_type>() / convert<UnitTypeLhs>(rhs).template toLinearized<underlying_type>(), std::true_type());
+		return unit<compound_unit_conversion<UnitConversionLhs, inverse<UnitConversionRhs>>, CommonUnderlying, decibel_scale>
+			(CommonUnit(lhs).template toLinearized<CommonUnderlying>() / CommonUnit(rhs).template toLinearized<CommonUnderlying>(), std::true_type());
 	}
 
 	/// Subtraction between unit types with a decibel_scale and dimensionless dB units
-	template<class UnitTypeLhs>
-	inline constexpr std::enable_if_t<traits::has_decibel_scale_v<UnitTypeLhs> && !traits::is_dimensionless_unit_v<UnitTypeLhs>, UnitTypeLhs>
-	operator-(const UnitTypeLhs& lhs, const dB_t& rhs) noexcept
+	template<class UnitTypeLhs, class UnitTypeRhs,
+		std::enable_if_t<traits::has_decibel_scale_v<UnitTypeLhs, UnitTypeRhs> && !traits::is_dimensionless_unit_v<UnitTypeLhs> && traits::is_dimensionless_unit_v<UnitTypeRhs>, int> = 0>
+	constexpr unit<typename UnitTypeLhs::unit_conversion, std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>, decibel_scale>
+	operator-(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using underlying_type = typename units::traits::unit_traits<UnitTypeLhs>::underlying_type;
-		return UnitTypeLhs(lhs.template toLinearized<underlying_type>() / rhs.template toLinearized<underlying_type>(), std::true_type());
+		using CommonUnderlying = std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>;
+		return unit<typename UnitTypeLhs::unit_conversion, CommonUnderlying, decibel_scale>
+			(lhs.template toLinearized<CommonUnderlying>() / rhs.template toLinearized<CommonUnderlying>(), std::true_type());
 	}
 
 	/// Subtraction between unit types with a decibel_scale and dimensionless dB units
-	template<class UnitTypeRhs, 
-		std::enable_if_t<traits::has_decibel_scale_v<UnitTypeRhs> && !traits::is_dimensionless_unit_v<UnitTypeRhs>, int> = 0>
-	inline constexpr auto operator-(const dB_t& lhs, const UnitTypeRhs& rhs) noexcept -> unit<inverse<typename units::traits::unit_traits<UnitTypeRhs>::unit_conversion>, typename units::traits::unit_traits<UnitTypeRhs>::underlying_type, decibel_scale>
+	template<class UnitTypeLhs, class UnitTypeRhs,
+		std::enable_if_t<traits::has_decibel_scale_v<UnitTypeLhs, UnitTypeRhs> && traits::is_dimensionless_unit_v<UnitTypeLhs> && !traits::is_dimensionless_unit_v<UnitTypeRhs>, int> = 0>
+	constexpr auto operator-(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept -> unit<inverse<typename units::traits::unit_traits<UnitTypeRhs>::unit_conversion>, std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>, decibel_scale>
 	{
-		using RhsUnitConversion = typename units::traits::unit_traits<UnitTypeRhs>::unit_conversion;
-		using underlying_type = typename units::traits::unit_traits<RhsUnitConversion>::underlying_type;
+		using UnitConversionRhs	= typename units::traits::unit_traits<UnitTypeRhs>::unit_conversion;
+		using CommonUnderlying	= std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>;
 
-		return unit<inverse<RhsUnitConversion>, underlying_type, decibel_scale>
-			(lhs.template toLinearized<underlying_type>() / rhs.template toLinearized<underlying_type>(), std::true_type());
+		return unit<inverse<UnitConversionRhs>, CommonUnderlying, decibel_scale>
+			(lhs.template toLinearized<CommonUnderlying>() / rhs.template toLinearized<CommonUnderlying>(), std::true_type());
 	}
 
 	//------------------------------

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -1372,7 +1372,7 @@ TEST_F(UnitContainer, unitTypeDivision)
 	EXPECT_TRUE(isSame);
 }
 
-TEST_F(UnitContainer, unitTypeModulus)
+TEST_F(UnitContainer, unitTypeModulo)
 {
 	const unit<meters, int> a_m(2200);
 	const unit<meters, int> b_m(1800);
@@ -1390,27 +1390,9 @@ TEST_F(UnitContainer, unitTypeModulus)
 	EXPECT_EQ(2, b_km());
 	static_assert(has_equivalent_unit_conversion(b_km, a_km));
 
-	auto e_m = a_m % 2000;
+	const auto e_m = a_m % 2000;
 	EXPECT_EQ(200, e_m());
 	static_assert(has_equivalent_unit_conversion(e_m, a_m));
-
-	e_m %= a_m;
-	EXPECT_EQ(200, e_m());
-
-	e_m %= a_km;
-	EXPECT_EQ(200, e_m());
-
-	e_m %= unit<dimensionless_unit, int>(180);
-	EXPECT_EQ(20, e_m());
-
-	e_m %= dimensionless(15.0);
-	EXPECT_EQ(5, e_m());
-
-	e_m %= 6;
-	EXPECT_EQ(5, e_m());
-
-	e_m %= 3.0;
-	EXPECT_EQ(2, e_m());
 
 	const unit<dimensionless_unit, int> a_s(12);
 	const unit<dimensionless_unit, int> b_s(5);
@@ -1419,21 +1401,9 @@ TEST_F(UnitContainer, unitTypeModulus)
 	EXPECT_EQ(2, c_s());
 	static_assert(has_equivalent_unit_conversion(c_s, a_s));
 
-	auto d_s = a_s % 20;
+	const auto d_s = a_s % 20;
 	EXPECT_EQ(12, d_s());
 	static_assert(has_equivalent_unit_conversion(d_s, a_s));
-
-	d_s %= unit<dimensionless_unit, int>(20);
-	EXPECT_EQ(12, d_s());
-
-	d_s %= dimensionless(7.0);
-	EXPECT_EQ(5, d_s());
-
-	d_s %= 3;
-	EXPECT_EQ(2, d_s());
-
-	d_s %= 3.0;
-	EXPECT_EQ(2, d_s());
 }
 
 TEST_F(UnitContainer, compoundAssignmentAddition)
@@ -1526,6 +1496,45 @@ TEST_F(UnitContainer, compoundAssignmentDivision)
 	b /= 2;
 
 	EXPECT_EQ(dimensionless(2.0), b);
+}
+
+TEST_F(UnitContainer, compoundAssignmentModulo)
+{
+	// units
+	unit<meters, int> a_m(2200);
+
+	a_m %= unit<meters, int>(2000);
+	EXPECT_EQ(200, a_m());
+
+	a_m %= unit<kilometers, int>(1);
+	EXPECT_EQ(200, a_m());
+
+	a_m %= unit<dimensionless_unit, int>(180);
+	EXPECT_EQ(20, a_m());
+
+	a_m %= dimensionless(15.0);
+	EXPECT_EQ(5, a_m());
+
+	a_m %= 6;
+	EXPECT_EQ(5, a_m());
+
+	a_m %= 3.0;
+	EXPECT_EQ(2, a_m());
+
+	// dimensionless
+	unit<dimensionless_unit, int> a_s(12);
+
+	a_s %= unit<dimensionless_unit, int>(20);
+	EXPECT_EQ(12, a_s());
+
+	a_s %= dimensionless(7.0);
+	EXPECT_EQ(5, a_s());
+
+	a_s %= 3;
+	EXPECT_EQ(2, a_s());
+
+	a_s %= 3.0;
+	EXPECT_EQ(2, a_s());
 }
 
 TEST_F(UnitContainer, dimensionlessTypeImplicitConversion)

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -1008,22 +1008,72 @@ TEST_F(UnitContainer, constructionFromArithmeticType)
 
 TEST_F(UnitContainer, constructionFromUnitContainer)
 {
-	unit<meters, int> a_m(1);
+	const unit<meters, int> a_m(1);
 
-	unit<meters, int> b_m(a_m);
+	const unit<meters, int> b_m(a_m);
 	EXPECT_EQ(1, b_m());
 
-	unit<millimeters, int> a_mm(b_m);
+	const unit<millimeters, int> a_mm(b_m);
 	EXPECT_EQ(1000, a_mm());
 
-	meter_t c_m(b_m);
+	const meter_t c_m(b_m);
 	EXPECT_EQ(1.0, c_m());
 
-	meter_t d_m(a_mm);
+	const meter_t d_m(a_mm);
 	EXPECT_EQ(1.0, d_m());
 
-	meter_t e_m(unit<kilometers, int>(1));
+	const meter_t e_m(unit<kilometers, int>(1));
 	EXPECT_EQ(1000.0, e_m());
+
+	const unit<dimensionless_unit, int> a_dim(1);
+
+	const unit<dimensionless_unit, int> b_dim(a_dim);
+	EXPECT_EQ(1, b_dim());
+
+	const dimensionless c_dim(b_dim);
+	EXPECT_EQ(1, b_dim());
+
+	const dimensionless d_dim(c_dim);
+	EXPECT_EQ(1.0, d_dim());
+}
+
+TEST_F(UnitContainer, assignmentFromUnitContainer)
+{
+	const unit<meters, int> a_m(1);
+
+	unit<meters, int> b_m;
+	b_m = a_m;
+	EXPECT_EQ(1, b_m());
+
+	unit<millimeters, int> a_mm;
+	a_mm = b_m;
+	EXPECT_EQ(1000, a_mm());
+
+	meter_t c_m;
+	c_m = b_m;
+	EXPECT_EQ(1.0, c_m());
+
+	meter_t d_m;
+	d_m = a_mm;
+	EXPECT_EQ(1.0, d_m());
+
+	meter_t e_m;
+	e_m = unit<kilometers, int>(1);
+	EXPECT_EQ(1000.0, e_m());
+
+	const unit<dimensionless_unit, int> a_dim(1);
+
+	unit<dimensionless_unit, int> b_dim;
+	b_dim = a_dim;
+	EXPECT_EQ(1, b_dim());
+
+	dimensionless c_dim;
+	c_dim = b_dim;
+	EXPECT_EQ(1, b_dim());
+
+	dimensionless d_dim;
+	d_dim = c_dim;
+	EXPECT_EQ(1.0, d_dim());
 }
 
 TEST_F(UnitContainer, make_unit)

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -985,23 +985,23 @@ TEST_F(UnitContainer, has_value_member)
 
 TEST_F(UnitContainer, constructionFromArithmeticType)
 {
-	meter_t a_m(1.0);
+	const meter_t a_m(1.0);
 	EXPECT_EQ(1.0, a_m());
 
-	meter_t b_m(1);
+	const meter_t b_m(1);
 	EXPECT_EQ(1, b_m());
 
-	unit<meters, int> c_m(1);
+	const unit<meters, int> c_m(1);
 	static_assert(std::is_same_v<int, decltype(c_m())>);
 	EXPECT_EQ(1, c_m());
 
-	dimensionless a_dim(1.0);
+	const dimensionless a_dim(1.0);
 	EXPECT_EQ(1.0, a_dim());
 
-	dimensionless b_dim(1);
+	const dimensionless b_dim(1);
 	EXPECT_EQ(1, b_dim());
 
-	unit<dimensionless_unit, int> c_dim(1);
+	const unit<dimensionless_unit, int> c_dim(1);
 	static_assert(std::is_same_v<int, decltype(c_dim())>);
 	EXPECT_EQ(1, c_dim());
 }
@@ -1028,8 +1028,23 @@ TEST_F(UnitContainer, constructionFromUnitContainer)
 
 TEST_F(UnitContainer, make_unit)
 {
-	auto dist = units::make_unit<meter_t>(5);
-	EXPECT_EQ(meter_t(5), dist);
+	const auto a_m = make_unit<meter_t>(5.0);
+	EXPECT_EQ(meter_t(5.0), a_m);
+
+	const auto b_m = make_unit<meter_t>(5);
+	EXPECT_EQ(meter_t(5), b_m);
+
+	const auto c_m = make_unit<unit<meters, int>>(5);
+	EXPECT_EQ((unit<meters, int>(5)), c_m);
+
+	const auto a_dim = make_unit<dimensionless>(5.0);
+	EXPECT_EQ(dimensionless(5.0), a_dim);
+
+	const auto b_dim = make_unit<dimensionless>(5);
+	EXPECT_EQ(dimensionless(5), b_dim);
+
+	const auto c_dim = make_unit<unit<dimensionless_unit, int>>(5);
+	EXPECT_EQ((unit<dimensionless_unit, int>(5)), c_dim);
 }
 
 TEST_F(UnitContainer, unitTypeAddition)

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -1047,7 +1047,7 @@ TEST_F(UnitContainer, unitTypeAddition)
 	c_m = b_ft + meter_t(3);
 	EXPECT_NEAR(4.0, c_m(), 5.0e-5);
 
-	auto e_ft = b_ft + meter_t(3);
+	foot_t e_ft = b_ft + meter_t(3);
 	EXPECT_NEAR(13.12336, e_ft(), 5.0e-6);
 
 	// dimensionless
@@ -1100,7 +1100,7 @@ TEST_F(UnitContainer, unitTypeSubtraction)
 	c_m = b_ft - meter_t(1);
 	EXPECT_NEAR(0.0, c_m(), 5.0e-5);
 
-	auto e_ft = b_ft - meter_t(1);
+	foot_t e_ft = b_ft - meter_t(1);
 	EXPECT_NEAR(0.0, e_ft(), 5.0e-6);
 
 	dimensionless sresult = dimensionless(1.0) - dimensionless(1.0);
@@ -1190,10 +1190,10 @@ TEST_F(UnitContainer, unitTypeMixedUnitMultiplication)
 	unit<inverse<meter>> i_m(2.0);
 
 	// resultant unit is square of leftmost unit
-	auto c_m2 = a_m * b_ft;
+	unit<squared<meter>> c_m2 = a_m * b_ft;
 	EXPECT_NEAR(1.0, c_m2(), 5.0e-5);
 
-	auto c_ft2 = b_ft * a_m;
+	unit<squared<foot>> c_ft2 = b_ft * a_m;
 	EXPECT_NEAR(10.7639111056, c_ft2(), 5.0e-7);
 
 	// you can get whatever (compatible) type you want if you ask explicitly
@@ -1214,7 +1214,7 @@ TEST_F(UnitContainer, unitTypeMixedUnitMultiplication)
 	c_m2 = b_ft * meter_t(2);
 	EXPECT_NEAR(2.0, c_m2(), 5.0e-5);
 
-	auto e_ft2 = b_ft * meter_t(3);
+	unit<squared<foot>> e_ft2 = b_ft * meter_t(3);
 	EXPECT_NEAR(32.2917333168, e_ft2(), 5.0e-6);
 
 	auto mps = meter_t(10.0) * unit<inverse<seconds>>(1.0);

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -1307,6 +1307,70 @@ TEST_F(UnitContainer, unitTypeDivision)
 	EXPECT_TRUE(isSame);
 }
 
+TEST_F(UnitContainer, unitTypeModulus)
+{
+	const unit<meters, int> a_m(2200);
+	const unit<meters, int> b_m(1800);
+	const unit<kilometers, int> a_km(2);
+
+	const auto c_m = a_m % b_m;
+	EXPECT_EQ(400, c_m());
+	static_assert(has_equivalent_unit_conversion(c_m, a_m));
+
+	const auto d_m = a_m % a_km;
+	EXPECT_EQ(200, d_m());
+	static_assert(has_equivalent_unit_conversion(d_m, a_m));
+
+	const auto b_km = a_km % unit<dimensionless_unit, int>(3);
+	EXPECT_EQ(2, b_km());
+	static_assert(has_equivalent_unit_conversion(b_km, a_km));
+
+	auto e_m = a_m % 2000;
+	EXPECT_EQ(200, e_m());
+	static_assert(has_equivalent_unit_conversion(e_m, a_m));
+
+	e_m %= a_m;
+	EXPECT_EQ(200, e_m());
+
+	e_m %= a_km;
+	EXPECT_EQ(200, e_m());
+
+	e_m %= unit<dimensionless_unit, int>(180);
+	EXPECT_EQ(20, e_m());
+
+	e_m %= dimensionless(15.0);
+	EXPECT_EQ(5, e_m());
+
+	e_m %= 6;
+	EXPECT_EQ(5, e_m());
+
+	e_m %= 3.0;
+	EXPECT_EQ(2, e_m());
+
+	const unit<dimensionless_unit, int> a_s(12);
+	const unit<dimensionless_unit, int> b_s(5);
+
+	const auto c_s = a_s % b_s;
+	EXPECT_EQ(2, c_s());
+	static_assert(has_equivalent_unit_conversion(c_s, a_s));
+
+	auto d_s = a_s % 20;
+	EXPECT_EQ(12, d_s());
+	static_assert(has_equivalent_unit_conversion(d_s, a_s));
+
+	d_s %= unit<dimensionless_unit, int>(20);
+	EXPECT_EQ(12, d_s());
+
+	d_s %= dimensionless(7.0);
+	EXPECT_EQ(5, d_s());
+
+	d_s %= 3;
+	EXPECT_EQ(2, d_s());
+
+	d_s %= 3.0;
+	EXPECT_EQ(2, d_s());
+}
+
 TEST_F(UnitContainer, compoundAssignmentAddition)
 {
 	// units

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -919,6 +919,29 @@ TEST_F(UnitContainer, has_value_member)
 	EXPECT_FALSE((traits::has_value_member_v<meter, double>));
 }
 
+TEST_F(UnitContainer, constructionFromArithmeticType)
+{
+	meter_t a_m(1.0);
+	EXPECT_EQ(1.0, a_m());
+
+	meter_t b_m(1);
+	EXPECT_EQ(1, b_m());
+
+	unit<meters, int> c_m(1);
+	static_assert(std::is_same_v<int, decltype(c_m())>);
+	EXPECT_EQ(1, c_m());
+
+	dimensionless a_dim(1.0);
+	EXPECT_EQ(1.0, a_dim());
+
+	dimensionless b_dim(1);
+	EXPECT_EQ(1, b_dim());
+
+	unit<dimensionless_unit, int> c_dim(1);
+	static_assert(std::is_same_v<int, decltype(c_dim())>);
+	EXPECT_EQ(1, c_dim());
+}
+
 TEST_F(UnitContainer, make_unit)
 {
 	auto dist = units::make_unit<meter_t>(5);

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -3545,6 +3545,10 @@ TEST_F(UnitMath, min)
 	meter_t b(2);
 	foot_t c(1);
 	EXPECT_EQ(c, units::min(a, c));
+
+	const unit<meters> d(1);
+	const unit<centimeters> e(99);
+	EXPECT_EQ(e, units::min(d, e));
 }
 
 TEST_F(UnitMath, max)
@@ -3553,101 +3557,146 @@ TEST_F(UnitMath, max)
 	meter_t b(2);
 	foot_t c(1);
 	EXPECT_EQ(a, max(a, c));
+
+	const unit<meters> d(1);
+	const unit<centimeters> e(101);
+	EXPECT_EQ(e, max(d, e));
 }
 
 TEST_F(UnitMath, cos)
 {
 	EXPECT_TRUE((std::is_same_v<typename std::decay<dimensionless>::type, typename std::decay<decltype(cos(angle::radian_t(0)))>::type>));
+	EXPECT_TRUE((std::is_same_v<typename std::decay<dimensionless>::type, typename std::decay<decltype(cos(unit<degrees, int>(0)))>::type>));
 	EXPECT_NEAR(dimensionless(-0.41614683654), cos(angle::radian_t(2)), 5.0e-11);
+	EXPECT_NEAR(dimensionless(-0.41614683654), cos(unit<radians, int>(2)), 5.0e-11);
 	EXPECT_NEAR(dimensionless(-0.70710678118), cos(angle::degree_t(135)), 5.0e-11);
+	EXPECT_NEAR(dimensionless(-0.70710678118), cos(unit<degrees, int>(135)), 5.0e-11);
 }
 
 TEST_F(UnitMath, sin)
 {
 	EXPECT_TRUE((std::is_same_v<typename std::decay<dimensionless>::type, typename std::decay<decltype(sin(angle::radian_t(0)))>::type>));
+	EXPECT_TRUE((std::is_same_v<typename std::decay<dimensionless>::type, typename std::decay<decltype(sin(unit<degrees, int>(0)))>::type>));
 	EXPECT_NEAR(dimensionless(0.90929742682), sin(angle::radian_t(2)), 5.0e-11);
+	EXPECT_NEAR(dimensionless(0.90929742682), sin(unit<radians, int>(2)), 5.0e-11);
 	EXPECT_NEAR(dimensionless(0.70710678118), sin(angle::degree_t(135)), 5.0e-11);
+	EXPECT_NEAR(dimensionless(0.70710678118), sin(unit<degrees, int>(135)), 5.0e-11);
 }
 
 TEST_F(UnitMath, tan)
 {
 	EXPECT_TRUE((std::is_same_v<typename std::decay<dimensionless>::type, typename std::decay<decltype(tan(angle::radian_t(0)))>::type>));
+	EXPECT_TRUE((std::is_same_v<typename std::decay<dimensionless>::type, typename std::decay<decltype(tan(unit<degrees, int>(0)))>::type>));
 	EXPECT_NEAR(dimensionless(-2.18503986326), tan(angle::radian_t(2)), 5.0e-11);
+	EXPECT_NEAR(dimensionless(-2.18503986326), tan(unit<radians, int>(2)), 5.0e-11);
 	EXPECT_NEAR(dimensionless(-1.0), tan(angle::degree_t(135)), 5.0e-11);
+	EXPECT_NEAR(dimensionless(-1.0), tan(unit<degrees, int>(135)), 5.0e-11);
 }
 
 TEST_F(UnitMath, acos)
 {
 	EXPECT_TRUE((std::is_same_v<typename std::decay<angle::radian_t>::type, typename std::decay<decltype(acos(dimensionless(0)))>::type>));
+	EXPECT_TRUE((std::is_same_v<typename std::decay<angle::radian_t>::type, typename std::decay<decltype(acos(unit<dimensionless_unit, int>(0)))>::type>));
 	EXPECT_NEAR(angle::radian_t(2).to<double>(), acos(dimensionless(-0.41614683654)).to<double>(), 5.0e-11);
+	EXPECT_NEAR(angle::radian_t(1.570796326795).to<double>(), acos(unit<dimensionless_unit, int>(0)).to<double>(), 5.0e-11);
 	EXPECT_NEAR(angle::degree_t(135).to<double>(), angle::degree_t(acos(dimensionless(-0.70710678118654752440084436210485))).to<double>(), 5.0e-12);
+	EXPECT_NEAR(angle::degree_t(90).to<double>(), angle::degree_t(acos(unit<dimensionless_unit, int>(0))).to<double>(), 5.0e-12);
 }
 
 TEST_F(UnitMath, asin)
 {
 	EXPECT_TRUE((std::is_same_v<typename std::decay<angle::radian_t>::type, typename std::decay<decltype(asin(dimensionless(0)))>::type>));
+	EXPECT_TRUE((std::is_same_v<typename std::decay<angle::radian_t>::type, typename std::decay<decltype(asin(unit<dimensionless_unit, int>(0)))>::type>));
 	EXPECT_NEAR(angle::radian_t(1.14159265).to<double>(), asin(dimensionless(0.90929742682)).to<double>(), 5.0e-9);
+	EXPECT_NEAR(angle::radian_t(1.570796326795).to<double>(), asin(unit<dimensionless_unit, int>(1)).to<double>(), 5.0e-9);
 	EXPECT_NEAR(angle::degree_t(45).to<double>(), angle::degree_t(asin(dimensionless(0.70710678118654752440084436210485))).to<double>(), 5.0e-12);
+	EXPECT_NEAR(angle::degree_t(90).to<double>(), angle::degree_t(asin(unit<dimensionless_unit, int>(1))).to<double>(), 5.0e-12);
 }
 
 TEST_F(UnitMath, atan)
 {
 	EXPECT_TRUE((std::is_same_v<typename std::decay<angle::radian_t>::type, typename std::decay<decltype(atan(dimensionless(0)))>::type>));
+	EXPECT_TRUE((std::is_same_v<typename std::decay<angle::radian_t>::type, typename std::decay<decltype(atan(unit<dimensionless_unit, int>(0)))>::type>));
 	EXPECT_NEAR(angle::radian_t(-1.14159265).to<double>(), atan(dimensionless(-2.18503986326)).to<double>(), 5.0e-9);
+	EXPECT_NEAR(angle::radian_t(0.785398163397).to<double>(), atan(unit<dimensionless_unit, int>(1)).to<double>(), 5.0e-9);
 	EXPECT_NEAR(angle::degree_t(-45).to<double>(), angle::degree_t(atan(dimensionless(-1.0))).to<double>(), 5.0e-12);
+	EXPECT_NEAR(angle::degree_t(45).to<double>(), angle::degree_t(atan(unit<dimensionless_unit, int>(1))).to<double>(), 5.0e-12);
 }
 
 TEST_F(UnitMath, atan2)
 {
 	EXPECT_TRUE((std::is_same_v<typename std::decay<angle::radian_t>::type, typename std::decay<decltype(atan2(dimensionless(1), dimensionless(1)))>::type>));
+	EXPECT_TRUE((std::is_same_v<typename std::decay<angle::radian_t>::type, typename std::decay<decltype(atan2(unit<dimensionless_unit, int>(1), unit<dimensionless_unit, int>(1)))>::type>));
 	EXPECT_NEAR(angle::radian_t(constants::detail::PI_VAL / 4).to<double>(), atan2(dimensionless(2), dimensionless(2)).to<double>(), 5.0e-12);
+	EXPECT_NEAR(angle::radian_t(constants::detail::PI_VAL / 4).to<double>(), atan2(unit<dimensionless_unit, int>(2), unit<dimensionless_unit, int>(2)).to<double>(), 5.0e-12);
 	EXPECT_NEAR(angle::degree_t(45).to<double>(), angle::degree_t(atan2(dimensionless(2), dimensionless(2))).to<double>(), 5.0e-12);
+	EXPECT_NEAR(angle::degree_t(45).to<double>(), angle::degree_t(atan2(unit<dimensionless_unit, int>(2), unit<dimensionless_unit, int>(2))).to<double>(), 5.0e-12);
 
 	EXPECT_TRUE((std::is_same_v<typename std::decay<angle::radian_t>::type, typename std::decay<decltype(atan2(dimensionless(1), dimensionless(1)))>::type>));
 	EXPECT_NEAR(angle::radian_t(constants::detail::PI_VAL / 6).to<double>(), atan2(dimensionless(1), sqrt(dimensionless(3))).to<double>(), 5.0e-12);
+	EXPECT_NEAR(angle::radian_t(constants::detail::PI_VAL / 6).to<double>(), atan2(unit<dimensionless_unit, int>(1), sqrt(unit<dimensionless_unit, int>(3))).to<double>(), 5.0e-12);
 	EXPECT_NEAR(angle::degree_t(30).to<double>(), angle::degree_t(atan2(dimensionless(1), sqrt(dimensionless(3)))).to<double>(), 5.0e-12);
+	EXPECT_NEAR(angle::degree_t(30).to<double>(), angle::degree_t(atan2(unit<dimensionless_unit, int>(1), sqrt(unit<dimensionless_unit, int>(3)))).to<double>(), 5.0e-12);
 }
 
 TEST_F(UnitMath, cosh)
 {
 	EXPECT_TRUE((std::is_same_v<typename std::decay<dimensionless>::type, typename std::decay<decltype(cosh(angle::radian_t(0)))>::type>));
+	EXPECT_TRUE((std::is_same_v<typename std::decay<dimensionless>::type, typename std::decay<decltype(cosh(unit<degrees, int>(0)))>::type>));
 	EXPECT_NEAR(dimensionless(3.76219569108), cosh(angle::radian_t(2)), 5.0e-11);
+	EXPECT_NEAR(dimensionless(3.76219569108), cosh(unit<radians, int>(2)), 5.0e-11);
 	EXPECT_NEAR(dimensionless(5.32275215), cosh(angle::degree_t(135)), 5.0e-9);
+	EXPECT_NEAR(dimensionless(5.32275215), cosh(unit<degrees, int>(135)), 5.0e-9);
 }
 
 TEST_F(UnitMath, sinh)
 {
 	EXPECT_TRUE((std::is_same_v<typename std::decay<dimensionless>::type, typename std::decay<decltype(sinh(angle::radian_t(0)))>::type>));
+	EXPECT_TRUE((std::is_same_v<typename std::decay<dimensionless>::type, typename std::decay<decltype(sinh(unit<degrees, int>(0)))>::type>));
 	EXPECT_NEAR(dimensionless(3.62686040785), sinh(angle::radian_t(2)), 5.0e-11);
+	EXPECT_NEAR(dimensionless(3.62686040785), sinh(unit<radians, int>(2)), 5.0e-11);
 	EXPECT_NEAR(dimensionless(5.22797192), sinh(angle::degree_t(135)), 5.0e-9);
+	EXPECT_NEAR(dimensionless(5.22797192), sinh(unit<degrees, int>(135)), 5.0e-9);
 }
 
 TEST_F(UnitMath, tanh)
 {
 	EXPECT_TRUE((std::is_same_v<typename std::decay<dimensionless>::type, typename std::decay<decltype(tanh(angle::radian_t(0)))>::type>));
+	EXPECT_TRUE((std::is_same_v<typename std::decay<dimensionless>::type, typename std::decay<decltype(tanh(unit<degrees, int>(0)))>::type>));
 	EXPECT_NEAR(dimensionless(0.96402758007), tanh(angle::radian_t(2)), 5.0e-11);
+	EXPECT_NEAR(dimensionless(0.96402758007), tanh(unit<radians, int>(2)), 5.0e-11);
 	EXPECT_NEAR(dimensionless(0.98219338), tanh(angle::degree_t(135)), 5.0e-11);
+	EXPECT_NEAR(dimensionless(0.98219338), tanh(unit<degrees, int>(135)), 5.0e-11);
 }
 
 TEST_F(UnitMath, acosh)
 {
 	EXPECT_TRUE((std::is_same_v<typename std::decay<angle::radian_t>::type, typename std::decay<decltype(acosh(dimensionless(0)))>::type>));
+	EXPECT_TRUE((std::is_same_v<typename std::decay<angle::radian_t>::type, typename std::decay<decltype(acosh(unit<dimensionless_unit, int>(0)))>::type>));
 	EXPECT_NEAR(angle::radian_t(1.316957896924817).to<double>(), acosh(dimensionless(2.0)).to<double>(), 5.0e-11);
+	EXPECT_NEAR(angle::radian_t(1.316957896924817).to<double>(), acosh(unit<dimensionless_unit, int>(2)).to<double>(), 5.0e-11);
 	EXPECT_NEAR(angle::degree_t(75.456129290216893).to<double>(), angle::degree_t(acosh(dimensionless(2.0))).to<double>(), 5.0e-12);
+	EXPECT_NEAR(angle::degree_t(75.456129290216893).to<double>(), angle::degree_t(acosh(unit<dimensionless_unit, int>(2))).to<double>(), 5.0e-12);
 }
 
 TEST_F(UnitMath, asinh)
 {
 	EXPECT_TRUE((std::is_same_v<typename std::decay<angle::radian_t>::type, typename std::decay<decltype(asinh(dimensionless(0)))>::type>));
+	EXPECT_TRUE((std::is_same_v<typename std::decay<angle::radian_t>::type, typename std::decay<decltype(asinh(unit<dimensionless_unit, int>(0)))>::type>));
 	EXPECT_NEAR(angle::radian_t(1.443635475178810).to<double>(), asinh(dimensionless(2)).to<double>(), 5.0e-9);
+	EXPECT_NEAR(angle::radian_t(1.443635475178810).to<double>(), asinh(unit<dimensionless_unit, int>(2)).to<double>(), 5.0e-9);
 	EXPECT_NEAR(angle::degree_t(82.714219883108939).to<double>(), angle::degree_t(asinh(dimensionless(2))).to<double>(), 5.0e-12);
+	EXPECT_NEAR(angle::degree_t(82.714219883108939).to<double>(), angle::degree_t(asinh(unit<dimensionless_unit, int>(2))).to<double>(), 5.0e-12);
 }
 
 TEST_F(UnitMath, atanh)
 {
 	EXPECT_TRUE((std::is_same_v<typename std::decay<angle::radian_t>::type, typename std::decay<decltype(atanh(dimensionless(0)))>::type>));
+	EXPECT_TRUE((std::is_same_v<typename std::decay<angle::radian_t>::type, typename std::decay<decltype(atanh(unit<dimensionless_unit, int>(0)))>::type>));
 	EXPECT_NEAR(angle::radian_t(0.549306144334055).to<double>(), atanh(dimensionless(0.5)).to<double>(), 5.0e-9);
+	EXPECT_NEAR(angle::radian_t(0).to<double>(), atanh(unit<dimensionless_unit, int>(0)).to<double>(), 5.0e-9);
 	EXPECT_NEAR(angle::degree_t(31.472923730945389).to<double>(), angle::degree_t(atanh(dimensionless(0.5))).to<double>(), 5.0e-12);
+	EXPECT_NEAR(angle::degree_t(0).to<double>(), angle::degree_t(atanh(unit<dimensionless_unit, int>(0))).to<double>(), 5.0e-12);
 }
 
 TEST_F(UnitMath, exp)

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -1250,36 +1250,70 @@ TEST_F(UnitContainer, unitTypeAddition)
 	// units
 	meter_t a_m(1.0), c_m;
 	foot_t b_ft(3.28084);
+	const unit<meters, int> f_m(1);
+	const std::common_type_t<unit<meters, int>, unit<feet, int>> g(f_m);
 
 	double d = meter_t(b_ft)();
+	EXPECT_NEAR(1.0, d, 5.0e-5);
+	d = meter_t(g)();
 	EXPECT_NEAR(1.0, d, 5.0e-5);
 
 	c_m = a_m + b_ft;
 	EXPECT_NEAR(2.0, c_m(), 5.0e-5);
+	c_m = f_m + g;
+	EXPECT_NEAR(2.0, c_m(), 5.0e-5);
+	c_m = a_m + g;
+	EXPECT_NEAR(2.0, c_m(), 5.0e-5);
+	c_m = f_m + b_ft;
+	EXPECT_NEAR(2.0, c_m(), 5.0e-5);
 
 	c_m = b_ft + meter_t(3);
 	EXPECT_NEAR(4.0, c_m(), 5.0e-5);
+	c_m = g + unit<meters, int>(3);
+	EXPECT_NEAR(4.0, c_m(), 5.0e-5);
+	c_m = b_ft + unit<meters, int>(3);
+	EXPECT_NEAR(4.0, c_m(), 5.0e-5);
+	c_m = g + meter_t(3);
+	EXPECT_NEAR(4.0, c_m(), 5.0e-5);
 
 	foot_t e_ft = b_ft + meter_t(3);
+	EXPECT_NEAR(13.12336, e_ft(), 5.0e-6);
+	e_ft = g + unit<meters, int>(3);
+	EXPECT_NEAR(13.12336, e_ft(), 5.0e-6);
+	e_ft = b_ft + unit<meters, int>(3);
+	EXPECT_NEAR(13.12336, e_ft(), 5.0e-6);
+	e_ft = g + meter_t(3);
 	EXPECT_NEAR(13.12336, e_ft(), 5.0e-6);
 
 	// dimensionless
 	dimensionless sresult = dimensionless(1.0) + dimensionless(1.0);
 	EXPECT_NEAR(2.0, sresult, 5.0e-6);
+	sresult = unit<dimensionless_unit, int>(1) + unit<dimensionless_unit, int>(1);
+	EXPECT_NEAR(2.0, sresult, 5.0e-6);
 
 	sresult = dimensionless(1.0) + 1.0;
+	EXPECT_NEAR(2.0, sresult, 5.0e-6);
+	sresult = unit<dimensionless_unit, int>(1) + 1.0;
 	EXPECT_NEAR(2.0, sresult, 5.0e-6);
 
 	sresult = 1.0 + dimensionless(1.0);
 	EXPECT_NEAR(2.0, sresult, 5.0e-6);
+	sresult = 1.0 + unit<dimensionless_unit, int>(1);
+	EXPECT_NEAR(2.0, sresult, 5.0e-6);
 
 	d = dimensionless(1.0) + dimensionless(1.0);
+	EXPECT_NEAR(2.0, d, 5.0e-6);
+	d = unit<dimensionless_unit, int>(1) + unit<dimensionless_unit, int>(1);
 	EXPECT_NEAR(2.0, d, 5.0e-6);
 
 	d = dimensionless(1.0) + 1.0;
 	EXPECT_NEAR(2.0, d, 5.0e-6);
+	d = unit<dimensionless_unit, int>(1) + 1.0;
+	EXPECT_NEAR(2.0, d, 5.0e-6);
 
 	d = 1.0 + dimensionless(1.0);
+	EXPECT_NEAR(2.0, d, 5.0e-6);
+	d = 1.0 + unit<dimensionless_unit, int>(1);
 	EXPECT_NEAR(2.0, d, 5.0e-6);
 }
 
@@ -1306,32 +1340,64 @@ TEST_F(UnitContainer, unitTypeSubtraction)
 {
 	meter_t a_m(1.0), c_m;
 	foot_t b_ft(3.28084);
+	const unit<meters, int> f_m(1);
+	const std::common_type_t<unit<meters, int>, unit<feet, int>> g(f_m);
 
 	c_m = a_m - b_ft;
+	EXPECT_NEAR(0.0, c_m(), 5.0e-5);
+	c_m = f_m - g;
+	EXPECT_NEAR(0.0, c_m(), 5.0e-5);
+	c_m = a_m - g;
+	EXPECT_NEAR(0.0, c_m(), 5.0e-5);
+	c_m = f_m - b_ft;
 	EXPECT_NEAR(0.0, c_m(), 5.0e-5);
 
 	c_m = b_ft - meter_t(1);
 	EXPECT_NEAR(0.0, c_m(), 5.0e-5);
+	c_m = g - unit<meters, int>(1);
+	EXPECT_NEAR(0.0, c_m(), 5.0e-5);
+	c_m = b_ft - unit<meters, int>(1);
+	EXPECT_NEAR(0.0, c_m(), 5.0e-5);
+	c_m = g - meter_t(1);
+	EXPECT_NEAR(0.0, c_m(), 5.0e-5);
 
 	foot_t e_ft = b_ft - meter_t(1);
+	EXPECT_NEAR(0.0, e_ft(), 5.0e-6);
+	e_ft = g - unit<meters, int>(1);
+	EXPECT_NEAR(0.0, e_ft(), 5.0e-6);
+	e_ft = b_ft - unit<meters, int>(1);
+	EXPECT_NEAR(0.0, e_ft(), 5.0e-6);
+	e_ft = g - meter_t(1);
 	EXPECT_NEAR(0.0, e_ft(), 5.0e-6);
 
 	dimensionless sresult = dimensionless(1.0) - dimensionless(1.0);
 	EXPECT_NEAR(0.0, sresult, 5.0e-6);
+	sresult = unit<dimensionless_unit, int>(1) - unit<dimensionless_unit, int>(1);
+	EXPECT_NEAR(0.0, sresult, 5.0e-6);
 
 	sresult = dimensionless(1.0) - 1.0;
+	EXPECT_NEAR(0.0, sresult, 5.0e-6);
+	sresult = unit<dimensionless_unit, int>(1) - 1.0;
 	EXPECT_NEAR(0.0, sresult, 5.0e-6);
 
 	sresult = 1.0 - dimensionless(1.0);
 	EXPECT_NEAR(0.0, sresult, 5.0e-6);
+	sresult = 1.0 - unit<dimensionless_unit, int>(1);
+	EXPECT_NEAR(0.0, sresult, 5.0e-6);
 
 	double d = dimensionless(1.0) - dimensionless(1.0);
+	EXPECT_NEAR(0.0, d, 5.0e-6);
+	d = unit<dimensionless_unit, int>(1) - unit<dimensionless_unit, int>(1);
 	EXPECT_NEAR(0.0, d, 5.0e-6);
 
 	d = dimensionless(1.0) - 1.0;
 	EXPECT_NEAR(0.0, d, 5.0e-6);
+	d = unit<dimensionless_unit, int>(1) - 1.0;
+	EXPECT_NEAR(0.0, d, 5.0e-6);
 
 	d = 1.0 - dimensionless(1.0);
+	EXPECT_NEAR(0.0, d, 5.0e-6);
+	d = 1.0 - unit<dimensionless_unit, int>(1);
 	EXPECT_NEAR(0.0, d, 5.0e-6);
 }
 
@@ -1358,41 +1424,87 @@ TEST_F(UnitContainer, unitTypeMultiplication)
 {
 	meter_t a_m(1.0), b_m(2.0);
 	foot_t a_ft(3.28084);
+	const unit<meters, int> d_m(1), e_m(2);
+	const std::common_type_t<unit<meters, int>, unit<feet, int>> f(d_m);
 
 	auto c_m2 = a_m * b_m;
+	EXPECT_NEAR(2.0, c_m2(), 5.0e-5);
+	c_m2 = d_m * e_m;
+	EXPECT_NEAR(2.0, c_m2(), 5.0e-5);
+	c_m2 = a_m * e_m;
+	EXPECT_NEAR(2.0, c_m2(), 5.0e-5);
+	c_m2 = d_m * b_m;
 	EXPECT_NEAR(2.0, c_m2(), 5.0e-5);
 
 	c_m2 = b_m * meter_t(2);
 	EXPECT_NEAR(4.0, c_m2(), 5.0e-5);
+	c_m2 = e_m * unit<meters, int>(2);
+	EXPECT_NEAR(4.0, c_m2(), 5.0e-5);
+	c_m2 = b_m * unit<meters, int>(2);
+	EXPECT_NEAR(4.0, c_m2(), 5.0e-5);
+	c_m2 = e_m * meter_t(2);
+	EXPECT_NEAR(4.0, c_m2(), 5.0e-5);
 
 	c_m2 = b_m *a_ft;
+	EXPECT_NEAR(2.0, c_m2(), 5.0e-5);
+	c_m2 = e_m * f;
+	EXPECT_NEAR(2.0, c_m2(), 5.0e-5);
+	c_m2 = b_m * f;
+	EXPECT_NEAR(2.0, c_m2(), 5.0e-5);
+	c_m2 = e_m * a_ft;
 	EXPECT_NEAR(2.0, c_m2(), 5.0e-5);
 
 	auto c_m = b_m * 2.0;
 	EXPECT_NEAR(4.0, c_m(), 5.0e-5);
+	c_m = e_m * 2;
+	EXPECT_NEAR(4.0, c_m(), 5.0e-5);
+	c_m = b_m * 2;
+	EXPECT_NEAR(4.0, c_m(), 5.0e-5);
+	c_m = e_m * 2.0;
+	EXPECT_NEAR(4.0, c_m(), 5.0e-5);
 
 	c_m = 2.0 * b_m;
+	EXPECT_NEAR(4.0, c_m(), 5.0e-5);
+	c_m = 2 * e_m;
+	EXPECT_NEAR(4.0, c_m(), 5.0e-5);
+	c_m = 2 * b_m;
+	EXPECT_NEAR(4.0, c_m(), 5.0e-5);
+	c_m = 2.0 * e_m;
 	EXPECT_NEAR(4.0, c_m(), 5.0e-5);
 
 	double convert = dimensionless(3.14);
 	EXPECT_NEAR(3.14, convert, 5.0e-5);
+	convert = unit<dimensionless_unit, int>(3);
+	EXPECT_NEAR(3, convert, 5.0e-5);
 
 	dimensionless sresult = dimensionless(5.0) * dimensionless(4.0);
+	EXPECT_NEAR(20.0, sresult(), 5.0e-5);
+	sresult = unit<dimensionless_unit, int>(5) * unit<dimensionless_unit, int>(4);
 	EXPECT_NEAR(20.0, sresult(), 5.0e-5);
 
 	sresult = dimensionless(5.0) * 4.0;
 	EXPECT_NEAR(20.0, sresult(), 5.0e-5);
+	sresult = unit<dimensionless_unit, int>(5) * 4.0;
+	EXPECT_NEAR(20.0, sresult(), 5.0e-5);
 
 	sresult = 4.0 * dimensionless(5.0);
+	EXPECT_NEAR(20.0, sresult(), 5.0e-5);
+	sresult = 4.0 * unit<dimensionless_unit, int>(5);
 	EXPECT_NEAR(20.0, sresult(), 5.0e-5);
 
 	double result = dimensionless(5.0) * dimensionless(4.0);
 	EXPECT_NEAR(20.0, result, 5.0e-5);
+	result = unit<dimensionless_unit, int>(5) * unit<dimensionless_unit, int>(4);
+	EXPECT_NEAR(20.0, result, 5.0e-5);
 
 	result = dimensionless(5.0) * 4.0;
 	EXPECT_NEAR(20.0, result, 5.0e-5);
+	result = unit<dimensionless_unit, int>(5) * 4.0;
+	EXPECT_NEAR(20.0, result, 5.0e-5);
 
 	result = 4.0 * dimensionless(5.0);
+	EXPECT_NEAR(20.0, result, 5.0e-5);
+	result = 4.0 * unit<dimensionless_unit, int>(5);
 	EXPECT_NEAR(20.0, result, 5.0e-5);
 }
 
@@ -1401,37 +1513,90 @@ TEST_F(UnitContainer, unitTypeMixedUnitMultiplication)
 	meter_t a_m(1.0);
 	foot_t b_ft(3.28084);
 	unit<inverse<meter>> i_m(2.0);
+	const unit<meters, int> b_m(1);
+	const std::common_type_t<unit<meters, int>, unit<feet, int>> f(b_m);
+	const unit<inverse<meter>, int> i_i_m(2);
 
-	// resultant unit is square of leftmost unit
+	// resultant unit is square of the common type unit
+	// you can get whatever (compatible) type you want if you ask explicitly
 	unit<squared<meter>> c_m2 = a_m * b_ft;
+	EXPECT_NEAR(1.0, c_m2(), 5.0e-5);
+	c_m2 = b_m * f;
+	EXPECT_NEAR(1.0, c_m2(), 5.0e-5);
+	c_m2 = a_m * f;
+	EXPECT_NEAR(1.0, c_m2(), 5.0e-5);
+	c_m2 = b_m * b_ft;
 	EXPECT_NEAR(1.0, c_m2(), 5.0e-5);
 
 	unit<squared<foot>> c_ft2 = b_ft * a_m;
 	EXPECT_NEAR(10.7639111056, c_ft2(), 5.0e-7);
+	c_ft2 = f * b_m;
+	EXPECT_NEAR(10.7639111056, c_ft2(), 5.0e-6);
+	c_ft2 = b_ft * b_m;
+	EXPECT_NEAR(10.7639111056, c_ft2(), 5.0e-7);
+	c_ft2 = f * a_m;
+	EXPECT_NEAR(10.7639111056, c_ft2(), 5.0e-6);
 
-	// you can get whatever (compatible) type you want if you ask explicitly
 	square_meter_t d_m2 = b_ft * a_m;
+	EXPECT_NEAR(1.0, d_m2(), 5.0e-5);
+	d_m2 = f * b_m;
+	EXPECT_NEAR(1.0, d_m2(), 5.0e-5);
+	d_m2 = b_ft * b_m;
+	EXPECT_NEAR(1.0, d_m2(), 5.0e-5);
+	d_m2 = f * a_m;
 	EXPECT_NEAR(1.0, d_m2(), 5.0e-5);
 
 	// a unit times a sclar ends up with the same units.
 	meter_t e_m = a_m * dimensionless(3.0);
 	EXPECT_NEAR(3.0, e_m(), 5.0e-5);
+	e_m = b_m * unit<dimensionless_unit, int>(3);
+	EXPECT_NEAR(3.0, e_m(), 5.0e-5);
+	e_m = a_m * unit<dimensionless_unit, int>(3);
+	EXPECT_NEAR(3.0, e_m(), 5.0e-5);
+	e_m = b_m * dimensionless(3.0);
+	EXPECT_NEAR(3.0, e_m(), 5.0e-5);
 
 	e_m = dimensionless(4.0) * a_m;
+	EXPECT_NEAR(4.0, e_m(), 5.0e-5);
+	e_m = unit<dimensionless_unit, int>(4) * b_m;
+	EXPECT_NEAR(4.0, e_m(), 5.0e-5);
+	e_m = unit<dimensionless_unit, int>(4) * a_m;
+	EXPECT_NEAR(4.0, e_m(), 5.0e-5);
+	e_m = dimensionless(4) * b_m;
 	EXPECT_NEAR(4.0, e_m(), 5.0e-5);
 
 	// unit times its inverse results in a dimensionless
 	dimensionless s = a_m * i_m;
 	EXPECT_NEAR(2.0, s, 5.0e-5);
+	s = b_m * i_i_m;
+	EXPECT_NEAR(2.0, s, 5.0e-5);
+	s = a_m * i_i_m;
+	EXPECT_NEAR(2.0, s, 5.0e-5);
+	s = b_m * i_m;
+	EXPECT_NEAR(2.0, s, 5.0e-5);
 
 	c_m2 = b_ft * meter_t(2);
+	EXPECT_NEAR(2.0, c_m2(), 5.0e-5);
+	c_m2 = f * unit<meters, int>(2);
+	EXPECT_NEAR(2.0, c_m2(), 5.0e-5);
+	c_m2 = b_ft * unit<meters, int>(2);
+	EXPECT_NEAR(2.0, c_m2(), 5.0e-5);
+	c_m2 = f * meter_t(2);
 	EXPECT_NEAR(2.0, c_m2(), 5.0e-5);
 
 	unit<squared<foot>> e_ft2 = b_ft * meter_t(3);
 	EXPECT_NEAR(32.2917333168, e_ft2(), 5.0e-6);
+	e_ft2 = f * unit<meters, int>(3);
+	EXPECT_NEAR(32.2917333168, e_ft2(), 5.0e-6);
+	e_ft2 = b_ft * unit<meters, int>(3);
+	EXPECT_NEAR(32.2917333168, e_ft2(), 5.0e-6);
+	e_ft2 = f * meter_t(3);
+	EXPECT_NEAR(32.2917333168, e_ft2(), 5.0e-6);
 
 	auto mps = meter_t(10.0) * unit<inverse<seconds>>(1.0);
 	EXPECT_EQ(mps, meters_per_second_t(10));
+	auto i_mps = unit<meters, int>(10) * unit<inverse<seconds>, int>(1);
+	EXPECT_EQ(i_mps, meters_per_second_t(10));
 }
 
 TEST_F(UnitContainer, unitTypedimensionlessMultiplication)
@@ -1460,29 +1625,62 @@ TEST_F(UnitContainer, unitTypeDivision)
 	meter_t a_m(1.0), b_m(2.0);
 	foot_t a_ft(3.28084);
 	second_t a_sec(10.0);
+	const unit<meters, int> d_m(1), e_m(2);
+	const std::common_type_t<unit<meters, int>, unit<feet, int>> j(d_m);
+	const unit<seconds, int> b_sec(10);
 	bool isSame;
 
 	auto c = a_m / a_ft;
+	EXPECT_NEAR(1.0, c, 5.0e-5);
+	c = d_m / j;
+	EXPECT_NEAR(1.0, c, 5.0e-5);
+	c = a_m / j;
+	EXPECT_NEAR(1.0, c, 5.0e-5);
+	c = d_m / a_ft;
 	EXPECT_NEAR(1.0, c, 5.0e-5);
 	isSame = std::is_same_v<decltype(c), dimensionless>;
 	EXPECT_TRUE(isSame);
 
 	c = a_m / b_m;
 	EXPECT_NEAR(0.5, c, 5.0e-5);
+	c = d_m / e_m;
+	EXPECT_NEAR(0, c, 5.0e-5);
+	c = a_m / e_m;
+	EXPECT_NEAR(0.5, c, 5.0e-5);
+	c = d_m / b_m;
+	EXPECT_NEAR(0.5, c, 5.0e-5);
 	isSame = std::is_same_v<decltype(c), dimensionless>;
 	EXPECT_TRUE(isSame);
 
 	c = a_ft / a_m;
+	EXPECT_NEAR(1.0, c, 5.0e-5);
+	c = j / d_m;
+	EXPECT_NEAR(1.0, c, 5.0e-5);
+	c = a_ft / d_m;
+	EXPECT_NEAR(1.0, c, 5.0e-5);
+	c = j / a_m;
 	EXPECT_NEAR(1.0, c, 5.0e-5);
 	isSame = std::is_same_v<decltype(c), dimensionless>;
 	EXPECT_TRUE(isSame);
 
 	c = dimensionless(1.0) / 2.0;
 	EXPECT_NEAR(0.5, c, 5.0e-5);
+	c = unit<dimensionless_unit, int>(1) / 2;
+	EXPECT_NEAR(0, c, 5.0e-5);
+	c = unit<dimensionless_unit, int>(1) / 2.0;
+	EXPECT_NEAR(0.5, c, 5.0e-5);
+	c = dimensionless(1.0) / 2;
+	EXPECT_NEAR(0.5, c, 5.0e-5);
 	isSame = std::is_same_v<decltype(c), dimensionless>;
 	EXPECT_TRUE(isSame);
 
 	c = 1.0 / dimensionless(2.0);
+	EXPECT_NEAR(0.5, c, 5.0e-5);
+	c = 1 / unit<dimensionless_unit, int>(2);
+	EXPECT_NEAR(0, c, 5.0e-5);
+	c = 1.0 / unit<dimensionless_unit, int>(2);
+	EXPECT_NEAR(0.5, c, 5.0e-5);
+	c = 1 / dimensionless(2.0);
 	EXPECT_NEAR(0.5, c, 5.0e-5);
 	isSame = std::is_same_v<decltype(c), dimensionless>;
 	EXPECT_TRUE(isSame);
@@ -1492,15 +1690,33 @@ TEST_F(UnitContainer, unitTypeDivision)
 
 	auto e = a_m / a_sec;
 	EXPECT_NEAR(0.1, e(), 5.0e-5);
+	e = d_m / b_sec;
+	EXPECT_NEAR(0, e(), 5.0e-5);
+	e = a_m / b_sec;
+	EXPECT_NEAR(0.1, e(), 5.0e-5);
+	e = d_m / a_sec;
+	EXPECT_NEAR(0.1, e(), 5.0e-5);
 	isSame = std::is_same_v<decltype(e), meters_per_second_t>;
 	EXPECT_TRUE(isSame);
 
 	auto f = a_m / 8.0;
 	EXPECT_NEAR(0.125, f(), 5.0e-5);
+	f = d_m / 8;
+	EXPECT_NEAR(0, f(), 5.0e-5);
+	f = a_m / 8;
+	EXPECT_NEAR(0.125, f(), 5.0e-5);
+	f = d_m / 8.0;
+	EXPECT_NEAR(0.125, f(), 5.0e-5);
 	isSame = std::is_same_v<decltype(f), meter_t>;
 	EXPECT_TRUE(isSame);
 
 	auto g = 4.0 / b_m;
+	EXPECT_NEAR(2.0, g(), 5.0e-5);
+	g = 4 / e_m;
+	EXPECT_NEAR(2.0, g(), 5.0e-5);
+	g = 4 / b_m;
+	EXPECT_NEAR(2.0, g(), 5.0e-5);
+	g = 4.0 / e_m;
 	EXPECT_NEAR(2.0, g(), 5.0e-5);
 	isSame = std::is_same_v<decltype(g), unit<inverse<meters>>>;
 	EXPECT_TRUE(isSame);
@@ -1508,13 +1724,31 @@ TEST_F(UnitContainer, unitTypeDivision)
 	auto mph = mile_t(60.0) / hour_t(1.0);
 	meters_per_second_t mps = mph;
 	EXPECT_NEAR(26.8224, mps(), 5.0e-5);
+	mps = unit<miles, int>(60) / unit<hours, int>(1);
+	EXPECT_NEAR(26.8224, mps(), 5.0e-5);
+	mps = mile_t(60.0) / unit<hours, int>(1);
+	EXPECT_NEAR(26.8224, mps(), 5.0e-5);
+	mps = unit<miles, int>(60) / hour_t(1.0);
+	EXPECT_NEAR(26.8224, mps(), 5.0e-5);
 
 	auto h = 10_rad / 2_rad;
+	EXPECT_NEAR(5, h, 5.0e-5);
+	h = unit<radians, int>(10) / unit<radians, int>(2);
+	EXPECT_NEAR(5, h, 5.0e-5);
+	h = 10_rad / unit<radians, int>(2);
+	EXPECT_NEAR(5, h, 5.0e-5);
+	h = unit<radians, int>(10) / 2_rad;
 	EXPECT_NEAR(5, h, 5.0e-5);
 	isSame = std::is_same_v<decltype(h), dimensionless>;
 	EXPECT_TRUE(isSame);
 
 	auto i = (3_N * 2_m) / 6_J;
+	EXPECT_NEAR(1, i, 5.0e-5);
+	i = (unit<force::newtons, int>(3) * unit<meters, int>(2)) / unit<joules, int>(6);
+	EXPECT_NEAR(1, i, 5.0e-5);
+	i = (3_N * unit<meters, int>(2)) / unit<joules, int>(6);
+	EXPECT_NEAR(1, i, 5.0e-5);
+	i = (unit<force::newtons, int>(3) * unit<meters, int>(2)) / 6_J;
 	EXPECT_NEAR(1, i, 5.0e-5);
 	isSame = std::is_same_v<decltype(i), dimensionless>;
 	EXPECT_TRUE(isSame);
@@ -1566,15 +1800,45 @@ TEST_F(UnitContainer, compoundAssignmentAddition)
 
 	EXPECT_EQ(meter_t(2.0), a);
 
+	a += unit<meters, int>(1);
+
+	EXPECT_EQ(meter_t(3.0), a);
+
+	unit<meters, int> c(0);
+	c += unit<meters, int>(1);
+
+	EXPECT_EQ((unit<meters, int>(1)), c);
+
+	c += unit<kilometers, int>(1);
+
+	EXPECT_EQ((unit<meters, int>(1001)), c);
+
 	// dimensionlesss
 	dimensionless b(0);
 	b += dimensionless(1.0);
 
 	EXPECT_EQ(dimensionless(1.0), b);
 
-	b += 1;
+	b += 1.0;
 
 	EXPECT_EQ(dimensionless(2.0), b);
+
+	b += unit<dimensionless_unit, int>(1);
+
+	EXPECT_EQ(dimensionless(3.0), b);
+
+	b += 1;
+
+	EXPECT_EQ(dimensionless(4.0), b);
+
+	unit<dimensionless_unit, int> d(0);
+	d += unit<dimensionless_unit, int>(1);
+
+	EXPECT_EQ((unit<dimensionless_unit, int>(1)), d);
+
+	d += 1;
+
+	EXPECT_EQ((unit<dimensionless_unit, int>(2)), d);
 }
 
 TEST_F(UnitContainer, compoundAssignmentSubtraction)
@@ -1589,15 +1853,45 @@ TEST_F(UnitContainer, compoundAssignmentSubtraction)
 
 	EXPECT_EQ(meter_t(0.0), a);
 
+	a -= unit<meters, int>(1);
+
+	EXPECT_EQ(meter_t(-1.0), a);
+
+	unit<meters, int> c(1);
+	c -= unit<meters, int>(1);
+
+	EXPECT_EQ((unit<meters, int>(0)), c);
+
+	c -= unit<kilometers, int>(1);
+
+	EXPECT_EQ((unit<meters, int>(-1000)), c);
+
 	// dimensionlesss
 	dimensionless b(2);
 	b -= dimensionless(1.0);
 
 	EXPECT_EQ(dimensionless(1.0), b);
 
-	b -= 1;
+	b -= 1.0;
 
 	EXPECT_EQ(dimensionless(0), b);
+
+	b -= unit<dimensionless_unit, int>(1);
+
+	EXPECT_EQ(dimensionless(-1.0), b);
+
+	b -= 1;
+
+	EXPECT_EQ(dimensionless(-2.0), b);
+
+	unit<dimensionless_unit, int> d(2);
+	d -= unit<dimensionless_unit, int>(1);
+
+	EXPECT_EQ((unit<dimensionless_unit, int>(1)), d);
+
+	d -= 1;
+
+	EXPECT_EQ((unit<dimensionless_unit, int>(0)), d);
 }
 
 TEST_F(UnitContainer, compoundAssignmentMultiplication)
@@ -1612,38 +1906,138 @@ TEST_F(UnitContainer, compoundAssignmentMultiplication)
 
 	EXPECT_EQ(meter_t(8.0), a);
 
+	a *= unit<dimensionless_unit, int>(2);
+
+	EXPECT_EQ(meter_t(16), a);
+
+	a *= 2;
+
+	EXPECT_EQ(meter_t(32), a);
+
+	unit<meters, int> c(2);
+	c *= unit<dimensionless_unit, int>(2);
+
+	EXPECT_EQ((unit<meters, int>(4)), c);
+
+	c *= dimensionless(2.0);
+
+	EXPECT_EQ((unit<meters, int>(8)), c);
+
+	c *= 2;
+
+	EXPECT_EQ((unit<meters, int>(16)), c);
+
+	c *= 2.0;
+
+	EXPECT_EQ((unit<meters, int>(32)), c);
+
 	// dimensionlesss
 	dimensionless b(2);
 	b *= dimensionless(2.0);
 
 	EXPECT_EQ(dimensionless(4.0), b);
 
-	b *= 2;
+	b *= 2.0;
 
 	EXPECT_EQ(dimensionless(8.0), b);
+
+	b *= unit<dimensionless_unit, int>(2);
+
+	EXPECT_EQ(dimensionless(16.0), b);
+
+	b *= 2;
+
+	EXPECT_EQ(dimensionless(32.0), b);
+
+	unit<dimensionless_unit, int> d(2);
+	d *= unit<dimensionless_unit, int>(2);
+
+	EXPECT_EQ((unit<dimensionless_unit, int>(4)), d);
+
+	d *= dimensionless(2.0);
+
+	EXPECT_EQ((unit<dimensionless_unit, int>(8)), d);
+
+	d *= 2;
+
+	EXPECT_EQ((unit<dimensionless_unit, int>(16)), d);
+
+	d *= 2.0;
+
+	EXPECT_EQ((unit<dimensionless_unit, int>(32)), d);
 }
 
 TEST_F(UnitContainer, compoundAssignmentDivision)
 {
 	// units
-	meter_t a(8.0);
+	meter_t a(32.0);
 	a /= dimensionless(2.0);
 
-	EXPECT_EQ(meter_t(4.0), a);
+	EXPECT_EQ(meter_t(16.0), a);
 
 	a /= 2.0;
 
-	EXPECT_EQ(meter_t(2.0), a);
+	EXPECT_EQ(meter_t(8.0), a);
+
+	a /= unit<dimensionless_unit, int>(2);
+
+	EXPECT_EQ(meter_t(4), a);
+
+	a /= 2;
+
+	EXPECT_EQ(meter_t(2), a);
+
+	unit<meters, int> c(32);
+	c /= unit<dimensionless_unit, int>(2);
+
+	EXPECT_EQ((unit<meters, int>(16)), c);
+
+	c /= dimensionless(2.0);
+
+	EXPECT_EQ((unit<meters, int>(8)), c);
+
+	c /= 2;
+
+	EXPECT_EQ((unit<meters, int>(4)), c);
+
+	c /= 2.0;
+
+	EXPECT_EQ((unit<meters, int>(2)), c);
 
 	// dimensionlesss
-	dimensionless b(8);
+	dimensionless b(32);
 	b /= dimensionless(2.0);
+
+	EXPECT_EQ(dimensionless(16.0), b);
+
+	b /= 2.0;
+
+	EXPECT_EQ(dimensionless(8.0), b);
+
+	b /= unit<dimensionless_unit, int>(2);
 
 	EXPECT_EQ(dimensionless(4.0), b);
 
 	b /= 2;
 
 	EXPECT_EQ(dimensionless(2.0), b);
+
+	unit<dimensionless_unit, int> d(32);
+	d /= unit<dimensionless_unit, int>(2);
+
+	EXPECT_EQ((unit<dimensionless_unit, int>(16)), d);
+
+	d /= dimensionless(2.0);
+
+	EXPECT_EQ((unit<dimensionless_unit, int>(8)), d);
+
+	d /= 2;
+
+	EXPECT_EQ((unit<dimensionless_unit, int>(4)), d);
+
+	d /= 2.0;
+
+	EXPECT_EQ((unit<dimensionless_unit, int>(2)), d);
 }
 
 TEST_F(UnitContainer, compoundAssignmentModulo)

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -942,6 +942,26 @@ TEST_F(UnitContainer, constructionFromArithmeticType)
 	EXPECT_EQ(1, c_dim());
 }
 
+TEST_F(UnitContainer, constructionFromUnitContainer)
+{
+	unit<meters, int> a_m(1);
+
+	unit<meters, int> b_m(a_m);
+	EXPECT_EQ(1, b_m());
+
+	unit<millimeters, int> a_mm(b_m);
+	EXPECT_EQ(1000, a_mm());
+
+	meter_t c_m(b_m);
+	EXPECT_EQ(1.0, c_m());
+
+	meter_t d_m(a_mm);
+	EXPECT_EQ(1.0, d_m());
+
+	meter_t e_m(unit<kilometers, int>(1));
+	EXPECT_EQ(1000.0, e_m());
+}
+
 TEST_F(UnitContainer, make_unit)
 {
 	auto dist = units::make_unit<meter_t>(5);

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -1097,6 +1097,54 @@ TEST_F(UnitContainer, make_unit)
 	EXPECT_EQ((unit<dimensionless_unit, int>(5)), c_dim);
 }
 
+TEST_F(UnitContainer, unitTypeEquality)
+{
+	const meter_t a_m(0);
+	const meter_t b_m(1);
+
+	EXPECT_TRUE(a_m == a_m);
+	EXPECT_FALSE(a_m == b_m);
+	EXPECT_TRUE(a_m != b_m);
+	EXPECT_FALSE(b_m != b_m);
+
+	const unit<meters, int> c_m(0);
+	const unit<meters, int> d_m(1);
+
+	EXPECT_TRUE(c_m == c_m);
+	EXPECT_FALSE(c_m == d_m);
+	EXPECT_TRUE(c_m != d_m);
+	EXPECT_FALSE(d_m != d_m);
+
+	EXPECT_TRUE(a_m == c_m);
+	EXPECT_TRUE(d_m == b_m);
+	EXPECT_FALSE(a_m != c_m);
+	EXPECT_FALSE(d_m != b_m);
+	EXPECT_TRUE(a_m != d_m);
+	EXPECT_TRUE(c_m != b_m);
+	EXPECT_FALSE(a_m != c_m);
+	EXPECT_FALSE(d_m != b_m);
+}
+
+TEST_F(UnitContainer, unitTypeMixedEquality)
+{
+	const meter_t a_m(0);
+	const foot_t a_f(meter_t(1));
+
+	EXPECT_FALSE(a_m == a_f);
+	EXPECT_TRUE(a_m != a_f);
+
+	const unit<feet, int> b_f(0);
+	const unit<meters, int> b_m(1);
+
+	EXPECT_FALSE(b_f == b_m);
+	EXPECT_TRUE(b_f != b_m);
+
+	EXPECT_TRUE(a_m == b_f);
+	EXPECT_TRUE(b_m == a_f);
+	EXPECT_FALSE(a_m != b_f);
+	EXPECT_FALSE(b_m != a_f);
+}
+
 TEST_F(UnitContainer, unitTypeAddition)
 {
 	// units

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -1290,30 +1290,54 @@ TEST_F(UnitContainer, unitTypeAddition)
 	EXPECT_NEAR(2.0, sresult, 5.0e-6);
 	sresult = unit<dimensionless_unit, int>(1) + unit<dimensionless_unit, int>(1);
 	EXPECT_NEAR(2.0, sresult, 5.0e-6);
+	sresult = dimensionless(1.0) + unit<dimensionless_unit, int>(1);
+	EXPECT_NEAR(2.0, sresult, 5.0e-6);
+	sresult = unit<dimensionless_unit, int>(1) + dimensionless(1.0);
+	EXPECT_NEAR(2.0, sresult, 5.0e-6);
 
 	sresult = dimensionless(1.0) + 1.0;
+	EXPECT_NEAR(2.0, sresult, 5.0e-6);
+	sresult = unit<dimensionless_unit, int>(1) + 1;
+	EXPECT_NEAR(2.0, sresult, 5.0e-6);
+	sresult = dimensionless(1.0) + 1;
 	EXPECT_NEAR(2.0, sresult, 5.0e-6);
 	sresult = unit<dimensionless_unit, int>(1) + 1.0;
 	EXPECT_NEAR(2.0, sresult, 5.0e-6);
 
 	sresult = 1.0 + dimensionless(1.0);
 	EXPECT_NEAR(2.0, sresult, 5.0e-6);
+	sresult = 1 + unit<dimensionless_unit, int>(1);
+	EXPECT_NEAR(2.0, sresult, 5.0e-6);
 	sresult = 1.0 + unit<dimensionless_unit, int>(1);
+	EXPECT_NEAR(2.0, sresult, 5.0e-6);
+	sresult = 1 + dimensionless(1.0);
 	EXPECT_NEAR(2.0, sresult, 5.0e-6);
 
 	d = dimensionless(1.0) + dimensionless(1.0);
 	EXPECT_NEAR(2.0, d, 5.0e-6);
 	d = unit<dimensionless_unit, int>(1) + unit<dimensionless_unit, int>(1);
 	EXPECT_NEAR(2.0, d, 5.0e-6);
+	d = dimensionless(1.0) + unit<dimensionless_unit, int>(1);
+	EXPECT_NEAR(2.0, d, 5.0e-6);
+	d = unit<dimensionless_unit, int>(1) + dimensionless(1.0);
+	EXPECT_NEAR(2.0, d, 5.0e-6);
 
 	d = dimensionless(1.0) + 1.0;
+	EXPECT_NEAR(2.0, d, 5.0e-6);
+	d = unit<dimensionless_unit, int>(1) + 1;
+	EXPECT_NEAR(2.0, d, 5.0e-6);
+	d = dimensionless(1.0) + 1;
 	EXPECT_NEAR(2.0, d, 5.0e-6);
 	d = unit<dimensionless_unit, int>(1) + 1.0;
 	EXPECT_NEAR(2.0, d, 5.0e-6);
 
 	d = 1.0 + dimensionless(1.0);
 	EXPECT_NEAR(2.0, d, 5.0e-6);
+	d = 1.+ unit<dimensionless_unit, int>(1);
+	EXPECT_NEAR(2.0, d, 5.0e-6);
 	d = 1.0 + unit<dimensionless_unit, int>(1);
+	EXPECT_NEAR(2.0, d, 5.0e-6);
+	d = 1 + dimensionless(1.0);
 	EXPECT_NEAR(2.0, d, 5.0e-6);
 }
 
@@ -1374,30 +1398,54 @@ TEST_F(UnitContainer, unitTypeSubtraction)
 	EXPECT_NEAR(0.0, sresult, 5.0e-6);
 	sresult = unit<dimensionless_unit, int>(1) - unit<dimensionless_unit, int>(1);
 	EXPECT_NEAR(0.0, sresult, 5.0e-6);
+	sresult = dimensionless(1.0) - unit<dimensionless_unit, int>(1);
+	EXPECT_NEAR(0.0, sresult, 5.0e-6);
+	sresult = unit<dimensionless_unit, int>(1) - dimensionless(1.0);
+	EXPECT_NEAR(0.0, sresult, 5.0e-6);
 
 	sresult = dimensionless(1.0) - 1.0;
+	EXPECT_NEAR(0.0, sresult, 5.0e-6);
+	sresult = unit<dimensionless_unit, int>(1) - 1;
+	EXPECT_NEAR(0.0, sresult, 5.0e-6);
+	sresult = dimensionless(1.0) - 1;
 	EXPECT_NEAR(0.0, sresult, 5.0e-6);
 	sresult = unit<dimensionless_unit, int>(1) - 1.0;
 	EXPECT_NEAR(0.0, sresult, 5.0e-6);
 
 	sresult = 1.0 - dimensionless(1.0);
 	EXPECT_NEAR(0.0, sresult, 5.0e-6);
+	sresult = 1 - unit<dimensionless_unit, int>(1);
+	EXPECT_NEAR(0.0, sresult, 5.0e-6);
 	sresult = 1.0 - unit<dimensionless_unit, int>(1);
+	EXPECT_NEAR(0.0, sresult, 5.0e-6);
+	sresult = 1 - dimensionless(1.0);
 	EXPECT_NEAR(0.0, sresult, 5.0e-6);
 
 	double d = dimensionless(1.0) - dimensionless(1.0);
 	EXPECT_NEAR(0.0, d, 5.0e-6);
 	d = unit<dimensionless_unit, int>(1) - unit<dimensionless_unit, int>(1);
 	EXPECT_NEAR(0.0, d, 5.0e-6);
+	d = dimensionless(1.0) - unit<dimensionless_unit, int>(1);
+	EXPECT_NEAR(0.0, d, 5.0e-6);
+	d = unit<dimensionless_unit, int>(1) - dimensionless(1.0);
+	EXPECT_NEAR(0.0, d, 5.0e-6);
 
 	d = dimensionless(1.0) - 1.0;
+	EXPECT_NEAR(0.0, d, 5.0e-6);
+	d = unit<dimensionless_unit, int>(1) - 1;
+	EXPECT_NEAR(0.0, d, 5.0e-6);
+	d = dimensionless(1.0) - 1;
 	EXPECT_NEAR(0.0, d, 5.0e-6);
 	d = unit<dimensionless_unit, int>(1) - 1.0;
 	EXPECT_NEAR(0.0, d, 5.0e-6);
 
 	d = 1.0 - dimensionless(1.0);
 	EXPECT_NEAR(0.0, d, 5.0e-6);
+	d = 1 - unit<dimensionless_unit, int>(1);
+	EXPECT_NEAR(0.0, d, 5.0e-6);
 	d = 1.0 - unit<dimensionless_unit, int>(1);
+	EXPECT_NEAR(0.0, d, 5.0e-6);
+	d = 1 - dimensionless(1.0);
 	EXPECT_NEAR(0.0, d, 5.0e-6);
 }
 
@@ -1467,9 +1515,9 @@ TEST_F(UnitContainer, unitTypeMultiplication)
 	EXPECT_NEAR(4.0, c_m(), 5.0e-5);
 	c_m = 2 * e_m;
 	EXPECT_NEAR(4.0, c_m(), 5.0e-5);
-	c_m = 2 * b_m;
-	EXPECT_NEAR(4.0, c_m(), 5.0e-5);
 	c_m = 2.0 * e_m;
+	EXPECT_NEAR(4.0, c_m(), 5.0e-5);
+	c_m = 2 * b_m;
 	EXPECT_NEAR(4.0, c_m(), 5.0e-5);
 
 	double convert = dimensionless(3.14);
@@ -1481,30 +1529,54 @@ TEST_F(UnitContainer, unitTypeMultiplication)
 	EXPECT_NEAR(20.0, sresult(), 5.0e-5);
 	sresult = unit<dimensionless_unit, int>(5) * unit<dimensionless_unit, int>(4);
 	EXPECT_NEAR(20.0, sresult(), 5.0e-5);
+	sresult = dimensionless(5.0) * unit<dimensionless_unit, int>(4);
+	EXPECT_NEAR(20.0, sresult(), 5.0e-5);
+	sresult = unit<dimensionless_unit, int>(5) * dimensionless(4.0);
+	EXPECT_NEAR(20.0, sresult(), 5.0e-5);
 
 	sresult = dimensionless(5.0) * 4.0;
+	EXPECT_NEAR(20.0, sresult(), 5.0e-5);
+	sresult = unit<dimensionless_unit, int>(5) * 4;
+	EXPECT_NEAR(20.0, sresult(), 5.0e-5);
+	sresult = dimensionless(5.0) * 4;
 	EXPECT_NEAR(20.0, sresult(), 5.0e-5);
 	sresult = unit<dimensionless_unit, int>(5) * 4.0;
 	EXPECT_NEAR(20.0, sresult(), 5.0e-5);
 
 	sresult = 4.0 * dimensionless(5.0);
 	EXPECT_NEAR(20.0, sresult(), 5.0e-5);
+	sresult = 4 * unit<dimensionless_unit, int>(5);
+	EXPECT_NEAR(20.0, sresult(), 5.0e-5);
 	sresult = 4.0 * unit<dimensionless_unit, int>(5);
+	EXPECT_NEAR(20.0, sresult(), 5.0e-5);
+	sresult = 4 * dimensionless(5.0);
 	EXPECT_NEAR(20.0, sresult(), 5.0e-5);
 
 	double result = dimensionless(5.0) * dimensionless(4.0);
 	EXPECT_NEAR(20.0, result, 5.0e-5);
 	result = unit<dimensionless_unit, int>(5) * unit<dimensionless_unit, int>(4);
 	EXPECT_NEAR(20.0, result, 5.0e-5);
+	result = dimensionless(5.0) * unit<dimensionless_unit, int>(4);
+	EXPECT_NEAR(20.0, result, 5.0e-5);
+	result = unit<dimensionless_unit, int>(5) * dimensionless(4.0);
+	EXPECT_NEAR(20.0, result, 5.0e-5);
 
 	result = dimensionless(5.0) * 4.0;
+	EXPECT_NEAR(20.0, result, 5.0e-5);
+	result = unit<dimensionless_unit, int>(5) * 4;
+	EXPECT_NEAR(20.0, result, 5.0e-5);
+	result = dimensionless(5.0) * 4;
 	EXPECT_NEAR(20.0, result, 5.0e-5);
 	result = unit<dimensionless_unit, int>(5) * 4.0;
 	EXPECT_NEAR(20.0, result, 5.0e-5);
 
 	result = 4.0 * dimensionless(5.0);
 	EXPECT_NEAR(20.0, result, 5.0e-5);
+	result = 4 * unit<dimensionless_unit, int>(5);
+	EXPECT_NEAR(20.0, result, 5.0e-5);
 	result = 4.0 * unit<dimensionless_unit, int>(5);
+	EXPECT_NEAR(20.0, result, 5.0e-5);
+	result = 4 * dimensionless(5.0);
 	EXPECT_NEAR(20.0, result, 5.0e-5);
 }
 
@@ -1560,9 +1632,9 @@ TEST_F(UnitContainer, unitTypeMixedUnitMultiplication)
 	EXPECT_NEAR(4.0, e_m(), 5.0e-5);
 	e_m = unit<dimensionless_unit, int>(4) * b_m;
 	EXPECT_NEAR(4.0, e_m(), 5.0e-5);
-	e_m = unit<dimensionless_unit, int>(4) * a_m;
-	EXPECT_NEAR(4.0, e_m(), 5.0e-5);
 	e_m = dimensionless(4) * b_m;
+	EXPECT_NEAR(4.0, e_m(), 5.0e-5);
+	e_m = unit<dimensionless_unit, int>(4) * a_m;
 	EXPECT_NEAR(4.0, e_m(), 5.0e-5);
 
 	// unit times its inverse results in a dimensionless
@@ -1595,8 +1667,12 @@ TEST_F(UnitContainer, unitTypeMixedUnitMultiplication)
 
 	auto mps = meter_t(10.0) * unit<inverse<seconds>>(1.0);
 	EXPECT_EQ(mps, meters_per_second_t(10));
-	auto i_mps = unit<meters, int>(10) * unit<inverse<seconds>, int>(1);
-	EXPECT_EQ(i_mps, meters_per_second_t(10));
+	mps = unit<meters, int>(10) * unit<inverse<seconds>, int>(1);
+	EXPECT_EQ(mps, meters_per_second_t(10));
+	mps = meter_t(10.0) * unit<inverse<seconds>, int>(1);
+	EXPECT_EQ(mps, meters_per_second_t(10));
+	mps = unit<meters, int>(10) * unit<inverse<seconds>>(1.0);
+	EXPECT_EQ(mps, meters_per_second_t(10));
 }
 
 TEST_F(UnitContainer, unitTypedimensionlessMultiplication)
@@ -1644,7 +1720,7 @@ TEST_F(UnitContainer, unitTypeDivision)
 	c = a_m / b_m;
 	EXPECT_NEAR(0.5, c, 5.0e-5);
 	c = d_m / e_m;
-	EXPECT_NEAR(0, c, 5.0e-5);
+	EXPECT_EQ(0, c);
 	c = a_m / e_m;
 	EXPECT_NEAR(0.5, c, 5.0e-5);
 	c = d_m / b_m;
@@ -1666,10 +1742,10 @@ TEST_F(UnitContainer, unitTypeDivision)
 	c = dimensionless(1.0) / 2.0;
 	EXPECT_NEAR(0.5, c, 5.0e-5);
 	c = unit<dimensionless_unit, int>(1) / 2;
-	EXPECT_NEAR(0, c, 5.0e-5);
-	c = unit<dimensionless_unit, int>(1) / 2.0;
-	EXPECT_NEAR(0.5, c, 5.0e-5);
+	EXPECT_EQ(0, c);
 	c = dimensionless(1.0) / 2;
+	EXPECT_NEAR(0.5, c, 5.0e-5);
+	c = unit<dimensionless_unit, int>(1) / 2.0;
 	EXPECT_NEAR(0.5, c, 5.0e-5);
 	isSame = std::is_same_v<decltype(c), dimensionless>;
 	EXPECT_TRUE(isSame);
@@ -1677,7 +1753,7 @@ TEST_F(UnitContainer, unitTypeDivision)
 	c = 1.0 / dimensionless(2.0);
 	EXPECT_NEAR(0.5, c, 5.0e-5);
 	c = 1 / unit<dimensionless_unit, int>(2);
-	EXPECT_NEAR(0, c, 5.0e-5);
+	EXPECT_EQ(0, c);
 	c = 1.0 / unit<dimensionless_unit, int>(2);
 	EXPECT_NEAR(0.5, c, 5.0e-5);
 	c = 1 / dimensionless(2.0);
@@ -1691,7 +1767,7 @@ TEST_F(UnitContainer, unitTypeDivision)
 	auto e = a_m / a_sec;
 	EXPECT_NEAR(0.1, e(), 5.0e-5);
 	e = d_m / b_sec;
-	EXPECT_NEAR(0, e(), 5.0e-5);
+	EXPECT_EQ(0, e());
 	e = a_m / b_sec;
 	EXPECT_NEAR(0.1, e(), 5.0e-5);
 	e = d_m / a_sec;
@@ -1702,7 +1778,7 @@ TEST_F(UnitContainer, unitTypeDivision)
 	auto f = a_m / 8.0;
 	EXPECT_NEAR(0.125, f(), 5.0e-5);
 	f = d_m / 8;
-	EXPECT_NEAR(0, f(), 5.0e-5);
+	EXPECT_EQ(0, f());
 	f = a_m / 8;
 	EXPECT_NEAR(0.125, f(), 5.0e-5);
 	f = d_m / 8.0;
@@ -1714,9 +1790,9 @@ TEST_F(UnitContainer, unitTypeDivision)
 	EXPECT_NEAR(2.0, g(), 5.0e-5);
 	g = 4 / e_m;
 	EXPECT_NEAR(2.0, g(), 5.0e-5);
-	g = 4 / b_m;
-	EXPECT_NEAR(2.0, g(), 5.0e-5);
 	g = 4.0 / e_m;
+	EXPECT_NEAR(2.0, g(), 5.0e-5);
+	g = 4 / b_m;
 	EXPECT_NEAR(2.0, g(), 5.0e-5);
 	isSame = std::is_same_v<decltype(g), unit<inverse<meters>>>;
 	EXPECT_TRUE(isSame);
@@ -1804,6 +1880,10 @@ TEST_F(UnitContainer, compoundAssignmentAddition)
 
 	EXPECT_EQ(meter_t(3.0), a);
 
+	a += std::common_type_t<unit<meters, int>, unit<feet, int>>(unit<meters, int>(1));
+
+	EXPECT_EQ(meter_t(4.0), a);
+
 	unit<meters, int> c(0);
 	c += unit<meters, int>(1);
 
@@ -1856,6 +1936,10 @@ TEST_F(UnitContainer, compoundAssignmentSubtraction)
 	a -= unit<meters, int>(1);
 
 	EXPECT_EQ(meter_t(-1.0), a);
+
+	a -= std::common_type_t<unit<meters, int>, unit<feet, int>>(unit<meters, int>(1));
+
+	EXPECT_EQ(meter_t(-2.0), a);
 
 	unit<meters, int> c(1);
 	c -= unit<meters, int>(1);
@@ -1970,22 +2054,22 @@ TEST_F(UnitContainer, compoundAssignmentMultiplication)
 TEST_F(UnitContainer, compoundAssignmentDivision)
 {
 	// units
-	meter_t a(32.0);
+	meter_t a(8.0);
 	a /= dimensionless(2.0);
 
-	EXPECT_EQ(meter_t(16.0), a);
+	EXPECT_EQ(meter_t(4.0), a);
 
 	a /= 2.0;
 
-	EXPECT_EQ(meter_t(8.0), a);
+	EXPECT_EQ(meter_t(2.0), a);
 
 	a /= unit<dimensionless_unit, int>(2);
 
-	EXPECT_EQ(meter_t(4), a);
+	EXPECT_EQ(meter_t(1), a);
 
 	a /= 2;
 
-	EXPECT_EQ(meter_t(2), a);
+	EXPECT_EQ(meter_t(0.5), a);
 
 	unit<meters, int> c(32);
 	c /= unit<dimensionless_unit, int>(2);
@@ -2005,22 +2089,22 @@ TEST_F(UnitContainer, compoundAssignmentDivision)
 	EXPECT_EQ((unit<meters, int>(2)), c);
 
 	// dimensionlesss
-	dimensionless b(32);
+	dimensionless b(8);
 	b /= dimensionless(2.0);
-
-	EXPECT_EQ(dimensionless(16.0), b);
-
-	b /= 2.0;
-
-	EXPECT_EQ(dimensionless(8.0), b);
-
-	b /= unit<dimensionless_unit, int>(2);
 
 	EXPECT_EQ(dimensionless(4.0), b);
 
-	b /= 2;
+	b /= 2.0;
 
 	EXPECT_EQ(dimensionless(2.0), b);
+
+	b /= unit<dimensionless_unit, int>(2);
+
+	EXPECT_EQ(dimensionless(1.0), b);
+
+	b /= 2;
+
+	EXPECT_EQ(dimensionless(0.5), b);
 
 	unit<dimensionless_unit, int> d(32);
 	d /= unit<dimensionless_unit, int>(2);

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -225,10 +225,10 @@ TEST_F(TypeTraits, inverse)
 	bool shouldBeTrue = std::is_same_v<htz, hertz>;
 	EXPECT_TRUE(shouldBeTrue);
 
-	test = convert<unit<inverse<fahrenheit>>>(unit<inverse<celsius>>(1.0))();
+	test = unit<inverse<fahrenheit>>(unit<inverse<celsius>>(1.0))();
 	EXPECT_NEAR(5.0 / 9.0, test, 5.0e-5);
 
-	test = convert<unit<inverse<fahrenheit>>>(unit<inverse<kelvin>>(6.0))();
+	test = unit<inverse<fahrenheit>>(unit<inverse<kelvin>>(6.0))();
 	EXPECT_NEAR(10.0 / 3.0, test, 5.0e-5);
 }
 
@@ -886,7 +886,7 @@ TEST_F(UnitManipulators, squared)
 {
 	double test;
 
-	test = convert<unit<square_feet>>(unit<squared<meters>>(0.092903))();
+	test = unit<square_feet>(unit<squared<meters>>(0.092903))();
 	EXPECT_NEAR(0.99999956944, test, 5.0e-12);
 
 	using dimensionless_2 = squared<units::dimensionless_unit>;	// this is actually nonsensical, and should also result in a dimensionless.
@@ -898,7 +898,7 @@ TEST_F(UnitManipulators, cubed)
 {
 	double test;
 
-	test = convert<unit<cubic_feet>>(unit<cubed<meters>>(0.0283168))();
+	test = unit<cubic_feet>(unit<cubed<meters>>(0.0283168))();
 	EXPECT_NEAR(0.999998354619, test, 5.0e-13);
 }
 
@@ -906,7 +906,7 @@ TEST_F(UnitManipulators, square_root)
 {
 	double test;
 
-	test = convert<meter_t>(unit<square_root<square_kilometer>>(1.0))();
+	test = meter_t(unit<square_root<square_kilometer>>(1.0))();
 	EXPECT_TRUE((traits::is_convertible_unit_v<typename std::decay<square_root<square_kilometer>>::type, kilometer>));
 	EXPECT_NEAR(1000.0, test, 5.0e-13);
 }
@@ -1103,7 +1103,7 @@ TEST_F(UnitContainer, unitTypeAddition)
 	meter_t a_m(1.0), c_m;
 	foot_t b_ft(3.28084);
 
-	double d = convert<meter_t>(b_ft)();
+	double d = meter_t(b_ft)();
 	EXPECT_NEAR(1.0, d, 5.0e-5);
 
 	c_m = a_m + b_ft;
@@ -1557,7 +1557,7 @@ TEST_F(UnitContainer, valueMethod)
 
 TEST_F(UnitContainer, convertMethod)
 {
-	double test = meter_t(3.0).convert<feet>().to<double>();
+	double test = foot_t(meter_t(3.0)).to<double>();
 	EXPECT_NEAR(9.84252, test, 5.0e-6);
 }
 
@@ -1844,46 +1844,46 @@ TEST_F(UnitContainer, literals)
 TEST_F(UnitConversion, length)
 {
 	double test;
-	test = convert<nanometer_t>(0.000000001_m)();
+	test = nanometer_t(0.000000001_m)();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<micrometer_t>(meter_t(0.000001))();
+	test = micrometer_t(meter_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<millimeter_t>(meter_t(0.001))();
+	test = millimeter_t(meter_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<centimeter_t>(meter_t(0.01))();
+	test = centimeter_t(meter_t(0.01))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<kilometer_t>(meter_t(1000.0))();
+	test = kilometer_t(meter_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<meter_t>(meter_t(1.0))();
+	test = meter_t(meter_t(1.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<foot_t>(meter_t(0.3048))();
+	test = foot_t(meter_t(0.3048))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<mile_t>(meter_t(1609.344))();
+	test = mile_t(meter_t(1609.344))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<inch_t>(meter_t(0.0254))();
+	test = inch_t(meter_t(0.0254))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<nauticalMile_t>(meter_t(1852.0))();
+	test = nauticalMile_t(meter_t(1852.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<astronicalUnit_t>(meter_t(149597870700.0))();
+	test = astronicalUnit_t(meter_t(149597870700.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<lightyear_t>(meter_t(9460730472580800.0))();
+	test = lightyear_t(meter_t(9460730472580800.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<parsec_t>(meter_t(3.08567758e16))();
+	test = parsec_t(meter_t(3.08567758e16))();
 	EXPECT_NEAR(1.0, test, 5.0e7);
 
-	test = convert<foot_t>(foot_t(6.3))();
+	test = foot_t(foot_t(6.3))();
 	EXPECT_NEAR(6.3, test, 5.0e-5);
-	test = convert<inch_t>(foot_t(6.0))();
+	test = inch_t(foot_t(6.0))();
 	EXPECT_NEAR(72.0, test, 5.0e-5);
-	test = convert<foot_t>(inch_t(6.0))();
+	test = foot_t(inch_t(6.0))();
 	EXPECT_NEAR(0.5, test, 5.0e-5);
-	test = convert<foot_t>(meter_t(1.0))();
+	test = foot_t(meter_t(1.0))();
 	EXPECT_NEAR(3.28084, test, 5.0e-5);
-	test = convert<nauticalMile_t>(mile_t(6.3))();
+	test = nauticalMile_t(mile_t(6.3))();
 	EXPECT_NEAR(5.47455, test, 5.0e-6);
-	test = convert<meter_t>(mile_t(11.0))();
+	test = meter_t(mile_t(11.0))();
 	EXPECT_NEAR(17702.8, test, 5.0e-2);
-	test = convert<chain_t>(meter_t(1.0))();
+	test = chain_t(meter_t(1.0))();
 	EXPECT_NEAR(0.0497097, test, 5.0e-7);
 
 //	dimensionless b = 5_rad;
@@ -1893,30 +1893,30 @@ TEST_F(UnitConversion, mass)
 {
 	double test;
 
-	test = convert<gram_t>(kilogram_t(1.0e-3))();
+	test = gram_t(kilogram_t(1.0e-3))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<microgram_t>(kilogram_t(1.0e-9))();
+	test = microgram_t(kilogram_t(1.0e-9))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<milligram_t>(kilogram_t(1.0e-6))();
+	test = milligram_t(kilogram_t(1.0e-6))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<kilogram_t>(kilogram_t(1.0))();
+	test = kilogram_t(kilogram_t(1.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<metric_ton_t>(kilogram_t(1000.0))();
+	test = metric_ton_t(kilogram_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<pound_t>(kilogram_t(0.453592))();
+	test = pound_t(kilogram_t(0.453592))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<long_ton_t>(kilogram_t(1016.05))();
+	test = long_ton_t(kilogram_t(1016.05))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<short_ton_t>(kilogram_t(907.185))();
+	test = short_ton_t(kilogram_t(907.185))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<mass::ounce_t>(kilogram_t(0.0283495))();
+	test = mass::ounce_t(kilogram_t(0.0283495))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<carat_t>(kilogram_t(0.0002))();
+	test = carat_t(kilogram_t(0.0002))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<kilogram_t>(slug_t(1.0))();
+	test = kilogram_t(slug_t(1.0))();
 	EXPECT_NEAR(14.593903, test, 5.0e-7);
 
-	test = convert<carat_t>(pound_t(6.3))();
+	test = carat_t(pound_t(6.3))();
 	EXPECT_NEAR(14288.2, test, 5.0e-2);
 }
 
@@ -1941,32 +1941,32 @@ TEST_F(UnitConversion, time)
 
 
 
-	test = convert<second_t>(second_t(1.0))();
+	test = second_t(second_t(1.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<nanosecond_t>(second_t(1.0e-9))();
+	test = nanosecond_t(second_t(1.0e-9))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<microsecond_t>(second_t(1.0e-6))();
+	test = microsecond_t(second_t(1.0e-6))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<millisecond_t>(second_t(1.0e-3))();
+	test = millisecond_t(second_t(1.0e-3))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<minute_t>(second_t(60.0))();
+	test = minute_t(second_t(60.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<hour_t>(second_t(3600.0))();
+	test = hour_t(second_t(3600.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<day_t>(second_t(86400.0))();
+	test = day_t(second_t(86400.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<week_t>(second_t(604800.0))();
+	test = week_t(second_t(604800.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<year_t>(second_t(3.154e7))();
+	test = year_t(second_t(3.154e7))();
 	EXPECT_NEAR(1.0, test, 5.0e3);
 
-	test = convert<week_t>(year_t(2.0))();
+	test = week_t(year_t(2.0))();
 	EXPECT_NEAR(104.2857142857143, test, 5.0e-14);
-	test = convert<minute_t>(hour_t(4.0))();
+	test = minute_t(hour_t(4.0))();
 	EXPECT_NEAR(240.0, test, 5.0e-14);
-	test = convert<day_t>(julian_year_t(1.0))();
+	test = day_t(julian_year_t(1.0))();
 	EXPECT_NEAR(365.25, test, 5.0e-14);
-	test = convert<day_t>(gregorian_year_t(1.0))();
+	test = day_t(gregorian_year_t(1.0))();
 	EXPECT_NEAR(365.2425, test, 5.0e-14);
 
 }
@@ -1979,28 +1979,28 @@ TEST_F(UnitConversion, angle)
 
 	double test;
 
-	test = convert<angle::radian_t>(angle::radian_t(1.0))();
+	test = angle::radian_t(angle::radian_t(1.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<angle::milliradian_t>(angle::radian_t(0.001))();
+	test = angle::milliradian_t(angle::radian_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-4);
-	test = convert<angle::degree_t>(angle::radian_t(0.0174533))();
+	test = angle::degree_t(angle::radian_t(0.0174533))();
 	EXPECT_NEAR(1.0, test, 5.0e-7);
-	test = convert<angle::arcminute_t>(angle::radian_t(0.000290888))();
+	test = angle::arcminute_t(angle::radian_t(0.000290888))();
 	EXPECT_NEAR(0.99999928265913, test, 5.0e-8);
-	test = convert<angle::arcsecond_t>(angle::radian_t(4.8481e-6))();
+	test = angle::arcsecond_t(angle::radian_t(4.8481e-6))();
 	EXPECT_NEAR(0.999992407, test, 5.0e-10);
-	test = convert<angle::turn_t>(angle::radian_t(6.28319))();
+	test = angle::turn_t(angle::radian_t(6.28319))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<angle::gradian_t>(angle::radian_t(0.015708))();
+	test = angle::gradian_t(angle::radian_t(0.015708))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
 
-	test = convert<angle::radian_t>(angle::radian_t(2.1))();
+	test = angle::radian_t(angle::radian_t(2.1))();
 	EXPECT_NEAR(2.1, test, 5.0e-6);
-	test = convert<angle::gradian_t>(angle::arcsecond_t(2.1))();
+	test = angle::gradian_t(angle::arcsecond_t(2.1))();
 	EXPECT_NEAR(0.000648148, test, 5.0e-6);
-	test = convert<angle::degree_t>(angle::radian_t(constants::detail::PI_VAL))();
+	test = angle::degree_t(angle::radian_t(constants::detail::PI_VAL))();
 	EXPECT_NEAR(180.0, test, 5.0e-6);
-	test = convert<angle::radian_t>(angle::degree_t(90.0))();
+	test = angle::radian_t(angle::degree_t(90.0))();
 	EXPECT_NEAR(constants::detail::PI_VAL / 2, test, 5.0e-6);
 }
 
@@ -2008,7 +2008,7 @@ TEST_F(UnitConversion, current)
 {
 	double test;
 
-	test = convert<current::milliampere_t>(current::ampere_t(2.1))();
+	test = current::milliampere_t(current::ampere_t(2.1))();
 	EXPECT_NEAR(2100.0, test, 5.0e-6);
 }
 
@@ -2017,43 +2017,43 @@ TEST_F(UnitConversion, temperature)
 	// temp conversion are weird/hard since they involve translations AND scaling.
 	double test;
 
-	test = convert<kelvin_t>(kelvin_t(72.0))();
+	test = kelvin_t(kelvin_t(72.0))();
 	EXPECT_NEAR(72.0, test, 5.0e-5);
-	test = convert<fahrenheit_t>(fahrenheit_t(72.0))();
+	test = fahrenheit_t(fahrenheit_t(72.0))();
 	EXPECT_NEAR(72.0, test, 5.0e-5);
-	test = convert<fahrenheit_t>(kelvin_t(300.0))();
+	test = fahrenheit_t(kelvin_t(300.0))();
 	EXPECT_NEAR(80.33, test, 5.0e-5);
-	test = convert<kelvin_t>(fahrenheit_t(451.0))();
+	test = kelvin_t(fahrenheit_t(451.0))();
 	EXPECT_NEAR(505.928, test, 5.0e-4);
-	test = convert<celsius_t>(kelvin_t(300.0))();
+	test = celsius_t(kelvin_t(300.0))();
 	EXPECT_NEAR(26.85, test, 5.0e-3);
-	test = convert<kelvin_t>(celsius_t(451.0))();
+	test = kelvin_t(celsius_t(451.0))();
 	EXPECT_NEAR(724.15, test, 5.0e-3);
-	test = convert<celsius_t>(fahrenheit_t(72.0))();
+	test = celsius_t(fahrenheit_t(72.0))();
 	EXPECT_NEAR(22.2222, test, 5.0e-5);
-	test = convert<fahrenheit_t>(celsius_t(100.0))();
+	test = fahrenheit_t(celsius_t(100.0))();
 	EXPECT_NEAR(212.0, test, 5.0e-5);
-	test = convert<celsius_t>(fahrenheit_t(32.0))();
+	test = celsius_t(fahrenheit_t(32.0))();
 	EXPECT_NEAR(0.0, test, 5.0e-5);
-	test = convert<fahrenheit_t>(celsius_t(0.0))();
+	test = fahrenheit_t(celsius_t(0.0))();
 	EXPECT_NEAR(32.0, test, 5.0e-5);
-	test = convert<kelvin_t>(rankine_t(100.0))();
+	test = kelvin_t(rankine_t(100.0))();
 	EXPECT_NEAR(55.5556, test, 5.0e-5);
-	test = convert<rankine_t>(kelvin_t(100.0))();
+	test = rankine_t(kelvin_t(100.0))();
 	EXPECT_NEAR(180.0, test, 5.0e-5);
-	test = convert<rankine_t>(fahrenheit_t(100.0))();
+	test = rankine_t(fahrenheit_t(100.0))();
 	EXPECT_NEAR(559.67, test, 5.0e-5);
-	test = convert<fahrenheit_t>(rankine_t(72.0))();
+	test = fahrenheit_t(rankine_t(72.0))();
 	EXPECT_NEAR(-387.67, test, 5.0e-5);
-	test = convert<kelvin_t>(reaumur_t(100.0))();
+	test = kelvin_t(reaumur_t(100.0))();
 	EXPECT_NEAR(398.0, test, 5.0e-1);
-	test = convert<celsius_t>(reaumur_t(80.0))();
+	test = celsius_t(reaumur_t(80.0))();
 	EXPECT_NEAR(100.0, test, 5.0e-5);
-	test = convert<reaumur_t>(celsius_t(212.0))();
+	test = reaumur_t(celsius_t(212.0))();
 	EXPECT_NEAR(169.6, test, 5.0e-2);
-	test = convert<fahrenheit_t>(reaumur_t(80.0))();
+	test = fahrenheit_t(reaumur_t(80.0))();
 	EXPECT_NEAR(212.0, test, 5.0e-5);
-	test = convert<reaumur_t>(fahrenheit_t(37.0))();
+	test = reaumur_t(fahrenheit_t(37.0))();
 	EXPECT_NEAR(2.222, test, 5.0e-3);
 }
 
@@ -2061,9 +2061,9 @@ TEST_F(UnitConversion, luminous_intensity)
 {
 	double test;
 
-	test = convert<millicandela_t>(candela_t(72.0))();
+	test = millicandela_t(candela_t(72.0))();
 	EXPECT_NEAR(72000.0, test, 5.0e-5);
-	test = convert<candela_t>(millicandela_t(376.0))();
+	test = candela_t(millicandela_t(376.0))();
 	EXPECT_NEAR(0.376, test, 5.0e-5);
 }
 
@@ -2075,23 +2075,23 @@ TEST_F(UnitConversion, solid_angle)
 	same = std::is_same_v<traits::dimension_of_t<steradians>, traits::dimension_of_t<degrees_squared>>;
 	EXPECT_TRUE(same);
 
-	test = convert<steradian_t>(steradian_t(72.0))();
+	test = steradian_t(steradian_t(72.0))();
 	EXPECT_NEAR(72.0, test, 5.0e-5);
-	test = convert<degree_squared_t>(steradian_t(1.0))();
+	test = degree_squared_t(steradian_t(1.0))();
 	EXPECT_NEAR(3282.8, test, 5.0e-2);
-	test = convert<spat_t>(steradian_t(8.0))();
+	test = spat_t(steradian_t(8.0))();
 	EXPECT_NEAR(0.636619772367582, test, 5.0e-14);
-	test = convert<steradian_t>(degree_squared_t(3282.8))();
+	test = steradian_t(degree_squared_t(3282.8))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<degree_squared_t>(degree_squared_t(72.0))();
+	test = degree_squared_t(degree_squared_t(72.0))();
 	EXPECT_NEAR(72.0, test, 5.0e-5);
-	test = convert<spat_t>(degree_squared_t(3282.8))();
+	test = spat_t(degree_squared_t(3282.8))();
 	EXPECT_NEAR(1.0 / (4 * constants::detail::PI_VAL), test, 5.0e-5);
-	test = convert<steradian_t>(spat_t(1.0 / (4 * constants::detail::PI_VAL)))();
+	test = steradian_t(spat_t(1.0 / (4 * constants::detail::PI_VAL)))();
 	EXPECT_NEAR(1.0, test, 5.0e-14);
-	test = convert<degree_squared_t>(spat_t(1.0 / (4 * constants::detail::PI_VAL)))();
+	test = degree_squared_t(spat_t(1.0 / (4 * constants::detail::PI_VAL)))();
 	EXPECT_NEAR(3282.8, test, 5.0e-2);
-	test = convert<spat_t>(spat_t(72.0))();
+	test = spat_t(spat_t(72.0))();
 	EXPECT_NEAR(72.0, test, 5.0e-5);
 }
 
@@ -2099,13 +2099,13 @@ TEST_F(UnitConversion, frequency)
 {
 	double test;
 
-	test = convert<kilohertz_t>(hertz_t(63000.0))();
+	test = kilohertz_t(hertz_t(63000.0))();
 	EXPECT_NEAR(63.0, test, 5.0e-5);
-	test = convert<hertz_t>(hertz_t(6.3))();
+	test = hertz_t(hertz_t(6.3))();
 	EXPECT_NEAR(6.3, test, 5.0e-5);
-	test = convert<hertz_t>(kilohertz_t(5.0))();
+	test = hertz_t(kilohertz_t(5.0))();
 	EXPECT_NEAR(5000.0, test, 5.0e-5);
-	test = convert<hertz_t>(megahertz_t(1.0))();
+	test = hertz_t(megahertz_t(1.0))();
 	EXPECT_NEAR(1.0e6, test, 5.0e-5);
 }
 
@@ -2119,15 +2119,15 @@ TEST_F(UnitConversion, velocity)
 	same = traits::is_convertible_unit_v<miles_per_hour, meters_per_second>;
 	EXPECT_TRUE(same);
 
-	test = convert<miles_per_hour_t>(meters_per_second_t(1250.0))();
+	test = miles_per_hour_t(meters_per_second_t(1250.0))();
 	EXPECT_NEAR(2796.17, test, 5.0e-3);
-	test = convert<kilometers_per_hour_t>(feet_per_second_t(2796.17))();
+	test = kilometers_per_hour_t(feet_per_second_t(2796.17))();
 	EXPECT_NEAR(3068.181418, test, 5.0e-7);
-	test = convert<miles_per_hour_t>(knot_t(600.0))();
+	test = miles_per_hour_t(knot_t(600.0))();
 	EXPECT_NEAR(690.468, test, 5.0e-4);
-	test = convert<feet_per_second_t>(miles_per_hour_t(120.0))();
+	test = feet_per_second_t(miles_per_hour_t(120.0))();
 	EXPECT_NEAR(176.0, test, 5.0e-5);
-	test = convert<meters_per_second_t>(feet_per_second_t(10.0))();
+	test = meters_per_second_t(feet_per_second_t(10.0))();
 	EXPECT_NEAR(3.048, test, 5.0e-5);
 }
 
@@ -2141,13 +2141,13 @@ TEST_F(UnitConversion, angular_velocity)
 	same = traits::is_convertible_unit_v<rpm, radians_per_second>;
 	EXPECT_TRUE(same);
 
-	test = convert<milliarcseconds_per_year_t>(radians_per_second_t(1.0))();
+	test = milliarcseconds_per_year_t(radians_per_second_t(1.0))();
 	EXPECT_NEAR(6.504e15, test, 1.0e12);
-	test = convert<radians_per_second_t>(degrees_per_second_t(1.0))();
+	test = radians_per_second_t(degrees_per_second_t(1.0))();
 	EXPECT_NEAR(0.0174533, test, 5.0e-8);
-	test = convert<radians_per_second_t>(revolutions_per_minute_t(1.0))();
+	test = radians_per_second_t(revolutions_per_minute_t(1.0))();
 	EXPECT_NEAR(0.10471975512, test, 5.0e-13);
-	test = convert<radians_per_second_t>(milliarcseconds_per_year_t(1.0))();
+	test = radians_per_second_t(milliarcseconds_per_year_t(1.0))();
 	EXPECT_NEAR(1.537e-16, test, 5.0e-20);
 }
 
@@ -2155,7 +2155,7 @@ TEST_F(UnitConversion, acceleration)
 {
 	double test;
 
-	test = convert<meters_per_second_squared_t>(standard_gravity_t(1.0))();
+	test = meters_per_second_squared_t(standard_gravity_t(1.0))();
 	EXPECT_NEAR(9.80665, test, 5.0e-10);
 }
 
@@ -2163,17 +2163,17 @@ TEST_F(UnitConversion, force)
 {
 	double test;
 
-	test = convert<units::force::newton_t>(units::force::newton_t(1.0))();
+	test = units::force::newton_t(units::force::newton_t(1.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<units::force::pound_t>(units::force::newton_t(6.3))();
+	test = units::force::pound_t(units::force::newton_t(6.3))();
 	EXPECT_NEAR(1.4163, test, 5.0e-5);
-	test = convert<units::force::dyne_t>(units::force::newton_t(5.0))();
+	test = units::force::dyne_t(units::force::newton_t(5.0))();
 	EXPECT_NEAR(500000.0, test, 5.0e-5);
-	test = convert<units::force::poundal_t>(units::force::newton_t(2.1))();
+	test = units::force::poundal_t(units::force::newton_t(2.1))();
 	EXPECT_NEAR(15.1893, test, 5.0e-5);
-	test = convert<units::force::kilopond_t>(units::force::newton_t(173.0))();
+	test = units::force::kilopond_t(units::force::newton_t(173.0))();
 	EXPECT_NEAR(17.6411, test, 5.0e-5);
-	test = convert<units::force::kilopond_t>(units::force::poundal_t(21.879))();
+	test = units::force::kilopond_t(units::force::poundal_t(21.879))();
 	EXPECT_NEAR(0.308451933, test, 5.0e-10);
 }
 
@@ -2181,15 +2181,15 @@ TEST_F(UnitConversion, area)
 {
 	double test;
 
-	test = convert<acre_t>(hectare_t(6.3))();
+	test = acre_t(hectare_t(6.3))();
 	EXPECT_NEAR(15.5676, test, 5.0e-5);
-	test = convert<square_kilometer_t>(square_mile_t(10.0))();
+	test = square_kilometer_t(square_mile_t(10.0))();
 	EXPECT_NEAR(25.8999, test, 5.0e-5);
-	test = convert<square_meter_t>(square_inch_t(4.0))();
+	test = square_meter_t(square_inch_t(4.0))();
 	EXPECT_NEAR(0.00258064, test, 5.0e-9);
-	test = convert<square_foot_t>(acre_t(5.0))();
+	test = square_foot_t(acre_t(5.0))();
 	EXPECT_NEAR(217800.0, test, 5.0e-5);
-	test = convert<square_foot_t>(square_meter_t(1.0))();
+	test = square_foot_t(square_meter_t(1.0))();
 	EXPECT_NEAR(10.7639, test, 5.0e-5);
 }
 
@@ -2197,25 +2197,25 @@ TEST_F(UnitConversion, pressure)
 {
 	double test;
 
-	test = convert<torr_t>(pascal_t(1.0))();
+	test = torr_t(pascal_t(1.0))();
 	EXPECT_NEAR(0.00750062, test, 5.0e-5);
-	test = convert<pounds_per_square_inch_t>(bar_t(2.2))();
+	test = pounds_per_square_inch_t(bar_t(2.2))();
 	EXPECT_NEAR(31.9083, test, 5.0e-5);
-	test = convert<bar_t>(atmosphere_t(4.0))();
+	test = bar_t(atmosphere_t(4.0))();
 	EXPECT_NEAR(4.053, test, 5.0e-5);
-	test = convert<pascal_t>(torr_t(800.0))();
+	test = pascal_t(torr_t(800.0))();
 	EXPECT_NEAR(106657.89474, test, 5.0e-5);
-	test = convert<atmosphere_t>(pounds_per_square_inch_t(38.0))();
+	test = atmosphere_t(pounds_per_square_inch_t(38.0))();
 	EXPECT_NEAR(2.58575, test, 5.0e-5);
-	test = convert<pascal_t>(pounds_per_square_inch_t(1.0))();
+	test = pascal_t(pounds_per_square_inch_t(1.0))();
 	EXPECT_NEAR(6894.76, test, 5.0e-3);
-	test = convert<bar_t>(pascal_t(0.25))();
+	test = bar_t(pascal_t(0.25))();
 	EXPECT_NEAR(2.5e-6, test, 5.0e-5);
-	test = convert<atmosphere_t>(torr_t(9.0))();
+	test = atmosphere_t(torr_t(9.0))();
 	EXPECT_NEAR(0.0118421, test, 5.0e-8);
-	test = convert<torr_t>(bar_t(12.0))();
+	test = torr_t(bar_t(12.0))();
 	EXPECT_NEAR(9000.74, test, 5.0e-3);
-	test = convert<pounds_per_square_inch_t>(atmosphere_t(1.0))();
+	test = pounds_per_square_inch_t(atmosphere_t(1.0))();
 	EXPECT_NEAR(14.6959, test, 5.0e-5);
 }
 
@@ -2223,9 +2223,9 @@ TEST_F(UnitConversion, charge)
 {
 	double test;
 
-	test = convert<ampere_hour_t>(coulomb_t(4.0))();
+	test = ampere_hour_t(coulomb_t(4.0))();
 	EXPECT_NEAR(0.00111111, test, 5.0e-9);
-	test = convert<coulomb_t>(ampere_hour_t(1.0))();
+	test = coulomb_t(ampere_hour_t(1.0))();
 	EXPECT_NEAR(3600.0, test, 5.0e-6);
 }
 
@@ -2233,31 +2233,31 @@ TEST_F(UnitConversion, energy)
 {
 	double test;
 
-	test = convert<calorie_t>(joule_t(8000.000464))();
+	test = calorie_t(joule_t(8000.000464))();
 	EXPECT_NEAR(1912.046, test, 5.0e-4);
-	test = convert<joule_t>(therm_t(12.0))();
+	test = joule_t(therm_t(12.0))();
 	EXPECT_NEAR(1.266e+9, test, 5.0e5);
-	test = convert<watt_hour_t>(megajoule_t(100.0))();
+	test = watt_hour_t(megajoule_t(100.0))();
 	EXPECT_NEAR(27777.778, test, 5.0e-4);
-	test = convert<megajoule_t>(kilocalorie_t(56.0))();
+	test = megajoule_t(kilocalorie_t(56.0))();
 	EXPECT_NEAR(0.234304, test, 5.0e-7);
-	test = convert<therm_t>(kilojoule_t(56.0))();
+	test = therm_t(kilojoule_t(56.0))();
 	EXPECT_NEAR(0.000530904, test, 5.0e-5);
-	test = convert<kilojoule_t>(british_thermal_unit_t(18.56399995447))();
+	test = kilojoule_t(british_thermal_unit_t(18.56399995447))();
 	EXPECT_NEAR(19.5860568, test, 5.0e-5);
-	test = convert<energy::foot_pound_t>(calorie_t(18.56399995447))();
+	test = energy::foot_pound_t(calorie_t(18.56399995447))();
 	EXPECT_NEAR(57.28776190423856, test, 5.0e-5);
-	test = convert<calorie_t>(megajoule_t(1.0))();
+	test = calorie_t(megajoule_t(1.0))();
 	EXPECT_NEAR(239006.0, test, 5.0e-1);
-	test = convert<kilowatt_hour_t>(kilocalorie_t(2.0))();
+	test = kilowatt_hour_t(kilocalorie_t(2.0))();
 	EXPECT_NEAR(0.00232444, test, 5.0e-9);
-	test = convert<kilocalorie_t>(therm_t(0.1))();
+	test = kilocalorie_t(therm_t(0.1))();
 	EXPECT_NEAR(2521.04, test, 5.0e-3);
-	test = convert<megajoule_t>(watt_hour_t(67.0))();
+	test = megajoule_t(watt_hour_t(67.0))();
 	EXPECT_NEAR(0.2412, test, 5.0e-5);
-	test = convert<watt_hour_t>(british_thermal_unit_t(100.0))();
+	test = watt_hour_t(british_thermal_unit_t(100.0))();
 	EXPECT_NEAR(29.3071, test, 5.0e-5);
-	test = convert<british_thermal_unit_t>(calorie_t(100.0))();
+	test = british_thermal_unit_t(calorie_t(100.0))();
 	EXPECT_NEAR(0.396567, test, 5.0e-5);
 }
 
@@ -2265,19 +2265,19 @@ TEST_F(UnitConversion, power)
 {
 	double test;
 
-	test = convert<watt_t>(unit<compound_unit_conversion<energy::foot_pounds, inverse<seconds>>>(550.0))();
+	test = watt_t(unit<compound_unit_conversion<energy::foot_pounds, inverse<seconds>>>(550.0))();
 	EXPECT_NEAR(745.7, test, 5.0e-2);
-	test = convert<gigawatt_t>(watt_t(1000000000.0))();
+	test = gigawatt_t(watt_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-4);
-	test = convert<watt_t>(microwatt_t(200000.0))();
+	test = watt_t(microwatt_t(200000.0))();
 	EXPECT_NEAR(0.2, test, 5.0e-4);
-	test = convert<watt_t>(horsepower_t(100.0))();
+	test = watt_t(horsepower_t(100.0))();
 	EXPECT_NEAR(74570.0, test, 5.0e-1);
-	test = convert<megawatt_t>(horsepower_t(5.0))();
+	test = megawatt_t(horsepower_t(5.0))();
 	EXPECT_NEAR(0.0037284994, test, 5.0e-7);
-	test = convert<horsepower_t>(kilowatt_t(232.0))();
+	test = horsepower_t(kilowatt_t(232.0))();
 	EXPECT_NEAR(311.117, test, 5.0e-4);
-	test = convert<horsepower_t>(milliwatt_t(1001.0))();
+	test = horsepower_t(milliwatt_t(1001.0))();
 	EXPECT_NEAR(0.001342363, test, 5.0e-9);
 }
 
@@ -2285,29 +2285,29 @@ TEST_F(UnitConversion, voltage)
 {
 	double test;
 
-	test = convert<millivolt_t>(volt_t(10.0))();
+	test = millivolt_t(volt_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<volt_t>(picovolt_t(1000000000000.0))();
+	test = volt_t(picovolt_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<volt_t>(nanovolt_t(1000000000.0))();
+	test = volt_t(nanovolt_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<volt_t>(microvolt_t(1000000.0))();
+	test = volt_t(microvolt_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<volt_t>(millivolt_t(1000.0))();
+	test = volt_t(millivolt_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<volt_t>(kilovolt_t(0.001))();
+	test = volt_t(kilovolt_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<volt_t>(megavolt_t(0.000001))();
+	test = volt_t(megavolt_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<volt_t>(gigavolt_t(0.000000001))();
+	test = volt_t(gigavolt_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<volt_t>(statvolt_t(299.792458))();
+	test = volt_t(statvolt_t(299.792458))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<statvolt_t>(millivolt_t(1000.0))();
+	test = statvolt_t(millivolt_t(1000.0))();
 	EXPECT_NEAR(299.792458, test, 5.0e-5);
-	test = convert<nanovolt_t>(abvolt_t(0.1))();
+	test = nanovolt_t(abvolt_t(0.1))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<abvolt_t>(microvolt_t(0.01))();
+	test = abvolt_t(microvolt_t(0.01))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
@@ -2315,21 +2315,21 @@ TEST_F(UnitConversion, capacitance)
 {
 	double test;
 
-	test = convert<millifarad_t>(farad_t(10.0))();
+	test = millifarad_t(farad_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<farad_t>(picofarad_t(1000000000000.0))();
+	test = farad_t(picofarad_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<farad_t>(nanofarad_t(1000000000.0))();
+	test = farad_t(nanofarad_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<farad_t>(microfarad_t(1000000.0))();
+	test = farad_t(microfarad_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<farad_t>(millifarad_t(1000.0))();
+	test = farad_t(millifarad_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<farad_t>(kilofarad_t(0.001))();
+	test = farad_t(kilofarad_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<farad_t>(megafarad_t(0.000001))();
+	test = farad_t(megafarad_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<farad_t>(gigafarad_t(0.000000001))();
+	test = farad_t(gigafarad_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
@@ -2337,21 +2337,21 @@ TEST_F(UnitConversion, impedance)
 {
 	double test;
 
-	test = convert<milliohm_t>(ohm_t(10.0))();
+	test = milliohm_t(ohm_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<ohm_t>(picoohm_t(1000000000000.0))();
+	test = ohm_t(picoohm_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<ohm_t>(nanoohm_t(1000000000.0))();
+	test = ohm_t(nanoohm_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<ohm_t>(microohm_t(1000000.0))();
+	test = ohm_t(microohm_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<ohm_t>(milliohm_t(1000.0))();
+	test = ohm_t(milliohm_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<ohm_t>(kiloohm_t(0.001))();
+	test = ohm_t(kiloohm_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<ohm_t>(megaohm_t(0.000001))();
+	test = ohm_t(megaohm_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<ohm_t>(gigaohm_t(0.000000001))();
+	test = ohm_t(gigaohm_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
@@ -2359,21 +2359,21 @@ TEST_F(UnitConversion, conductance)
 {
 	double test;
 
-	test = convert<millisiemens_t>(siemens_t(10.0))();
+	test = millisiemens_t(siemens_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<siemens_t>(picosiemens_t(1000000000000.0))();
+	test = siemens_t(picosiemens_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<siemens_t>(nanosiemens_t(1000000000.0))();
+	test = siemens_t(nanosiemens_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<siemens_t>(microsiemens_t(1000000.0))();
+	test = siemens_t(microsiemens_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<siemens_t>(millisiemens_t(1000.0))();
+	test = siemens_t(millisiemens_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<siemens_t>(kilosiemens_t(0.001))();
+	test = siemens_t(kilosiemens_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<siemens_t>(megasiemens_t(0.000001))();
+	test = siemens_t(megasiemens_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<siemens_t>(gigasiemens_t(0.000000001))();
+	test = siemens_t(gigasiemens_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
@@ -2381,25 +2381,25 @@ TEST_F(UnitConversion, magnetic_flux)
 {
 	double test;
 
-	test = convert<milliweber_t>(weber_t(10.0))();
+	test = milliweber_t(weber_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<weber_t>(picoweber_t(1000000000000.0))();
+	test = weber_t(picoweber_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<weber_t>(nanoweber_t(1000000000.0))();
+	test = weber_t(nanoweber_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<weber_t>(microweber_t(1000000.0))();
+	test = weber_t(microweber_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<weber_t>(milliweber_t(1000.0))();
+	test = weber_t(milliweber_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<weber_t>(kiloweber_t(0.001))();
+	test = weber_t(kiloweber_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<weber_t>(megaweber_t(0.000001))();
+	test = weber_t(megaweber_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<weber_t>(gigaweber_t(0.000000001))();
+	test = weber_t(gigaweber_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<weber_t>(maxwell_t(100000000.0))();
+	test = weber_t(maxwell_t(100000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<maxwell_t>(nanoweber_t(10.0))();
+	test = maxwell_t(nanoweber_t(10.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
@@ -2407,25 +2407,25 @@ TEST_F(UnitConversion, magnetic_field_strength)
 {
 	double test;
 
-	test = convert<millitesla_t>(tesla_t(10.0))();
+	test = millitesla_t(tesla_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<tesla_t>(picotesla_t(1000000000000.0))();
+	test = tesla_t(picotesla_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<tesla_t>(nanotesla_t(1000000000.0))();
+	test = tesla_t(nanotesla_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<tesla_t>(microtesla_t(1000000.0))();
+	test = tesla_t(microtesla_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<tesla_t>(millitesla_t(1000.0))();
+	test = tesla_t(millitesla_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<tesla_t>(kilotesla_t(0.001))();
+	test = tesla_t(kilotesla_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<tesla_t>(megatesla_t(0.000001))();
+	test = tesla_t(megatesla_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<tesla_t>(gigatesla_t(0.000000001))();
+	test = tesla_t(gigatesla_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<tesla_t>(gauss_t(10000.0))();
+	test = tesla_t(gauss_t(10000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gauss_t>(nanotesla_t(100000.0))();
+	test = gauss_t(nanotesla_t(100000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
@@ -2433,21 +2433,21 @@ TEST_F(UnitConversion, inductance)
 {
 	double test;
 
-	test = convert<millihenry_t>(henry_t(10.0))();
+	test = millihenry_t(henry_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<henry_t>(picohenry_t(1000000000000.0))();
+	test = henry_t(picohenry_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<henry_t>(nanohenry_t(1000000000.0))();
+	test = henry_t(nanohenry_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<henry_t>(microhenry_t(1000000.0))();
+	test = henry_t(microhenry_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<henry_t>(millihenry_t(1000.0))();
+	test = henry_t(millihenry_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<henry_t>(kilohenry_t(0.001))();
+	test = henry_t(kilohenry_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<henry_t>(megahenry_t(0.000001))();
+	test = henry_t(megahenry_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<henry_t>(gigahenry_t(0.000000001))();
+	test = henry_t(gigahenry_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
@@ -2455,21 +2455,21 @@ TEST_F(UnitConversion, luminous_flux)
 {
 	double test;
 
-	test = convert<millilumen_t>(lumen_t(10.0))();
+	test = millilumen_t(lumen_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<lumen_t>(picolumen_t(1000000000000.0))();
+	test = lumen_t(picolumen_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<lumen_t>(nanolumen_t(1000000000.0))();
+	test = lumen_t(nanolumen_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<lumen_t>(microlumen_t(1000000.0))();
+	test = lumen_t(microlumen_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<lumen_t>(millilumen_t(1000.0))();
+	test = lumen_t(millilumen_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<lumen_t>(kilolumen_t(0.001))();
+	test = lumen_t(kilolumen_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<lumen_t>(megalumen_t(0.000001))();
+	test = lumen_t(megalumen_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<lumen_t>(gigalumen_t(0.000000001))();
+	test = lumen_t(gigalumen_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
@@ -2477,28 +2477,28 @@ TEST_F(UnitConversion, illuminance)
 {
 	double test;
 
-	test = convert<millilux_t>(lux_t(10.0))();
+	test = millilux_t(lux_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<lux_t>(picolux_t(1000000000000.0))();
+	test = lux_t(picolux_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<lux_t>(nanolux_t(1000000000.0))();
+	test = lux_t(nanolux_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<lux_t>(microlux_t(1000000.0))();
+	test = lux_t(microlux_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<lux_t>(millilux_t(1000.0))();
+	test = lux_t(millilux_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<lux_t>(kilolux_t(0.001))();
+	test = lux_t(kilolux_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<lux_t>(megalux_t(0.000001))();
+	test = lux_t(megalux_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<lux_t>(gigalux_t(0.000000001))();
+	test = lux_t(gigalux_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 
-// 	test = convert<lux_t>(footcandle_t(0.092903))();
+// 	test = lux_t(footcandle_t(0.092903))();
 // 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<lumens_per_square_inch_t>(lux_t(1550.0031000062))();
+	test = lumens_per_square_inch_t(lux_t(1550.0031000062))();
 	EXPECT_NEAR(1.0, test, 5.0e-13);
-	test = convert<lux_t>(phot_t(0.0001))();
+	test = lux_t(phot_t(0.0001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
@@ -2506,62 +2506,62 @@ TEST_F(UnitConversion, radiation)
 {
 	double test;
 
-	test = convert<millibecquerel_t>(becquerel_t(10.0))();
+	test = millibecquerel_t(becquerel_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<becquerel_t>(picobecquerel_t(1000000000000.0))();
+	test = becquerel_t(picobecquerel_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<becquerel_t>(nanobecquerel_t(1000000000.0))();
+	test = becquerel_t(nanobecquerel_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<becquerel_t>(microbecquerel_t(1000000.0))();
+	test = becquerel_t(microbecquerel_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<becquerel_t>(millibecquerel_t(1000.0))();
+	test = becquerel_t(millibecquerel_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<becquerel_t>(kilobecquerel_t(0.001))();
+	test = becquerel_t(kilobecquerel_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<becquerel_t>(megabecquerel_t(0.000001))();
+	test = becquerel_t(megabecquerel_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<becquerel_t>(gigabecquerel_t(0.000000001))();
+	test = becquerel_t(gigabecquerel_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 
-	test = convert<milligray_t>(gray_t(10.0))();
+	test = milligray_t(gray_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<gray_t>(picogray_t(1000000000000.0))();
+	test = gray_t(picogray_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gray_t>(nanogray_t(1000000000.0))();
+	test = gray_t(nanogray_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gray_t>(microgray_t(1000000.0))();
+	test = gray_t(microgray_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gray_t>(milligray_t(1000.0))();
+	test = gray_t(milligray_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gray_t>(kilogray_t(0.001))();
+	test = gray_t(kilogray_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gray_t>(megagray_t(0.000001))();
+	test = gray_t(megagray_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gray_t>(gigagray_t(0.000000001))();
+	test = gray_t(gigagray_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 
-	test = convert<millisievert_t>(sievert_t(10.0))();
+	test = millisievert_t(sievert_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<sievert_t>(picosievert_t(1000000000000.0))();
+	test = sievert_t(picosievert_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<sievert_t>(nanosievert_t(1000000000.0))();
+	test = sievert_t(nanosievert_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<sievert_t>(microsievert_t(1000000.0))();
+	test = sievert_t(microsievert_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<sievert_t>(millisievert_t(1000.0))();
+	test = sievert_t(millisievert_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<sievert_t>(kilosievert_t(0.001))();
+	test = sievert_t(kilosievert_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<sievert_t>(megasievert_t(0.000001))();
+	test = sievert_t(megasievert_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<sievert_t>(gigasievert_t(0.000000001))();
+	test = sievert_t(gigasievert_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 
-	test = convert<curie_t>(becquerel_t(37.0e9))();
+	test = curie_t(becquerel_t(37.0e9))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<rutherford_t>(becquerel_t(1000000.0))();
+	test = rutherford_t(becquerel_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gray_t>(rad_t(100.0))();
+	test = gray_t(rad_t(100.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
@@ -2569,17 +2569,17 @@ TEST_F(UnitConversion, torque)
 {
 	double test;
 
-	test = convert<newton_meter_t>(torque::foot_pound_t(1.0))();
+	test = newton_meter_t(torque::foot_pound_t(1.0))();
 	EXPECT_NEAR(1.355817948, test, 5.0e-5);
-	test = convert<newton_meter_t>(inch_pound_t(1.0))();
+	test = newton_meter_t(inch_pound_t(1.0))();
 	EXPECT_NEAR(0.112984829, test, 5.0e-5);
-	test = convert<newton_meter_t>(foot_poundal_t(1.0))();
+	test = newton_meter_t(foot_poundal_t(1.0))();
 	EXPECT_NEAR(4.214011009e-2, test, 5.0e-5);
-	test = convert<newton_meter_t>(meter_kilogram_t(1.0))();
+	test = newton_meter_t(meter_kilogram_t(1.0))();
 	EXPECT_NEAR(9.80665, test, 5.0e-5);
-	test = convert<meter_kilogram_t>(inch_pound_t(86.79616930855788))();
+	test = meter_kilogram_t(inch_pound_t(86.79616930855788))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<inch_pound_t>(foot_poundal_t(2.681170713))();
+	test = inch_pound_t(foot_poundal_t(2.681170713))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 
 }
@@ -2588,67 +2588,67 @@ TEST_F(UnitConversion, volume)
 {
 	double test;
 
-	test = convert<cubic_meter_t>(cubic_meter_t(1.0))();
+	test = cubic_meter_t(cubic_meter_t(1.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<cubic_meter_t>(cubic_millimeter_t(1.0))();
+	test = cubic_meter_t(cubic_millimeter_t(1.0))();
 	EXPECT_NEAR(1.0e-9, test, 5.0e-5);
-	test = convert<cubic_meter_t>(cubic_kilometer_t(1.0))();
+	test = cubic_meter_t(cubic_kilometer_t(1.0))();
 	EXPECT_NEAR(1.0e9, test, 5.0e-5);
-	test = convert<cubic_meter_t>(liter_t(1.0))();
+	test = cubic_meter_t(liter_t(1.0))();
 	EXPECT_NEAR(0.001, test, 5.0e-5);
-	test = convert<cubic_meter_t>(milliliter_t(1.0))();
+	test = cubic_meter_t(milliliter_t(1.0))();
 	EXPECT_NEAR(1.0e-6, test, 5.0e-5);
-	test = convert<cubic_meter_t>(cubic_inch_t(1.0))();
+	test = cubic_meter_t(cubic_inch_t(1.0))();
 	EXPECT_NEAR(1.6387e-5, test, 5.0e-10);
-	test = convert<cubic_meter_t>(cubic_foot_t(1.0))();
+	test = cubic_meter_t(cubic_foot_t(1.0))();
 	EXPECT_NEAR(0.0283168, test, 5.0e-8);
-	test = convert<cubic_meter_t>(cubic_yard_t(1.0))();
+	test = cubic_meter_t(cubic_yard_t(1.0))();
 	EXPECT_NEAR(0.764555, test, 5.0e-7);
-	test = convert<cubic_meter_t>(cubic_mile_t(1.0))();
+	test = cubic_meter_t(cubic_mile_t(1.0))();
 	EXPECT_NEAR(4.168e+9, test, 5.0e5);
-	test = convert<cubic_meter_t>(gallon_t(1.0))();
+	test = cubic_meter_t(gallon_t(1.0))();
 	EXPECT_NEAR(0.00378541, test, 5.0e-8);
-	test = convert<cubic_meter_t>(quart_t(1.0))();
+	test = cubic_meter_t(quart_t(1.0))();
 	EXPECT_NEAR(0.000946353, test, 5.0e-10);
-	test = convert<cubic_meter_t>(pint_t(1.0))();
+	test = cubic_meter_t(pint_t(1.0))();
 	EXPECT_NEAR(0.000473176, test, 5.0e-10);
-	test = convert<cubic_meter_t>(cup_t(1.0))();
+	test = cubic_meter_t(cup_t(1.0))();
 	EXPECT_NEAR(0.00024, test, 5.0e-6);
-	test = convert<cubic_meter_t>(volume::fluid_ounce_t(1.0))();
+	test = cubic_meter_t(volume::fluid_ounce_t(1.0))();
 	EXPECT_NEAR(2.9574e-5, test, 5.0e-5);
-	test = convert<cubic_meter_t>(barrel_t(1.0))();
+	test = cubic_meter_t(barrel_t(1.0))();
 	EXPECT_NEAR(0.158987294928, test, 5.0e-13);
-	test = convert<cubic_meter_t>(bushel_t(1.0))();
+	test = cubic_meter_t(bushel_t(1.0))();
 	EXPECT_NEAR(0.0352391, test, 5.0e-8);
-	test = convert<cubic_meter_t>(cord_t(1.0))();
+	test = cubic_meter_t(cord_t(1.0))();
 	EXPECT_NEAR(3.62456, test, 5.0e-6);
-	test = convert<cubic_meter_t>(cubic_fathom_t(1.0))();
+	test = cubic_meter_t(cubic_fathom_t(1.0))();
 	EXPECT_NEAR(6.11644, test, 5.0e-6);
-	test = convert<cubic_meter_t>(tablespoon_t(1.0))();
+	test = cubic_meter_t(tablespoon_t(1.0))();
 	EXPECT_NEAR(1.4787e-5, test, 5.0e-10);
-	test = convert<cubic_meter_t>(teaspoon_t(1.0))();
+	test = cubic_meter_t(teaspoon_t(1.0))();
 	EXPECT_NEAR(4.9289e-6, test, 5.0e-11);
-	test = convert<cubic_meter_t>(pinch_t(1.0))();
+	test = cubic_meter_t(pinch_t(1.0))();
 	EXPECT_NEAR(616.11519921875e-9, test, 5.0e-20);
-	test = convert<cubic_meter_t>(dash_t(1.0))();
+	test = cubic_meter_t(dash_t(1.0))();
 	EXPECT_NEAR(308.057599609375e-9, test, 5.0e-20);
-	test = convert<cubic_meter_t>(drop_t(1.0))();
+	test = cubic_meter_t(drop_t(1.0))();
 	EXPECT_NEAR(82.14869322916e-9, test, 5.0e-9);
-	test = convert<cubic_meter_t>(fifth_t(1.0))();
+	test = cubic_meter_t(fifth_t(1.0))();
 	EXPECT_NEAR(0.00075708236, test, 5.0e-12);
-	test = convert<cubic_meter_t>(dram_t(1.0))();
+	test = cubic_meter_t(dram_t(1.0))();
 	EXPECT_NEAR(3.69669e-6, test, 5.0e-12);
-	test = convert<cubic_meter_t>(gill_t(1.0))();
+	test = cubic_meter_t(gill_t(1.0))();
 	EXPECT_NEAR(0.000118294, test, 5.0e-10);
-	test = convert<cubic_meter_t>(peck_t(1.0))();
+	test = cubic_meter_t(peck_t(1.0))();
 	EXPECT_NEAR(0.00880977, test, 5.0e-9);
-	test = convert<cubic_meter_t>(sack_t(9.4591978))();
+	test = cubic_meter_t(sack_t(9.4591978))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<cubic_meter_t>(shot_t(1.0))();
+	test = cubic_meter_t(shot_t(1.0))();
 	EXPECT_NEAR(4.43603e-5, test, 5.0e-11);
-	test = convert<cubic_meter_t>(strike_t(1.0))();
+	test = cubic_meter_t(strike_t(1.0))();
 	EXPECT_NEAR(0.07047814033376, test, 5.0e-5);
-	test = convert<milliliter_t>(volume::fluid_ounce_t(1.0))();
+	test = milliliter_t(volume::fluid_ounce_t(1.0))();
 	EXPECT_NEAR(29.5735, test, 5.0e-5);
 }
 
@@ -2656,25 +2656,25 @@ TEST_F(UnitConversion, density)
 {
 	double test;
 
-	test = convert<kilograms_per_cubic_meter_t>(kilograms_per_cubic_meter_t(1.0))();
+	test = kilograms_per_cubic_meter_t(kilograms_per_cubic_meter_t(1.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<kilograms_per_cubic_meter_t>(grams_per_milliliter_t(1.0))();
+	test = kilograms_per_cubic_meter_t(grams_per_milliliter_t(1.0))();
 	EXPECT_NEAR(1000.0, test, 5.0e-5);
-	test = convert<kilograms_per_cubic_meter_t>(kilograms_per_liter_t(1.0))();
+	test = kilograms_per_cubic_meter_t(kilograms_per_liter_t(1.0))();
 	EXPECT_NEAR(1000.0, test, 5.0e-5);
-	test = convert<kilograms_per_cubic_meter_t>(ounces_per_cubic_foot_t(1.0))();
+	test = kilograms_per_cubic_meter_t(ounces_per_cubic_foot_t(1.0))();
 	EXPECT_NEAR(1.001153961, test, 5.0e-10);
-	test = convert<kilograms_per_cubic_meter_t>(ounces_per_cubic_inch_t(1.0))();
+	test = kilograms_per_cubic_meter_t(ounces_per_cubic_inch_t(1.0))();
 	EXPECT_NEAR(1.729994044e3, test, 5.0e-7);
-	test = convert<kilograms_per_cubic_meter_t>(ounces_per_gallon_t(1.0))();
+	test = kilograms_per_cubic_meter_t(ounces_per_gallon_t(1.0))();
 	EXPECT_NEAR(7.489151707, test, 5.0e-10);
-	test = convert<kilograms_per_cubic_meter_t>(pounds_per_cubic_foot_t(1.0))();
+	test = kilograms_per_cubic_meter_t(pounds_per_cubic_foot_t(1.0))();
 	EXPECT_NEAR(16.01846337, test, 5.0e-9);
-	test = convert<kilograms_per_cubic_meter_t>(pounds_per_cubic_inch_t(1.0))();
+	test = kilograms_per_cubic_meter_t(pounds_per_cubic_inch_t(1.0))();
 	EXPECT_NEAR(2.767990471e4, test, 5.0e-6);
-	test = convert<kilograms_per_cubic_meter_t>(pounds_per_gallon_t(1.0))();
+	test = kilograms_per_cubic_meter_t(pounds_per_gallon_t(1.0))();
 	EXPECT_NEAR(119.8264273, test, 5.0e-8);
-	test = convert<kilograms_per_cubic_meter_t>(slugs_per_cubic_foot_t(1.0))();
+	test = kilograms_per_cubic_meter_t(slugs_per_cubic_foot_t(1.0))();
 	EXPECT_NEAR(515.3788184, test, 5.0e-6);
 }
 
@@ -2694,37 +2694,37 @@ TEST_F(UnitConversion, concentration)
 
 TEST_F(UnitConversion, data)
 {
-	EXPECT_EQ(8, (convert<bit_t>(byte_t(1))()));
+	EXPECT_EQ(8, (bit_t(byte_t(1))()));
 
-	EXPECT_EQ(1000, (convert<byte_t>(kilobyte_t(1))()));
-	EXPECT_EQ(1000, (convert<kilobyte_t>(megabyte_t(1))()));
-	EXPECT_EQ(1000, (convert<megabyte_t>(gigabyte_t(1))()));
-	EXPECT_EQ(1000, (convert<gigabyte_t>(terabyte_t(1))()));
-	EXPECT_EQ(1000, (convert<terabyte_t>(petabyte_t(1))()));
-	EXPECT_EQ(1000, (convert<petabyte_t>(exabyte_t(1))()));
+	EXPECT_EQ(1000, (byte_t(kilobyte_t(1))()));
+	EXPECT_EQ(1000, (kilobyte_t(megabyte_t(1))()));
+	EXPECT_EQ(1000, (megabyte_t(gigabyte_t(1))()));
+	EXPECT_EQ(1000, (gigabyte_t(terabyte_t(1))()));
+	EXPECT_EQ(1000, (terabyte_t(petabyte_t(1))()));
+	EXPECT_EQ(1000, (petabyte_t(exabyte_t(1))()));
 
-	EXPECT_EQ(1024, (convert<byte_t>(kibibyte_t(1))()));
-	EXPECT_EQ(1024, (convert<kibibyte_t>(mebibyte_t(1))()));
-	EXPECT_EQ(1024, (convert<mebibyte_t>(gibibyte_t(1))()));
-	EXPECT_EQ(1024, (convert<gibibyte_t>(tebibyte_t(1))()));
-	EXPECT_EQ(1024, (convert<tebibyte_t>(pebibyte_t(1))()));
-	EXPECT_EQ(1024, (convert<pebibyte_t>(exbibyte_t(1))()));
+	EXPECT_EQ(1024, (byte_t(kibibyte_t(1))()));
+	EXPECT_EQ(1024, (kibibyte_t(mebibyte_t(1))()));
+	EXPECT_EQ(1024, (mebibyte_t(gibibyte_t(1))()));
+	EXPECT_EQ(1024, (gibibyte_t(tebibyte_t(1))()));
+	EXPECT_EQ(1024, (tebibyte_t(pebibyte_t(1))()));
+	EXPECT_EQ(1024, (pebibyte_t(exbibyte_t(1))()));
 
-	EXPECT_EQ(93750000, (convert<kibibit_t>(gigabyte_t(12))()));
+	EXPECT_EQ(93750000, (kibibit_t(gigabyte_t(12))()));
 
-	EXPECT_EQ(1000, (convert<bit_t>(kilobit_t(1))()));
-	EXPECT_EQ(1000, (convert<kilobit_t>(megabit_t(1))()));
-	EXPECT_EQ(1000, (convert<megabit_t>(gigabit_t(1))()));
-	EXPECT_EQ(1000, (convert<gigabit_t>(terabit_t(1))()));
-	EXPECT_EQ(1000, (convert<terabit_t>(petabit_t(1))()));
-	EXPECT_EQ(1000, (convert<petabit_t>(exabit_t(1))()));
+	EXPECT_EQ(1000, (bit_t(kilobit_t(1))()));
+	EXPECT_EQ(1000, (kilobit_t(megabit_t(1))()));
+	EXPECT_EQ(1000, (megabit_t(gigabit_t(1))()));
+	EXPECT_EQ(1000, (gigabit_t(terabit_t(1))()));
+	EXPECT_EQ(1000, (terabit_t(petabit_t(1))()));
+	EXPECT_EQ(1000, (petabit_t(exabit_t(1))()));
 
-	EXPECT_EQ(1024, (convert<bit_t>(kibibit_t(1))()));
-	EXPECT_EQ(1024, (convert<kibibit_t>(mebibit_t(1))()));
-	EXPECT_EQ(1024, (convert<mebibit_t>(gibibit_t(1))()));
-	EXPECT_EQ(1024, (convert<gibibit_t>(tebibit_t(1))()));
-	EXPECT_EQ(1024, (convert<tebibit_t>(pebibit_t(1))()));
-	EXPECT_EQ(1024, (convert<pebibit_t>(exbibit_t(1))()));
+	EXPECT_EQ(1024, (bit_t(kibibit_t(1))()));
+	EXPECT_EQ(1024, (kibibit_t(mebibit_t(1))()));
+	EXPECT_EQ(1024, (mebibit_t(gibibit_t(1))()));
+	EXPECT_EQ(1024, (gibibit_t(tebibit_t(1))()));
+	EXPECT_EQ(1024, (tebibit_t(pebibit_t(1))()));
+	EXPECT_EQ(1024, (pebibit_t(exbibit_t(1))()));
 
 	// Source: https://en.wikipedia.org/wiki/Binary_prefix
 	EXPECT_NEAR(percent_t(2.4), kibibyte_t(1) / kilobyte_t(1) - 1, 0.005);
@@ -2737,37 +2737,37 @@ TEST_F(UnitConversion, data)
 
 TEST_F(UnitConversion, data_transfer_rate)
 {
-	EXPECT_EQ(8, (convert<bits_per_second_t>(bytes_per_second_t(1))()));
+	EXPECT_EQ(8, (bits_per_second_t(bytes_per_second_t(1))()));
 
-	EXPECT_EQ(1000, (convert<bytes_per_second_t>(kilobytes_per_second_t(1))()));
-	EXPECT_EQ(1000, (convert<kilobytes_per_second_t>(megabytes_per_second_t(1))()));
-	EXPECT_EQ(1000, (convert<megabytes_per_second_t>(gigabytes_per_second_t(1))()));
-	EXPECT_EQ(1000, (convert<gigabytes_per_second_t>(terabytes_per_second_t(1))()));
-	EXPECT_EQ(1000, (convert<terabytes_per_second_t>(petabytes_per_second_t(1))()));
-	EXPECT_EQ(1000, (convert<petabytes_per_second_t>(exabytes_per_second_t(1))()));
+	EXPECT_EQ(1000, (bytes_per_second_t(kilobytes_per_second_t(1))()));
+	EXPECT_EQ(1000, (kilobytes_per_second_t(megabytes_per_second_t(1))()));
+	EXPECT_EQ(1000, (megabytes_per_second_t(gigabytes_per_second_t(1))()));
+	EXPECT_EQ(1000, (gigabytes_per_second_t(terabytes_per_second_t(1))()));
+	EXPECT_EQ(1000, (terabytes_per_second_t(petabytes_per_second_t(1))()));
+	EXPECT_EQ(1000, (petabytes_per_second_t(exabytes_per_second_t(1))()));
 
-	EXPECT_EQ(1024, (convert<bytes_per_second_t>(kibibytes_per_second_t(1))()));
-	EXPECT_EQ(1024, (convert<kibibytes_per_second_t>(mebibytes_per_second_t(1))()));
-	EXPECT_EQ(1024, (convert<mebibytes_per_second_t>(gibibytes_per_second_t(1))()));
-	EXPECT_EQ(1024, (convert<gibibytes_per_second_t>(tebibytes_per_second_t(1))()));
-	EXPECT_EQ(1024, (convert<tebibytes_per_second_t>(pebibytes_per_second_t(1))()));
-	EXPECT_EQ(1024, (convert<pebibytes_per_second_t>(exbibytes_per_second_t(1))()));
+	EXPECT_EQ(1024, (bytes_per_second_t(kibibytes_per_second_t(1))()));
+	EXPECT_EQ(1024, (kibibytes_per_second_t(mebibytes_per_second_t(1))()));
+	EXPECT_EQ(1024, (mebibytes_per_second_t(gibibytes_per_second_t(1))()));
+	EXPECT_EQ(1024, (gibibytes_per_second_t(tebibytes_per_second_t(1))()));
+	EXPECT_EQ(1024, (tebibytes_per_second_t(pebibytes_per_second_t(1))()));
+	EXPECT_EQ(1024, (pebibytes_per_second_t(exbibytes_per_second_t(1))()));
 
-	EXPECT_EQ(93750000, (convert<kibibits_per_second_t>(gigabytes_per_second_t(12))()));
+	EXPECT_EQ(93750000, (kibibits_per_second_t(gigabytes_per_second_t(12))()));
 
-	EXPECT_EQ(1000, (convert<bits_per_second_t>(kilobits_per_second_t(1))()));
-	EXPECT_EQ(1000, (convert<kilobits_per_second_t>(megabits_per_second_t(1))()));
-	EXPECT_EQ(1000, (convert<megabits_per_second_t>(gigabits_per_second_t(1))()));
-	EXPECT_EQ(1000, (convert<gigabits_per_second_t>(terabits_per_second_t(1))()));
-	EXPECT_EQ(1000, (convert<terabits_per_second_t>(petabits_per_second_t(1))()));
-	EXPECT_EQ(1000, (convert<petabits_per_second_t>(exabits_per_second_t(1))()));
+	EXPECT_EQ(1000, (bits_per_second_t(kilobits_per_second_t(1))()));
+	EXPECT_EQ(1000, (kilobits_per_second_t(megabits_per_second_t(1))()));
+	EXPECT_EQ(1000, (megabits_per_second_t(gigabits_per_second_t(1))()));
+	EXPECT_EQ(1000, (gigabits_per_second_t(terabits_per_second_t(1))()));
+	EXPECT_EQ(1000, (terabits_per_second_t(petabits_per_second_t(1))()));
+	EXPECT_EQ(1000, (petabits_per_second_t(exabits_per_second_t(1))()));
 
-	EXPECT_EQ(1024, (convert<bits_per_second_t>(kibibits_per_second_t(1))()));
-	EXPECT_EQ(1024, (convert<kibibits_per_second_t>(mebibits_per_second_t(1))()));
-	EXPECT_EQ(1024, (convert<mebibits_per_second_t>(gibibits_per_second_t(1))()));
-	EXPECT_EQ(1024, (convert<gibibits_per_second_t>(tebibits_per_second_t(1))()));
-	EXPECT_EQ(1024, (convert<tebibits_per_second_t>(pebibits_per_second_t(1))()));
-	EXPECT_EQ(1024, (convert<pebibits_per_second_t>(exbibits_per_second_t(1))()));
+	EXPECT_EQ(1024, (bits_per_second_t(kibibits_per_second_t(1))()));
+	EXPECT_EQ(1024, (kibibits_per_second_t(mebibits_per_second_t(1))()));
+	EXPECT_EQ(1024, (mebibits_per_second_t(gibibits_per_second_t(1))()));
+	EXPECT_EQ(1024, (gibibits_per_second_t(tebibits_per_second_t(1))()));
+	EXPECT_EQ(1024, (tebibits_per_second_t(pebibits_per_second_t(1))()));
+	EXPECT_EQ(1024, (pebibits_per_second_t(exbibits_per_second_t(1))()));
 
 	// Source: https://en.wikipedia.org/wiki/Binary_prefix
 	EXPECT_NEAR(percent_t(2.4), kibibytes_per_second_t(1) / kilobytes_per_second_t(1) - 1, 0.005);

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -1145,6 +1145,106 @@ TEST_F(UnitContainer, unitTypeMixedEquality)
 	EXPECT_FALSE(b_m != a_f);
 }
 
+TEST_F(UnitContainer, unitTypeRelational)
+{
+	const meter_t a_m(0);
+	const meter_t b_m(1);
+
+	EXPECT_FALSE(a_m < a_m);
+	EXPECT_FALSE(b_m < a_m);
+	EXPECT_TRUE(a_m < b_m);
+	EXPECT_TRUE(a_m <= a_m);
+	EXPECT_FALSE(b_m <= a_m);
+	EXPECT_TRUE(a_m <= b_m);
+	EXPECT_FALSE(a_m > a_m);
+	EXPECT_TRUE(b_m > a_m);
+	EXPECT_FALSE(a_m > b_m);
+	EXPECT_TRUE(a_m >= a_m);
+	EXPECT_TRUE(b_m >= a_m);
+	EXPECT_FALSE(a_m >= b_m);
+
+	const unit<meters, int> c_m(0);
+	const unit<meters, int> d_m(1);
+
+	EXPECT_FALSE(c_m < c_m);
+	EXPECT_FALSE(d_m < c_m);
+	EXPECT_TRUE(c_m < d_m);
+	EXPECT_TRUE(c_m <= c_m);
+	EXPECT_FALSE(d_m <= c_m);
+	EXPECT_TRUE(c_m <= d_m);
+	EXPECT_FALSE(c_m > c_m);
+	EXPECT_TRUE(d_m > c_m);
+	EXPECT_FALSE(c_m > d_m);
+	EXPECT_TRUE(c_m >= c_m);
+	EXPECT_TRUE(d_m >= c_m);
+	EXPECT_FALSE(c_m >= d_m);
+
+	EXPECT_FALSE(a_m < c_m);
+	EXPECT_FALSE(d_m < a_m);
+	EXPECT_TRUE(a_m < d_m);
+	EXPECT_TRUE(c_m <= a_m);
+	EXPECT_FALSE(d_m <= a_m);
+	EXPECT_TRUE(a_m <= d_m);
+	EXPECT_FALSE(a_m > c_m);
+	EXPECT_TRUE(d_m > a_m);
+	EXPECT_FALSE(a_m > d_m);
+	EXPECT_TRUE(c_m >= a_m);
+	EXPECT_TRUE(d_m >= a_m);
+	EXPECT_FALSE(a_m >= d_m);
+
+	const dimensionless a_s(0);
+	const unit<dimensionless_unit, int> b_s(1);
+
+	EXPECT_FALSE(a_s < a_s);
+	EXPECT_FALSE(b_s < a_s);
+	EXPECT_TRUE(a_s < b_s);
+	EXPECT_TRUE(a_s <= a_s);
+	EXPECT_FALSE(b_s <= a_s);
+	EXPECT_TRUE(a_s <= b_s);
+	EXPECT_FALSE(a_s > a_s);
+	EXPECT_TRUE(b_s > a_s);
+	EXPECT_FALSE(a_s > b_s);
+	EXPECT_TRUE(a_s >= a_s);
+	EXPECT_TRUE(b_s >= a_s);
+	EXPECT_FALSE(a_s >= b_s);
+}
+
+TEST_F(UnitContainer, unitTypeMixedRelational)
+{
+	const meter_t a_m(0);
+	const foot_t a_f(meter_t(1));
+
+	EXPECT_FALSE(a_f < a_m);
+	EXPECT_TRUE(a_m < a_f);
+	EXPECT_FALSE(a_f <= a_m);
+	EXPECT_TRUE(a_m <= a_f);
+	EXPECT_TRUE(a_f > a_m);
+	EXPECT_FALSE(a_m > a_f);
+	EXPECT_TRUE(a_f >= a_m);
+	EXPECT_FALSE(a_m >= a_f);
+
+	const unit<feet, int> b_f(0);
+	const unit<meters, int> b_m(1);
+
+	EXPECT_FALSE(b_m < b_f);
+	EXPECT_TRUE(b_f < b_m);
+	EXPECT_FALSE(b_m <= b_f);
+	EXPECT_TRUE(b_f <= b_m);
+	EXPECT_TRUE(b_m > b_f);
+	EXPECT_FALSE(b_f > b_m);
+	EXPECT_TRUE(b_m >= b_f);
+	EXPECT_FALSE(b_f >= b_m);
+
+	EXPECT_FALSE(a_m < b_f);
+	EXPECT_FALSE(a_f < b_m);
+	EXPECT_TRUE(b_f <= a_m);
+	EXPECT_TRUE(b_m <= a_f);
+	EXPECT_FALSE(a_m > b_f);
+	EXPECT_FALSE(a_f > b_m);
+	EXPECT_TRUE(b_f >= a_m);
+	EXPECT_TRUE(b_m >= a_f);
+}
+
 TEST_F(UnitContainer, unitTypeAddition)
 {
 	// units

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -2390,16 +2390,24 @@ TEST_F(UnitContainer, dBAddition)
 
 	auto result_dbw = dBW_t(10.0) + dB_t(30.0);
 	EXPECT_NEAR(40.0, result_dbw(), 5.0e-5);
+	result_dbw = unit<watt, int, decibel_scale>(10) + unit<dimensionless_unit, int, decibel_scale>(30);
+	EXPECT_NEAR(40.0, result_dbw(), 5.0e-5);
 	result_dbw = dB_t(12.0) + dBW_t(30.0);
 	EXPECT_NEAR(42.0, result_dbw(), 5.0e-5);
+	result_dbw = unit<dimensionless_unit, int, decibel_scale>(12) + unit<watt, int, decibel_scale>(30);
+	EXPECT_NEAR(42.0, result_dbw(), 2);
 	isSame = std::is_same_v<decltype(result_dbw), dBW_t>;
 	EXPECT_TRUE(isSame);
 
 	auto result_dbm = dB_t(30.0) + dBm_t(20.0);
 	EXPECT_NEAR(50.0, result_dbm(), 5.0e-5);
+	result_dbm = unit<dimensionless_unit, int, decibel_scale>(30) + unit<milliwatt, int, decibel_scale>(20);
+	EXPECT_NEAR(50.0, result_dbm(), 5.0e-5);
 
 	// adding dBW to dBW is something you probably shouldn't do, but let's see if it works...
 	auto result_dBW2 = dBW_t(10.0) + dBm_t(40.0);
+	EXPECT_NEAR(80.0, result_dBW2(), 5.0e-5);
+	result_dBW2 = unit<watt, int, decibel_scale>(10) + unit<milliwatt, int, decibel_scale>(40);
 	EXPECT_NEAR(80.0, result_dBW2(), 5.0e-5);
 	isSame = std::is_same_v<decltype(result_dBW2), unit<squared<milliwatts>, double, decibel_scale>>;
 	EXPECT_TRUE(isSame);
@@ -2411,21 +2419,29 @@ TEST_F(UnitContainer, dBSubtraction)
 
 	auto result_dbw = dBW_t(10.0) - dB_t(30.0);
 	EXPECT_NEAR(-20.0, result_dbw(), 5.0e-5);
+	result_dbw = unit<watt, int, decibel_scale>(10) - unit<dimensionless_unit, int, decibel_scale>(30);
+	EXPECT_EQ(-INFINITY, result_dbw());
 	isSame = std::is_same_v<decltype(result_dbw), dBW_t>;
 	EXPECT_TRUE(isSame);
 
 	auto result_dbm = dBm_t(100.0) - dB_t(30.0);
 	EXPECT_NEAR(70.0, result_dbm(), 5.0e-5);
+	result_dbm = unit<milliwatt, int, decibel_scale>(100) - unit<dimensionless_unit, int, decibel_scale>(30); // NaN
+//	EXPECT_NEAR(70.0, result_dbm(), 5.0e-5);
 	isSame = std::is_same_v<decltype(result_dbm), dBm_t>;
 	EXPECT_TRUE(isSame);
 
 	auto result_db = dBW_t(100.0) - dBW_t(80.0);
 	EXPECT_NEAR(20.0, result_db(), 5.0e-5);
+	result_db = unit<watt, int, decibel_scale>(100) - unit<watt, int, decibel_scale>(80); // NaN
+//	EXPECT_NEAR(20.0, result_db(), 5.0e-5);
 	isSame = std::is_same_v<decltype(result_db), dB_t>;
 	EXPECT_TRUE(isSame);
 
 	result_db = dB_t(100.0) - dB_t(80.0);
 	EXPECT_NEAR(20.0, result_db(), 5.0e-5);
+	result_db = unit<dimensionless_unit, int, decibel_scale>(100) - unit<dimensionless_unit, int, decibel_scale>(80); // NaN
+//	EXPECT_NEAR(20.0, result_db(), 5.0e-5);
 	isSame = std::is_same_v<decltype(result_db), dB_t>;
 	EXPECT_TRUE(isSame);
 }

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -3028,8 +3028,8 @@ TEST_F(UnitMath, hypot)
 	EXPECT_TRUE((std::is_same_v<typename std::decay<meter_t>::type, typename std::decay<decltype(hypot(meter_t(3.0), meter_t(4.0)))>::type>));
 	EXPECT_NEAR(meter_t(5.0).to<double>(), (hypot(meter_t(3.0), meter_t(4.0))).to<double>(), 5.0e-9);
 
-	EXPECT_TRUE((std::is_same_v<typename std::decay<foot_t>::type, typename std::decay<decltype(hypot(foot_t(3.0), meter_t(1.2192)))>::type>));
-	EXPECT_NEAR(foot_t(5.0).to<double>(), (hypot(foot_t(3.0), meter_t(1.2192))).to<double>(), 5.0e-9);
+	static_assert(traits::is_convertible_unit_v<foot_t, decltype(hypot(foot_t(3.0), meter_t(1.2192)))>);
+	EXPECT_NEAR(foot_t(5.0).to<double>(), foot_t(hypot(foot_t(3.0), meter_t(1.2192))).to<double>(), 5.0e-9);
 }
 
 TEST_F(UnitMath, ceil)
@@ -3074,7 +3074,7 @@ TEST_F(UnitMath, fdim)
 {
 	EXPECT_EQ(meter_t(0.0), fdim(meter_t(8.0), meter_t(10.0)));
 	EXPECT_EQ(meter_t(2.0), fdim(meter_t(10.0), meter_t(8.0)));
-	EXPECT_NEAR(meter_t(9.3904).to<double>(), fdim(meter_t(10.0), foot_t(2.0)).to<double>(), 5.0e-320);	// not sure why they aren't comparing exactly equal, but clearly they are.
+	EXPECT_NEAR(meter_t(9.3904).to<double>(), meter_t(fdim(meter_t(10.0), foot_t(2.0))).to<double>(), 5.0e-320);	// not sure why they aren't comparing exactly equal, but clearly they are.
 }
 
 TEST_F(UnitMath, fmin)

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -1700,8 +1700,8 @@ TEST_F(UnitContainer, dBAddition)
 
 	// adding dBW to dBW is something you probably shouldn't do, but let's see if it works...
 	auto result_dBW2 = dBW_t(10.0) + dBm_t(40.0);
-	EXPECT_NEAR(20.0, result_dBW2(), 5.0e-5);
-	isSame = std::is_same_v<decltype(result_dBW2), unit<squared<watts>, double, decibel_scale>>;
+	EXPECT_NEAR(80.0, result_dBW2(), 5.0e-5);
+	isSame = std::is_same_v<decltype(result_dBW2), unit<squared<milliwatts>, double, decibel_scale>>;
 	EXPECT_TRUE(isSame);
 }
 

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -217,10 +217,10 @@ TEST_F(TypeTraits, inverse)
 	bool shouldBeTrue = std::is_same_v<htz, hertz>;
 	EXPECT_TRUE(shouldBeTrue);
 
-	test = convert<inverse<celsius>, inverse<fahrenheit>>(1.0);
+	test = convert<unit<inverse<fahrenheit>>>(unit<inverse<celsius>>(1.0))();
 	EXPECT_NEAR(5.0 / 9.0, test, 5.0e-5);
 
-	test = convert<inverse<kelvin>, inverse<fahrenheit>>(6.0);
+	test = convert<unit<inverse<fahrenheit>>>(unit<inverse<kelvin>>(6.0))();
 	EXPECT_NEAR(10.0 / 3.0, test, 5.0e-5);
 }
 
@@ -822,7 +822,7 @@ TEST_F(UnitManipulators, squared)
 {
 	double test;
 
-	test = convert<squared<meters>, square_feet>(0.092903);
+	test = convert<unit<square_feet>>(unit<squared<meters>>(0.092903))();
 	EXPECT_NEAR(0.99999956944, test, 5.0e-12);
 
 	using dimensionless_2 = squared<units::dimensionless_unit>;	// this is actually nonsensical, and should also result in a dimensionless.
@@ -834,7 +834,7 @@ TEST_F(UnitManipulators, cubed)
 {
 	double test;
 
-	test = convert<cubed<meters>, cubic_feet>(0.0283168);
+	test = convert<unit<cubic_feet>>(unit<cubed<meters>>(0.0283168))();
 	EXPECT_NEAR(0.999998354619, test, 5.0e-13);
 }
 
@@ -842,7 +842,7 @@ TEST_F(UnitManipulators, square_root)
 {
 	double test;
 
-	test = convert<square_root<square_kilometer>, meter>(1.0);
+	test = convert<meter_t>(unit<square_root<square_kilometer>>(1.0))();
 	EXPECT_TRUE((traits::is_convertible_unit_v<typename std::decay<square_root<square_kilometer>>::type, kilometer>));
 	EXPECT_NEAR(1000.0, test, 5.0e-13);
 }
@@ -974,7 +974,7 @@ TEST_F(UnitContainer, unitTypeAddition)
 	meter_t a_m(1.0), c_m;
 	foot_t b_ft(3.28084);
 
-	double d = convert<feet, meters>(b_ft());
+	double d = convert<meter_t>(b_ft)();
 	EXPECT_NEAR(1.0, d, 5.0e-5);
 
 	c_m = a_m + b_ft;
@@ -1651,46 +1651,46 @@ TEST_F(UnitContainer, literals)
 TEST_F(UnitConversion, length)
 {
 	double test;
-	test = convert<meters, nanometers>(0.000000001);
+	test = convert<nanometer_t>(0.000000001_m)();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<meters, micrometers>(0.000001);
+	test = convert<micrometer_t>(meter_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<meters, millimeters>(0.001);
+	test = convert<millimeter_t>(meter_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<meters, centimeters>(0.01);
+	test = convert<centimeter_t>(meter_t(0.01))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<meters, kilometers>(1000.0);
+	test = convert<kilometer_t>(meter_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<meters, meters>(1.0);
+	test = convert<meter_t>(meter_t(1.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<meters, feet>(0.3048);
+	test = convert<foot_t>(meter_t(0.3048))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<meters, miles>(1609.344);
+	test = convert<mile_t>(meter_t(1609.344))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<meters, inches>(0.0254);
+	test = convert<inch_t>(meter_t(0.0254))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<meters, nauticalMiles>(1852.0);
+	test = convert<nauticalMile_t>(meter_t(1852.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<meters, astronicalUnits>(149597870700.0);
+	test = convert<astronicalUnit_t>(meter_t(149597870700.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<meters, lightyears>(9460730472580800.0);
+	test = convert<lightyear_t>(meter_t(9460730472580800.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<meters, parsec>(3.08567758e16);
+	test = convert<parsec_t>(meter_t(3.08567758e16))();
 	EXPECT_NEAR(1.0, test, 5.0e7);
 
-	test = convert<feet, feet>(6.3);
+	test = convert<foot_t>(foot_t(6.3))();
 	EXPECT_NEAR(6.3, test, 5.0e-5);
-	test = convert<feet, inches>(6.0);
+	test = convert<inch_t>(foot_t(6.0))();
 	EXPECT_NEAR(72.0, test, 5.0e-5);
-	test = convert<inches, feet>(6.0);
+	test = convert<foot_t>(inch_t(6.0))();
 	EXPECT_NEAR(0.5, test, 5.0e-5);
-	test = convert<meter, feet>(1.0);
+	test = convert<foot_t>(meter_t(1.0))();
 	EXPECT_NEAR(3.28084, test, 5.0e-5);
-	test = convert<miles, nauticalMiles>(6.3);
+	test = convert<nauticalMile_t>(mile_t(6.3))();
 	EXPECT_NEAR(5.47455, test, 5.0e-6);
-	test = convert<miles, meters>(11.0);
+	test = convert<meter_t>(mile_t(11.0))();
 	EXPECT_NEAR(17702.8, test, 5.0e-2);
-	test = convert<meters, chains>(1.0);
+	test = convert<chain_t>(meter_t(1.0))();
 	EXPECT_NEAR(0.0497097, test, 5.0e-7);
 
 //	dimensionless b = 5_rad;
@@ -1700,30 +1700,30 @@ TEST_F(UnitConversion, mass)
 {
 	double test;
 
-	test = convert<kilograms, grams>(1.0e-3);
+	test = convert<gram_t>(kilogram_t(1.0e-3))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<kilograms, micrograms>(1.0e-9);
+	test = convert<microgram_t>(kilogram_t(1.0e-9))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<kilograms, milligrams>(1.0e-6);
+	test = convert<milligram_t>(kilogram_t(1.0e-6))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<kilograms, kilograms>(1.0);
+	test = convert<kilogram_t>(kilogram_t(1.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<kilograms, metric_tons>(1000.0);
+	test = convert<metric_ton_t>(kilogram_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<kilograms, pounds>(0.453592);
+	test = convert<pound_t>(kilogram_t(0.453592))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<kilograms, long_tons>(1016.05);
+	test = convert<long_ton_t>(kilogram_t(1016.05))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<kilograms, short_tons>(907.185);
+	test = convert<short_ton_t>(kilogram_t(907.185))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<kilograms, mass::ounces>(0.0283495);
+	test = convert<mass::ounce_t>(kilogram_t(0.0283495))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<kilograms, carats>(0.0002);
+	test = convert<carat_t>(kilogram_t(0.0002))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<slugs, kilograms>(1.0);
+	test = convert<kilogram_t>(slug_t(1.0))();
 	EXPECT_NEAR(14.593903, test, 5.0e-7);
 
-	test = convert<pounds, carats>(6.3);
+	test = convert<carat_t>(pound_t(6.3))();
 	EXPECT_NEAR(14288.2, test, 5.0e-2);
 }
 
@@ -1748,32 +1748,32 @@ TEST_F(UnitConversion, time)
 
 
 
-	test = convert<seconds, seconds>(1.0);
+	test = convert<second_t>(second_t(1.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<seconds, nanoseconds>(1.0e-9);
+	test = convert<nanosecond_t>(second_t(1.0e-9))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<seconds, microseconds>(1.0e-6);
+	test = convert<microsecond_t>(second_t(1.0e-6))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<seconds, milliseconds>(1.0e-3);
+	test = convert<millisecond_t>(second_t(1.0e-3))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<seconds, minutes>(60.0);
+	test = convert<minute_t>(second_t(60.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<seconds, hours>(3600.0);
+	test = convert<hour_t>(second_t(3600.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<seconds, days>(86400.0);
+	test = convert<day_t>(second_t(86400.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<seconds, weeks>(604800.0);
+	test = convert<week_t>(second_t(604800.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<seconds, years>(3.154e7);
+	test = convert<year_t>(second_t(3.154e7))();
 	EXPECT_NEAR(1.0, test, 5.0e3);
 
-	test = convert<years, weeks>(2.0);
+	test = convert<week_t>(year_t(2.0))();
 	EXPECT_NEAR(104.2857142857143, test, 5.0e-14);
-	test = convert<hours, minutes>(4.0);
+	test = convert<minute_t>(hour_t(4.0))();
 	EXPECT_NEAR(240.0, test, 5.0e-14);
-	test = convert<julian_years, days>(1.0);
+	test = convert<day_t>(julian_year_t(1.0))();
 	EXPECT_NEAR(365.25, test, 5.0e-14);
-	test = convert<gregorian_years, days>(1.0);
+	test = convert<day_t>(gregorian_year_t(1.0))();
 	EXPECT_NEAR(365.2425, test, 5.0e-14);
 
 }
@@ -1786,28 +1786,28 @@ TEST_F(UnitConversion, angle)
 
 	double test;
 
-	test = convert<angle::radians, angle::radians>(1.0);
+	test = convert<angle::radian_t>(angle::radian_t(1.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-20);
-	test = convert<angle::radians, angle::milliradians>(0.001);
+	test = convert<angle::milliradian_t>(angle::radian_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-4);
-	test = convert<angle::radians, angle::degrees>(0.0174533);
+	test = convert<angle::degree_t>(angle::radian_t(0.0174533))();
 	EXPECT_NEAR(1.0, test, 5.0e-7);
-	test = convert<angle::radians, angle::arcminutes>(0.000290888);
+	test = convert<angle::arcminute_t>(angle::radian_t(0.000290888))();
 	EXPECT_NEAR(0.99999928265913, test, 5.0e-8);
-	test = convert<angle::radians, angle::arcseconds>(4.8481e-6);
+	test = convert<angle::arcsecond_t>(angle::radian_t(4.8481e-6))();
 	EXPECT_NEAR(0.999992407, test, 5.0e-10);
-	test = convert<angle::radians, angle::turns>(6.28319);
+	test = convert<angle::turn_t>(angle::radian_t(6.28319))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
-	test = convert<angle::radians, angle::gradians>(0.015708);
+	test = convert<angle::gradian_t>(angle::radian_t(0.015708))();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
 
-	test = convert<angle::radians, angle::radians>(2.1);
+	test = convert<angle::radian_t>(angle::radian_t(2.1))();
 	EXPECT_NEAR(2.1, test, 5.0e-6);
-	test = convert<angle::arcseconds, angle::gradians>(2.1);
+	test = convert<angle::gradian_t>(angle::arcsecond_t(2.1))();
 	EXPECT_NEAR(0.000648148, test, 5.0e-6);
-	test = convert<angle::radians, angle::degrees>(constants::detail::PI_VAL);
+	test = convert<angle::degree_t>(angle::radian_t(constants::detail::PI_VAL))();
 	EXPECT_NEAR(180.0, test, 5.0e-6);
-	test = convert<angle::degrees, angle::radians>(90.0);
+	test = convert<angle::radian_t>(angle::degree_t(90.0))();
 	EXPECT_NEAR(constants::detail::PI_VAL / 2, test, 5.0e-6);
 }
 
@@ -1815,7 +1815,7 @@ TEST_F(UnitConversion, current)
 {
 	double test;
 
-	test = convert<current::A, current::mA>(2.1);
+	test = convert<current::milliampere_t>(current::ampere_t(2.1))();
 	EXPECT_NEAR(2100.0, test, 5.0e-6);
 }
 
@@ -1824,43 +1824,43 @@ TEST_F(UnitConversion, temperature)
 	// temp conversion are weird/hard since they involve translations AND scaling.
 	double test;
 
-	test = convert<kelvin, kelvin>(72.0);
+	test = convert<kelvin_t>(kelvin_t(72.0))();
 	EXPECT_NEAR(72.0, test, 5.0e-5);
-	test = convert<fahrenheit, fahrenheit>(72.0);
+	test = convert<fahrenheit_t>(fahrenheit_t(72.0))();
 	EXPECT_NEAR(72.0, test, 5.0e-5);
-	test = convert<kelvin, fahrenheit>(300.0);
+	test = convert<fahrenheit_t>(kelvin_t(300.0))();
 	EXPECT_NEAR(80.33, test, 5.0e-5);
-	test = convert<fahrenheit, kelvin>(451.0);
+	test = convert<kelvin_t>(fahrenheit_t(451.0))();
 	EXPECT_NEAR(505.928, test, 5.0e-4);
-	test = convert<kelvin, celsius>(300.0);
+	test = convert<celsius_t>(kelvin_t(300.0))();
 	EXPECT_NEAR(26.85, test, 5.0e-3);
-	test = convert<celsius, kelvin>(451.0);
+	test = convert<kelvin_t>(celsius_t(451.0))();
 	EXPECT_NEAR(724.15, test, 5.0e-3);
-	test = convert<fahrenheit, celsius>(72.0);
+	test = convert<celsius_t>(fahrenheit_t(72.0))();
 	EXPECT_NEAR(22.2222, test, 5.0e-5);
-	test = convert<celsius, fahrenheit>(100.0);
+	test = convert<fahrenheit_t>(celsius_t(100.0))();
 	EXPECT_NEAR(212.0, test, 5.0e-5);
-	test = convert<fahrenheit, celsius>(32.0);
+	test = convert<celsius_t>(fahrenheit_t(32.0))();
 	EXPECT_NEAR(0.0, test, 5.0e-5);
-	test = convert<celsius, fahrenheit>(0.0);
+	test = convert<fahrenheit_t>(celsius_t(0.0))();
 	EXPECT_NEAR(32.0, test, 5.0e-5);
-	test = convert<rankine, kelvin>(100.0);
+	test = convert<kelvin_t>(rankine_t(100.0))();
 	EXPECT_NEAR(55.5556, test, 5.0e-5);
-	test = convert<kelvin, rankine>(100.0);
+	test = convert<rankine_t>(kelvin_t(100.0))();
 	EXPECT_NEAR(180.0, test, 5.0e-5);
-	test = convert<fahrenheit, rankine>(100.0);
+	test = convert<rankine_t>(fahrenheit_t(100.0))();
 	EXPECT_NEAR(559.67, test, 5.0e-5);
-	test = convert<rankine, fahrenheit>(72.0);
+	test = convert<fahrenheit_t>(rankine_t(72.0))();
 	EXPECT_NEAR(-387.67, test, 5.0e-5);
-	test = convert<reaumur, kelvin>(100.0);
+	test = convert<kelvin_t>(reaumur_t(100.0))();
 	EXPECT_NEAR(398.0, test, 5.0e-1);
-	test = convert<reaumur, celsius>(80.0);
+	test = convert<celsius_t>(reaumur_t(80.0))();
 	EXPECT_NEAR(100.0, test, 5.0e-5);
-	test = convert<celsius, reaumur>(212.0);
+	test = convert<reaumur_t>(celsius_t(212.0))();
 	EXPECT_NEAR(169.6, test, 5.0e-2);
-	test = convert<reaumur, fahrenheit>(80.0);
+	test = convert<fahrenheit_t>(reaumur_t(80.0))();
 	EXPECT_NEAR(212.0, test, 5.0e-5);
-	test = convert<fahrenheit, reaumur>(37.0);
+	test = convert<reaumur_t>(fahrenheit_t(37.0))();
 	EXPECT_NEAR(2.222, test, 5.0e-3);
 }
 
@@ -1868,9 +1868,9 @@ TEST_F(UnitConversion, luminous_intensity)
 {
 	double test;
 
-	test = convert<candela, millicandela>(72.0);
+	test = convert<millicandela_t>(candela_t(72.0))();
 	EXPECT_NEAR(72000.0, test, 5.0e-5);
-	test = convert<millicandela, candela>(376.0);
+	test = convert<candela_t>(millicandela_t(376.0))();
 	EXPECT_NEAR(0.376, test, 5.0e-5);
 }
 
@@ -1882,23 +1882,23 @@ TEST_F(UnitConversion, solid_angle)
 	same = std::is_same_v<traits::dimension_of_t<steradians>, traits::dimension_of_t<degrees_squared>>;
 	EXPECT_TRUE(same);
 
-	test = convert<steradians, steradians>(72.0);
+	test = convert<steradian_t>(steradian_t(72.0))();
 	EXPECT_NEAR(72.0, test, 5.0e-5);
-	test = convert<steradians, degrees_squared>(1.0);
+	test = convert<degree_squared_t>(steradian_t(1.0))();
 	EXPECT_NEAR(3282.8, test, 5.0e-2);
-	test = convert<steradians, spats>(8.0);
+	test = convert<spat_t>(steradian_t(8.0))();
 	EXPECT_NEAR(0.636619772367582, test, 5.0e-14);
-	test = convert<degrees_squared, steradians>(3282.8);
+	test = convert<steradian_t>(degree_squared_t(3282.8))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<degrees_squared, degrees_squared>(72.0);
+	test = convert<degree_squared_t>(degree_squared_t(72.0))();
 	EXPECT_NEAR(72.0, test, 5.0e-5);
-	test = convert<degrees_squared, spats>(3282.8);
+	test = convert<spat_t>(degree_squared_t(3282.8))();
 	EXPECT_NEAR(1.0 / (4 * constants::detail::PI_VAL), test, 5.0e-5);
-	test = convert<spats, steradians>(1.0 / (4 * constants::detail::PI_VAL));
+	test = convert<steradian_t>(spat_t(1.0 / (4 * constants::detail::PI_VAL)))();
 	EXPECT_NEAR(1.0, test, 5.0e-14);
-	test = convert<spats, degrees_squared>(1.0 / (4 * constants::detail::PI_VAL));
+	test = convert<degree_squared_t>(spat_t(1.0 / (4 * constants::detail::PI_VAL)))();
 	EXPECT_NEAR(3282.8, test, 5.0e-2);
-	test = convert<spats, spats>(72.0);
+	test = convert<spat_t>(spat_t(72.0))();
 	EXPECT_NEAR(72.0, test, 5.0e-5);
 }
 
@@ -1906,13 +1906,13 @@ TEST_F(UnitConversion, frequency)
 {
 	double test;
 
-	test = convert<hertz, kilohertz>(63000.0);
+	test = convert<kilohertz_t>(hertz_t(63000.0))();
 	EXPECT_NEAR(63.0, test, 5.0e-5);
-	test = convert<hertz, hertz>(6.3);
+	test = convert<hertz_t>(hertz_t(6.3))();
 	EXPECT_NEAR(6.3, test, 5.0e-5);
-	test = convert<kilohertz, hertz>(5.0);
+	test = convert<hertz_t>(kilohertz_t(5.0))();
 	EXPECT_NEAR(5000.0, test, 5.0e-5);
-	test = convert<megahertz, hertz>(1.0);
+	test = convert<hertz_t>(megahertz_t(1.0))();
 	EXPECT_NEAR(1.0e6, test, 5.0e-5);
 }
 
@@ -1926,15 +1926,15 @@ TEST_F(UnitConversion, velocity)
 	same = traits::is_convertible_unit_v<miles_per_hour, meters_per_second>;
 	EXPECT_TRUE(same);
 
-	test = convert<meters_per_second, miles_per_hour>(1250.0);
+	test = convert<miles_per_hour_t>(meters_per_second_t(1250.0))();
 	EXPECT_NEAR(2796.17, test, 5.0e-3);
-	test = convert<feet_per_second, kilometers_per_hour>(2796.17);
+	test = convert<kilometers_per_hour_t>(feet_per_second_t(2796.17))();
 	EXPECT_NEAR(3068.181418, test, 5.0e-7);
-	test = convert<knots, miles_per_hour>(600.0);
+	test = convert<miles_per_hour_t>(knot_t(600.0))();
 	EXPECT_NEAR(690.468, test, 5.0e-4);
-	test = convert<miles_per_hour, feet_per_second>(120.0);
+	test = convert<feet_per_second_t>(miles_per_hour_t(120.0))();
 	EXPECT_NEAR(176.0, test, 5.0e-5);
-	test = convert<feet_per_second, meters_per_second>(10.0);
+	test = convert<meters_per_second_t>(feet_per_second_t(10.0))();
 	EXPECT_NEAR(3.048, test, 5.0e-5);
 }
 
@@ -1948,13 +1948,13 @@ TEST_F(UnitConversion, angular_velocity)
 	same = traits::is_convertible_unit_v<rpm, radians_per_second>;
 	EXPECT_TRUE(same);
 
-	test = convert<radians_per_second, milliarcseconds_per_year>(1.0);
+	test = convert<milliarcseconds_per_year_t>(radians_per_second_t(1.0))();
 	EXPECT_NEAR(6.504e15, test, 1.0e12);
-	test = convert<degrees_per_second, radians_per_second>(1.0);
+	test = convert<radians_per_second_t>(degrees_per_second_t(1.0))();
 	EXPECT_NEAR(0.0174533, test, 5.0e-8);
-	test = convert<rpm, radians_per_second>(1.0);
+	test = convert<radians_per_second_t>(revolutions_per_minute_t(1.0))();
 	EXPECT_NEAR(0.10471975512, test, 5.0e-13);
-	test = convert<milliarcseconds_per_year, radians_per_second>(1.0);
+	test = convert<radians_per_second_t>(milliarcseconds_per_year_t(1.0))();
 	EXPECT_NEAR(1.537e-16, test, 5.0e-20);
 }
 
@@ -1962,24 +1962,25 @@ TEST_F(UnitConversion, acceleration)
 {
 	double test;
 
-	test = convert<standard_gravity, meters_per_second_squared>(1.0);
+	test = convert<meters_per_second_squared_t>(standard_gravity_t(1.0))();
 	EXPECT_NEAR(9.80665, test, 5.0e-10);
 }
+
 TEST_F(UnitConversion, force)
 {
 	double test;
 
-	test = convert<units::force::newton, units::force::newton>(1.0);
+	test = convert<units::force::newton_t>(units::force::newton_t(1.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<units::force::newton, units::force::pounds>(6.3);
+	test = convert<units::force::pound_t>(units::force::newton_t(6.3))();
 	EXPECT_NEAR(1.4163, test, 5.0e-5);
-	test = convert<units::force::newton, units::force::dynes>(5.0);
+	test = convert<units::force::dyne_t>(units::force::newton_t(5.0))();
 	EXPECT_NEAR(500000.0, test, 5.0e-5);
-	test = convert<units::force::newtons, units::force::poundals>(2.1);
+	test = convert<units::force::poundal_t>(units::force::newton_t(2.1))();
 	EXPECT_NEAR(15.1893, test, 5.0e-5);
-	test = convert<units::force::newtons, units::force::kiloponds>(173.0);
+	test = convert<units::force::kilopond_t>(units::force::newton_t(173.0))();
 	EXPECT_NEAR(17.6411, test, 5.0e-5);
-	test = convert<units::force::poundals, units::force::kiloponds>(21.879);
+	test = convert<units::force::kilopond_t>(units::force::poundal_t(21.879))();
 	EXPECT_NEAR(0.308451933, test, 5.0e-10);
 }
 
@@ -1987,15 +1988,15 @@ TEST_F(UnitConversion, area)
 {
 	double test;
 
-	test = convert<hectares, acres>(6.3);
+	test = convert<acre_t>(hectare_t(6.3))();
 	EXPECT_NEAR(15.5676, test, 5.0e-5);
-	test = convert<square_miles, square_kilometers>(10.0);
+	test = convert<square_kilometer_t>(square_mile_t(10.0))();
 	EXPECT_NEAR(25.8999, test, 5.0e-5);
-	test = convert<square_inch, square_meter>(4.0);
+	test = convert<square_meter_t>(square_inch_t(4.0))();
 	EXPECT_NEAR(0.00258064, test, 5.0e-9);
-	test = convert<acre, square_foot>(5.0);
+	test = convert<square_foot_t>(acre_t(5.0))();
 	EXPECT_NEAR(217800.0, test, 5.0e-5);
-	test = convert<square_meter, square_foot>(1.0);
+	test = convert<square_foot_t>(square_meter_t(1.0))();
 	EXPECT_NEAR(10.7639, test, 5.0e-5);
 }
 
@@ -2003,25 +2004,25 @@ TEST_F(UnitConversion, pressure)
 {
 	double test;
 
-	test = convert<pascals, torr>(1.0);
+	test = convert<torr_t>(pascal_t(1.0))();
 	EXPECT_NEAR(0.00750062, test, 5.0e-5);
-	test = convert<bar, psi>(2.2);
+	test = convert<pounds_per_square_inch_t>(bar_t(2.2))();
 	EXPECT_NEAR(31.9083, test, 5.0e-5);
-	test = convert<atmospheres, bar>(4.0);
+	test = convert<bar_t>(atmosphere_t(4.0))();
 	EXPECT_NEAR(4.053, test, 5.0e-5);
-	test = convert<torr, pascals>(800.0);
+	test = convert<pascal_t>(torr_t(800.0))();
 	EXPECT_NEAR(106657.89474, test, 5.0e-5);
-	test = convert<psi, atmospheres>(38.0);
+	test = convert<atmosphere_t>(pounds_per_square_inch_t(38.0))();
 	EXPECT_NEAR(2.58575, test, 5.0e-5);
-	test = convert<psi, pascals>(1.0);
+	test = convert<pascal_t>(pounds_per_square_inch_t(1.0))();
 	EXPECT_NEAR(6894.76, test, 5.0e-3);
-	test = convert<pascals, bar>(0.25);
+	test = convert<bar_t>(pascal_t(0.25))();
 	EXPECT_NEAR(2.5e-6, test, 5.0e-5);
-	test = convert<torr, atmospheres>(9.0);
+	test = convert<atmosphere_t>(torr_t(9.0))();
 	EXPECT_NEAR(0.0118421, test, 5.0e-8);
-	test = convert<bar, torr>(12.0);
+	test = convert<torr_t>(bar_t(12.0))();
 	EXPECT_NEAR(9000.74, test, 5.0e-3);
-	test = convert<atmospheres, psi>(1.0);
+	test = convert<pounds_per_square_inch_t>(atmosphere_t(1.0))();
 	EXPECT_NEAR(14.6959, test, 5.0e-5);
 }
 
@@ -2029,9 +2030,9 @@ TEST_F(UnitConversion, charge)
 {
 	double test;
 
-	test = convert<coulombs, ampere_hours>(4.0);
+	test = convert<ampere_hour_t>(coulomb_t(4.0))();
 	EXPECT_NEAR(0.00111111, test, 5.0e-9);
-	test = convert<ampere_hours, coulombs>(1.0);
+	test = convert<coulomb_t>(ampere_hour_t(1.0))();
 	EXPECT_NEAR(3600.0, test, 5.0e-6);
 }
 
@@ -2039,31 +2040,31 @@ TEST_F(UnitConversion, energy)
 {
 	double test;
 
-	test = convert<joules, calories>(8000.000464);
+	test = convert<calorie_t>(joule_t(8000.000464))();
 	EXPECT_NEAR(1912.046, test, 5.0e-4);
-	test = convert<therms, joules>(12.0);
+	test = convert<joule_t>(therm_t(12.0))();
 	EXPECT_NEAR(1.266e+9, test, 5.0e5);
-	test = convert<megajoules, watt_hours>(100.0);
+	test = convert<watt_hour_t>(megajoule_t(100.0))();
 	EXPECT_NEAR(27777.778, test, 5.0e-4);
-	test = convert<kilocalories, megajoules>(56.0);
+	test = convert<megajoule_t>(kilocalorie_t(56.0))();
 	EXPECT_NEAR(0.234304, test, 5.0e-7);
-	test = convert<kilojoules, therms>(56.0);
+	test = convert<therm_t>(kilojoule_t(56.0))();
 	EXPECT_NEAR(0.000530904, test, 5.0e-5);
-	test = convert<british_thermal_units, kilojoules>(18.56399995447);
+	test = convert<kilojoule_t>(british_thermal_unit_t(18.56399995447))();
 	EXPECT_NEAR(19.5860568, test, 5.0e-5);
-	test = convert<calories, energy::foot_pounds>(18.56399995447);
+	test = convert<energy::foot_pound_t>(calorie_t(18.56399995447))();
 	EXPECT_NEAR(57.28776190423856, test, 5.0e-5);
-	test = convert<megajoules, calories>(1.0);
+	test = convert<calorie_t>(megajoule_t(1.0))();
 	EXPECT_NEAR(239006.0, test, 5.0e-1);
-	test = convert<kilocalories, kilowatt_hours>(2.0);
+	test = convert<kilowatt_hour_t>(kilocalorie_t(2.0))();
 	EXPECT_NEAR(0.00232444, test, 5.0e-9);
-	test = convert<therms, kilocalories>(0.1);
+	test = convert<kilocalorie_t>(therm_t(0.1))();
 	EXPECT_NEAR(2521.04, test, 5.0e-3);
-	test = convert<watt_hours, megajoules>(67.0);
+	test = convert<megajoule_t>(watt_hour_t(67.0))();
 	EXPECT_NEAR(0.2412, test, 5.0e-5);
-	test = convert<british_thermal_units, watt_hours>(100.0);
+	test = convert<watt_hour_t>(british_thermal_unit_t(100.0))();
 	EXPECT_NEAR(29.3071, test, 5.0e-5);
-	test = convert<calories, BTU>(100.0);
+	test = convert<british_thermal_unit_t>(calorie_t(100.0))();
 	EXPECT_NEAR(0.396567, test, 5.0e-5);
 }
 
@@ -2071,19 +2072,19 @@ TEST_F(UnitConversion, power)
 {
 	double test;
 
-	test = convert<compound_unit_conversion<energy::foot_pounds, inverse<seconds>>, watts>(550.0);
+	test = convert<watt_t>(unit<compound_unit_conversion<energy::foot_pounds, inverse<seconds>>>(550.0))();
 	EXPECT_NEAR(745.7, test, 5.0e-2);
-	test = convert<watts, gigawatts>(1000000000.0);
+	test = convert<gigawatt_t>(watt_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-4);
-	test = convert<microwatts, watts>(200000.0);
+	test = convert<watt_t>(microwatt_t(200000.0))();
 	EXPECT_NEAR(0.2, test, 5.0e-4);
-	test = convert<horsepower, watts>(100.0);
+	test = convert<watt_t>(horsepower_t(100.0))();
 	EXPECT_NEAR(74570.0, test, 5.0e-1);
-	test = convert<horsepower, megawatts>(5.0);
+	test = convert<megawatt_t>(horsepower_t(5.0))();
 	EXPECT_NEAR(0.0037284994, test, 5.0e-7);
-	test = convert<kilowatts, horsepower>(232.0);
+	test = convert<horsepower_t>(kilowatt_t(232.0))();
 	EXPECT_NEAR(311.117, test, 5.0e-4);
-	test = convert<milliwatts, horsepower>(1001.0);
+	test = convert<horsepower_t>(milliwatt_t(1001.0))();
 	EXPECT_NEAR(0.001342363, test, 5.0e-9);
 }
 
@@ -2091,29 +2092,29 @@ TEST_F(UnitConversion, voltage)
 {
 	double test;
 
-	test = convert<volts, millivolts>(10.0);
+	test = convert<millivolt_t>(volt_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<picovolts, volts>(1000000000000.0);
+	test = convert<volt_t>(picovolt_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<nanovolts, volts>(1000000000.0);
+	test = convert<volt_t>(nanovolt_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<microvolts, volts>(1000000.0);
+	test = convert<volt_t>(microvolt_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<millivolts, volts>(1000.0);
+	test = convert<volt_t>(millivolt_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<kilovolts, volts>(0.001);
+	test = convert<volt_t>(kilovolt_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<megavolts, volts>(0.000001);
+	test = convert<volt_t>(megavolt_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gigavolts, volts>(0.000000001);
+	test = convert<volt_t>(gigavolt_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<statvolts, volts>(299.792458);
+	test = convert<volt_t>(statvolt_t(299.792458))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<millivolts, statvolts>(1000.0);
+	test = convert<statvolt_t>(millivolt_t(1000.0))();
 	EXPECT_NEAR(299.792458, test, 5.0e-5);
-	test = convert<abvolts, nanovolts>(0.1);
+	test = convert<nanovolt_t>(abvolt_t(0.1))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<microvolts, abvolts>(0.01);
+	test = convert<abvolt_t>(microvolt_t(0.01))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
@@ -2121,21 +2122,21 @@ TEST_F(UnitConversion, capacitance)
 {
 	double test;
 
-	test = convert<farads, millifarads>(10.0);
+	test = convert<millifarad_t>(farad_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<picofarads, farads>(1000000000000.0);
+	test = convert<farad_t>(picofarad_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<nanofarads, farads>(1000000000.0);
+	test = convert<farad_t>(nanofarad_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<microfarads, farads>(1000000.0);
+	test = convert<farad_t>(microfarad_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<millifarads, farads>(1000.0);
+	test = convert<farad_t>(millifarad_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<kilofarads, farads>(0.001);
+	test = convert<farad_t>(kilofarad_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<megafarads, farads>(0.000001);
+	test = convert<farad_t>(megafarad_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gigafarads, farads>(0.000000001);
+	test = convert<farad_t>(gigafarad_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
@@ -2143,21 +2144,21 @@ TEST_F(UnitConversion, impedance)
 {
 	double test;
 
-	test = convert<ohms, milliohms>(10.0);
+	test = convert<milliohm_t>(ohm_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<picoohms, ohms>(1000000000000.0);
+	test = convert<ohm_t>(picoohm_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<nanoohms, ohms>(1000000000.0);
+	test = convert<ohm_t>(nanoohm_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<microohms, ohms>(1000000.0);
+	test = convert<ohm_t>(microohm_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<milliohms, ohms>(1000.0);
+	test = convert<ohm_t>(milliohm_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<kiloohms, ohms>(0.001);
+	test = convert<ohm_t>(kiloohm_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<megaohms, ohms>(0.000001);
+	test = convert<ohm_t>(megaohm_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gigaohms, ohms>(0.000000001);
+	test = convert<ohm_t>(gigaohm_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
@@ -2165,21 +2166,21 @@ TEST_F(UnitConversion, conductance)
 {
 	double test;
 
-	test = convert<siemens, millisiemens>(10.0);
+	test = convert<millisiemens_t>(siemens_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<picosiemens, siemens>(1000000000000.0);
+	test = convert<siemens_t>(picosiemens_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<nanosiemens, siemens>(1000000000.0);
+	test = convert<siemens_t>(nanosiemens_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<microsiemens, siemens>(1000000.0);
+	test = convert<siemens_t>(microsiemens_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<millisiemens, siemens>(1000.0);
+	test = convert<siemens_t>(millisiemens_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<kilosiemens, siemens>(0.001);
+	test = convert<siemens_t>(kilosiemens_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<megasiemens, siemens>(0.000001);
+	test = convert<siemens_t>(megasiemens_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gigasiemens, siemens>(0.000000001);
+	test = convert<siemens_t>(gigasiemens_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
@@ -2187,25 +2188,25 @@ TEST_F(UnitConversion, magnetic_flux)
 {
 	double test;
 
-	test = convert<webers, milliwebers>(10.0);
+	test = convert<milliweber_t>(weber_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<picowebers, webers>(1000000000000.0);
+	test = convert<weber_t>(picoweber_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<nanowebers, webers>(1000000000.0);
+	test = convert<weber_t>(nanoweber_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<microwebers, webers>(1000000.0);
+	test = convert<weber_t>(microweber_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<milliwebers, webers>(1000.0);
+	test = convert<weber_t>(milliweber_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<kilowebers, webers>(0.001);
+	test = convert<weber_t>(kiloweber_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<megawebers, webers>(0.000001);
+	test = convert<weber_t>(megaweber_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gigawebers, webers>(0.000000001);
+	test = convert<weber_t>(gigaweber_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<maxwells, webers>(100000000.0);
+	test = convert<weber_t>(maxwell_t(100000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<nanowebers, maxwells>(10.0);
+	test = convert<maxwell_t>(nanoweber_t(10.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
@@ -2213,25 +2214,25 @@ TEST_F(UnitConversion, magnetic_field_strength)
 {
 	double test;
 
-	test = convert<teslas, milliteslas>(10.0);
+	test = convert<millitesla_t>(tesla_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<picoteslas, teslas>(1000000000000.0);
+	test = convert<tesla_t>(picotesla_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<nanoteslas, teslas>(1000000000.0);
+	test = convert<tesla_t>(nanotesla_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<microteslas, teslas>(1000000.0);
+	test = convert<tesla_t>(microtesla_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<milliteslas, teslas>(1000.0);
+	test = convert<tesla_t>(millitesla_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<kiloteslas, teslas>(0.001);
+	test = convert<tesla_t>(kilotesla_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<megateslas, teslas>(0.000001);
+	test = convert<tesla_t>(megatesla_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gigateslas, teslas>(0.000000001);
+	test = convert<tesla_t>(gigatesla_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gauss, teslas>(10000.0);
+	test = convert<tesla_t>(gauss_t(10000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<nanoteslas, gauss>(100000.0);
+	test = convert<gauss_t>(nanotesla_t(100000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
@@ -2239,21 +2240,21 @@ TEST_F(UnitConversion, inductance)
 {
 	double test;
 
-	test = convert<henries, millihenries>(10.0);
+	test = convert<millihenry_t>(henry_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<picohenries, henries>(1000000000000.0);
+	test = convert<henry_t>(picohenry_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<nanohenries, henries>(1000000000.0);
+	test = convert<henry_t>(nanohenry_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<microhenries, henries>(1000000.0);
+	test = convert<henry_t>(microhenry_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<millihenries, henries>(1000.0);
+	test = convert<henry_t>(millihenry_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<kilohenries, henries>(0.001);
+	test = convert<henry_t>(kilohenry_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<megahenries, henries>(0.000001);
+	test = convert<henry_t>(megahenry_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gigahenries, henries>(0.000000001);
+	test = convert<henry_t>(gigahenry_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
@@ -2261,21 +2262,21 @@ TEST_F(UnitConversion, luminous_flux)
 {
 	double test;
 
-	test = convert<lumens, millilumens>(10.0);
+	test = convert<millilumen_t>(lumen_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<picolumens, lumens>(1000000000000.0);
+	test = convert<lumen_t>(picolumen_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<nanolumens, lumens>(1000000000.0);
+	test = convert<lumen_t>(nanolumen_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<microlumens, lumens>(1000000.0);
+	test = convert<lumen_t>(microlumen_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<millilumens, lumens>(1000.0);
+	test = convert<lumen_t>(millilumen_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<kilolumens, lumens>(0.001);
+	test = convert<lumen_t>(kilolumen_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<megalumens, lumens>(0.000001);
+	test = convert<lumen_t>(megalumen_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gigalumens, lumens>(0.000000001);
+	test = convert<lumen_t>(gigalumen_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
@@ -2283,28 +2284,28 @@ TEST_F(UnitConversion, illuminance)
 {
 	double test;
 
-	test = convert<luxes, milliluxes>(10.0);
+	test = convert<millilux_t>(lux_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<picoluxes, luxes>(1000000000000.0);
+	test = convert<lux_t>(picolux_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<nanoluxes, luxes>(1000000000.0);
+	test = convert<lux_t>(nanolux_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<microluxes, luxes>(1000000.0);
+	test = convert<lux_t>(microlux_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<milliluxes, luxes>(1000.0);
+	test = convert<lux_t>(millilux_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<kiloluxes, luxes>(0.001);
+	test = convert<lux_t>(kilolux_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<megaluxes, luxes>(0.000001);
+	test = convert<lux_t>(megalux_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gigaluxes, luxes>(0.000000001);
+	test = convert<lux_t>(gigalux_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 
-// 	test = convert<footcandles, luxes>(0.092903);
+// 	test = convert<lux_t>(footcandle_t(0.092903))();
 // 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<lux, lumens_per_square_inch>(1550.0031000062);
+	test = convert<lumens_per_square_inch_t>(lux_t(1550.0031000062))();
 	EXPECT_NEAR(1.0, test, 5.0e-13);
-	test = convert<phots, luxes>(0.0001);
+	test = convert<lux_t>(phot_t(0.0001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
@@ -2312,62 +2313,62 @@ TEST_F(UnitConversion, radiation)
 {
 	double test;
 
-	test = convert<becquerels, millibecquerels>(10.0);
+	test = convert<millibecquerel_t>(becquerel_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<picobecquerels, becquerels>(1000000000000.0);
+	test = convert<becquerel_t>(picobecquerel_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<nanobecquerels, becquerels>(1000000000.0);
+	test = convert<becquerel_t>(nanobecquerel_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<microbecquerels, becquerels>(1000000.0);
+	test = convert<becquerel_t>(microbecquerel_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<millibecquerels, becquerels>(1000.0);
+	test = convert<becquerel_t>(millibecquerel_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<kilobecquerels, becquerels>(0.001);
+	test = convert<becquerel_t>(kilobecquerel_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<megabecquerels, becquerels>(0.000001);
+	test = convert<becquerel_t>(megabecquerel_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gigabecquerels, becquerels>(0.000000001);
+	test = convert<becquerel_t>(gigabecquerel_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 
-	test = convert<grays, milligrays>(10.0);
+	test = convert<milligray_t>(gray_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<picograys, grays>(1000000000000.0);
+	test = convert<gray_t>(picogray_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<nanograys, grays>(1000000000.0);
+	test = convert<gray_t>(nanogray_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<micrograys, grays>(1000000.0);
+	test = convert<gray_t>(microgray_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<milligrays, grays>(1000.0);
+	test = convert<gray_t>(milligray_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<kilograys, grays>(0.001);
+	test = convert<gray_t>(kilogray_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<megagrays, grays>(0.000001);
+	test = convert<gray_t>(megagray_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gigagrays, grays>(0.000000001);
+	test = convert<gray_t>(gigagray_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 
-	test = convert<sieverts, millisieverts>(10.0);
+	test = convert<millisievert_t>(sievert_t(10.0))();
 	EXPECT_NEAR(10000.0, test, 5.0e-5);
-	test = convert<picosieverts, sieverts>(1000000000000.0);
+	test = convert<sievert_t>(picosievert_t(1000000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<nanosieverts, sieverts>(1000000000.0);
+	test = convert<sievert_t>(nanosievert_t(1000000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<microsieverts, sieverts>(1000000.0);
+	test = convert<sievert_t>(microsievert_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<millisieverts, sieverts>(1000.0);
+	test = convert<sievert_t>(millisievert_t(1000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<kilosieverts, sieverts>(0.001);
+	test = convert<sievert_t>(kilosievert_t(0.001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<megasieverts, sieverts>(0.000001);
+	test = convert<sievert_t>(megasievert_t(0.000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<gigasieverts, sieverts>(0.000000001);
+	test = convert<sievert_t>(gigasievert_t(0.000000001))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 
-	test = convert<becquerels, curies>(37.0e9);
+	test = convert<curie_t>(becquerel_t(37.0e9))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<becquerels, rutherfords>(1000000.0);
+	test = convert<rutherford_t>(becquerel_t(1000000.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<rads, grays>(100.0);
+	test = convert<gray_t>(rad_t(100.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
@@ -2375,17 +2376,17 @@ TEST_F(UnitConversion, torque)
 {
 	double test;
 
-	test = convert<torque::foot_pounds, newton_meter>(1.0);
+	test = convert<newton_meter_t>(torque::foot_pound_t(1.0))();
 	EXPECT_NEAR(1.355817948, test, 5.0e-5);
-	test = convert<inch_pounds, newton_meter>(1.0);
+	test = convert<newton_meter_t>(inch_pound_t(1.0))();
 	EXPECT_NEAR(0.112984829, test, 5.0e-5);
-	test = convert<foot_poundals, newton_meter>(1.0);
+	test = convert<newton_meter_t>(foot_poundal_t(1.0))();
 	EXPECT_NEAR(4.214011009e-2, test, 5.0e-5);
-	test = convert<meter_kilograms, newton_meter>(1.0);
+	test = convert<newton_meter_t>(meter_kilogram_t(1.0))();
 	EXPECT_NEAR(9.80665, test, 5.0e-5);
-	test = convert<inch_pound, meter_kilogram>(86.79616930855788);
+	test = convert<meter_kilogram_t>(inch_pound_t(86.79616930855788))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<foot_poundals, inch_pound>(2.681170713);
+	test = convert<inch_pound_t>(foot_poundal_t(2.681170713))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 
 }
@@ -2394,67 +2395,67 @@ TEST_F(UnitConversion, volume)
 {
 	double test;
 
-	test = convert<cubic_meters, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(cubic_meter_t(1.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<cubic_millimeters, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(cubic_millimeter_t(1.0))();
 	EXPECT_NEAR(1.0e-9, test, 5.0e-5);
-	test = convert<cubic_kilometers, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(cubic_kilometer_t(1.0))();
 	EXPECT_NEAR(1.0e9, test, 5.0e-5);
-	test = convert<liters, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(liter_t(1.0))();
 	EXPECT_NEAR(0.001, test, 5.0e-5);
-	test = convert<milliliters, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(milliliter_t(1.0))();
 	EXPECT_NEAR(1.0e-6, test, 5.0e-5);
-	test = convert<cubic_inches, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(cubic_inch_t(1.0))();
 	EXPECT_NEAR(1.6387e-5, test, 5.0e-10);
-	test = convert<cubic_feet, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(cubic_foot_t(1.0))();
 	EXPECT_NEAR(0.0283168, test, 5.0e-8);
-	test = convert<cubic_yards, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(cubic_yard_t(1.0))();
 	EXPECT_NEAR(0.764555, test, 5.0e-7);
-	test = convert<cubic_miles, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(cubic_mile_t(1.0))();
 	EXPECT_NEAR(4.168e+9, test, 5.0e5);
-	test = convert<gallons, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(gallon_t(1.0))();
 	EXPECT_NEAR(0.00378541, test, 5.0e-8);
-	test = convert<quarts, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(quart_t(1.0))();
 	EXPECT_NEAR(0.000946353, test, 5.0e-10);
-	test = convert<pints, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(pint_t(1.0))();
 	EXPECT_NEAR(0.000473176, test, 5.0e-10);
-	test = convert<cups, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(cup_t(1.0))();
 	EXPECT_NEAR(0.00024, test, 5.0e-6);
-	test = convert<volume::fluid_ounces, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(volume::fluid_ounce_t(1.0))();
 	EXPECT_NEAR(2.9574e-5, test, 5.0e-5);
-	test = convert<barrels, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(barrel_t(1.0))();
 	EXPECT_NEAR(0.158987294928, test, 5.0e-13);
-	test = convert<bushels, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(bushel_t(1.0))();
 	EXPECT_NEAR(0.0352391, test, 5.0e-8);
-	test = convert<cords, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(cord_t(1.0))();
 	EXPECT_NEAR(3.62456, test, 5.0e-6);
-	test = convert<cubic_fathoms, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(cubic_fathom_t(1.0))();
 	EXPECT_NEAR(6.11644, test, 5.0e-6);
-	test = convert<tablespoons, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(tablespoon_t(1.0))();
 	EXPECT_NEAR(1.4787e-5, test, 5.0e-10);
-	test = convert<teaspoons, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(teaspoon_t(1.0))();
 	EXPECT_NEAR(4.9289e-6, test, 5.0e-11);
-	test = convert<pinches, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(pinch_t(1.0))();
 	EXPECT_NEAR(616.11519921875e-9, test, 5.0e-20);
-	test = convert<dashes, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(dash_t(1.0))();
 	EXPECT_NEAR(308.057599609375e-9, test, 5.0e-20);
-	test = convert<drops, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(drop_t(1.0))();
 	EXPECT_NEAR(82.14869322916e-9, test, 5.0e-9);
-	test = convert<fifths, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(fifth_t(1.0))();
 	EXPECT_NEAR(0.00075708236, test, 5.0e-12);
-	test = convert<drams, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(dram_t(1.0))();
 	EXPECT_NEAR(3.69669e-6, test, 5.0e-12);
-	test = convert<gills, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(gill_t(1.0))();
 	EXPECT_NEAR(0.000118294, test, 5.0e-10);
-	test = convert<pecks, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(peck_t(1.0))();
 	EXPECT_NEAR(0.00880977, test, 5.0e-9);
-	test = convert<sacks, cubic_meter>(9.4591978);
+	test = convert<cubic_meter_t>(sack_t(9.4591978))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<shots, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(shot_t(1.0))();
 	EXPECT_NEAR(4.43603e-5, test, 5.0e-11);
-	test = convert<strikes, cubic_meter>(1.0);
+	test = convert<cubic_meter_t>(strike_t(1.0))();
 	EXPECT_NEAR(0.07047814033376, test, 5.0e-5);
-	test = convert<volume::fluid_ounces, milliliters>(1.0);
+	test = convert<milliliter_t>(volume::fluid_ounce_t(1.0))();
 	EXPECT_NEAR(29.5735, test, 5.0e-5);
 }
 
@@ -2462,25 +2463,25 @@ TEST_F(UnitConversion, density)
 {
 	double test;
 
-	test = convert<kilograms_per_cubic_meter, kilograms_per_cubic_meter>(1.0);
+	test = convert<kilograms_per_cubic_meter_t>(kilograms_per_cubic_meter_t(1.0))();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = convert<grams_per_milliliter, kilograms_per_cubic_meter>(1.0);
+	test = convert<kilograms_per_cubic_meter_t>(grams_per_milliliter_t(1.0))();
 	EXPECT_NEAR(1000.0, test, 5.0e-5);
-	test = convert<kilograms_per_liter, kilograms_per_cubic_meter>(1.0);
+	test = convert<kilograms_per_cubic_meter_t>(kilograms_per_liter_t(1.0))();
 	EXPECT_NEAR(1000.0, test, 5.0e-5);
-	test = convert<ounces_per_cubic_foot, kilograms_per_cubic_meter>(1.0);
+	test = convert<kilograms_per_cubic_meter_t>(ounces_per_cubic_foot_t(1.0))();
 	EXPECT_NEAR(1.001153961, test, 5.0e-10);
-	test = convert<ounces_per_cubic_inch, kilograms_per_cubic_meter>(1.0);
+	test = convert<kilograms_per_cubic_meter_t>(ounces_per_cubic_inch_t(1.0))();
 	EXPECT_NEAR(1.729994044e3, test, 5.0e-7);
-	test = convert<ounces_per_gallon, kilograms_per_cubic_meter>(1.0);
+	test = convert<kilograms_per_cubic_meter_t>(ounces_per_gallon_t(1.0))();
 	EXPECT_NEAR(7.489151707, test, 5.0e-10);
-	test = convert<pounds_per_cubic_foot, kilograms_per_cubic_meter>(1.0);
+	test = convert<kilograms_per_cubic_meter_t>(pounds_per_cubic_foot_t(1.0))();
 	EXPECT_NEAR(16.01846337, test, 5.0e-9);
-	test = convert<pounds_per_cubic_inch, kilograms_per_cubic_meter>(1.0);
+	test = convert<kilograms_per_cubic_meter_t>(pounds_per_cubic_inch_t(1.0))();
 	EXPECT_NEAR(2.767990471e4, test, 5.0e-6);
-	test = convert<pounds_per_gallon, kilograms_per_cubic_meter>(1.0);
+	test = convert<kilograms_per_cubic_meter_t>(pounds_per_gallon_t(1.0))();
 	EXPECT_NEAR(119.8264273, test, 5.0e-8);
-	test = convert<slugs_per_cubic_foot, kilograms_per_cubic_meter>(1.0);
+	test = convert<kilograms_per_cubic_meter_t>(slugs_per_cubic_foot_t(1.0))();
 	EXPECT_NEAR(515.3788184, test, 5.0e-6);
 }
 
@@ -2500,37 +2501,37 @@ TEST_F(UnitConversion, concentration)
 
 TEST_F(UnitConversion, data)
 {
-	EXPECT_EQ(8, (convert<byte, bit>(1)));
+	EXPECT_EQ(8, (convert<bit_t>(byte_t(1))()));
 
-	EXPECT_EQ(1000, (convert<kilobytes, bytes>(1)));
-	EXPECT_EQ(1000, (convert<megabytes, kilobytes>(1)));
-	EXPECT_EQ(1000, (convert<gigabytes, megabytes>(1)));
-	EXPECT_EQ(1000, (convert<terabytes, gigabytes>(1)));
-	EXPECT_EQ(1000, (convert<petabytes, terabytes>(1)));
-	EXPECT_EQ(1000, (convert<exabytes, petabytes>(1)));
+	EXPECT_EQ(1000, (convert<byte_t>(kilobyte_t(1))()));
+	EXPECT_EQ(1000, (convert<kilobyte_t>(megabyte_t(1))()));
+	EXPECT_EQ(1000, (convert<megabyte_t>(gigabyte_t(1))()));
+	EXPECT_EQ(1000, (convert<gigabyte_t>(terabyte_t(1))()));
+	EXPECT_EQ(1000, (convert<terabyte_t>(petabyte_t(1))()));
+	EXPECT_EQ(1000, (convert<petabyte_t>(exabyte_t(1))()));
 
-	EXPECT_EQ(1024, (convert<kibibytes, bytes>(1)));
-	EXPECT_EQ(1024, (convert<mebibytes, kibibytes>(1)));
-	EXPECT_EQ(1024, (convert<gibibytes, mebibytes>(1)));
-	EXPECT_EQ(1024, (convert<tebibytes, gibibytes>(1)));
-	EXPECT_EQ(1024, (convert<pebibytes, tebibytes>(1)));
-	EXPECT_EQ(1024, (convert<exbibytes, pebibytes>(1)));
+	EXPECT_EQ(1024, (convert<byte_t>(kibibyte_t(1))()));
+	EXPECT_EQ(1024, (convert<kibibyte_t>(mebibyte_t(1))()));
+	EXPECT_EQ(1024, (convert<mebibyte_t>(gibibyte_t(1))()));
+	EXPECT_EQ(1024, (convert<gibibyte_t>(tebibyte_t(1))()));
+	EXPECT_EQ(1024, (convert<tebibyte_t>(pebibyte_t(1))()));
+	EXPECT_EQ(1024, (convert<pebibyte_t>(exbibyte_t(1))()));
 
-	EXPECT_EQ(93750000, (convert<gigabytes, kibibits>(12)));
+	EXPECT_EQ(93750000, (convert<kibibit_t>(gigabyte_t(12))()));
 
-	EXPECT_EQ(1000, (convert<kilobits, bits>(1)));
-	EXPECT_EQ(1000, (convert<megabits, kilobits>(1)));
-	EXPECT_EQ(1000, (convert<gigabits, megabits>(1)));
-	EXPECT_EQ(1000, (convert<terabits, gigabits>(1)));
-	EXPECT_EQ(1000, (convert<petabits, terabits>(1)));
-	EXPECT_EQ(1000, (convert<exabits, petabits>(1)));
+	EXPECT_EQ(1000, (convert<bit_t>(kilobit_t(1))()));
+	EXPECT_EQ(1000, (convert<kilobit_t>(megabit_t(1))()));
+	EXPECT_EQ(1000, (convert<megabit_t>(gigabit_t(1))()));
+	EXPECT_EQ(1000, (convert<gigabit_t>(terabit_t(1))()));
+	EXPECT_EQ(1000, (convert<terabit_t>(petabit_t(1))()));
+	EXPECT_EQ(1000, (convert<petabit_t>(exabit_t(1))()));
 
-	EXPECT_EQ(1024, (convert<kibibits, bits>(1)));
-	EXPECT_EQ(1024, (convert<mebibits, kibibits>(1)));
-	EXPECT_EQ(1024, (convert<gibibits, mebibits>(1)));
-	EXPECT_EQ(1024, (convert<tebibits, gibibits>(1)));
-	EXPECT_EQ(1024, (convert<pebibits, tebibits>(1)));
-	EXPECT_EQ(1024, (convert<exbibits, pebibits>(1)));
+	EXPECT_EQ(1024, (convert<bit_t>(kibibit_t(1))()));
+	EXPECT_EQ(1024, (convert<kibibit_t>(mebibit_t(1))()));
+	EXPECT_EQ(1024, (convert<mebibit_t>(gibibit_t(1))()));
+	EXPECT_EQ(1024, (convert<gibibit_t>(tebibit_t(1))()));
+	EXPECT_EQ(1024, (convert<tebibit_t>(pebibit_t(1))()));
+	EXPECT_EQ(1024, (convert<pebibit_t>(exbibit_t(1))()));
 
 	// Source: https://en.wikipedia.org/wiki/Binary_prefix
 	EXPECT_NEAR(percent_t(2.4), kibibyte_t(1) / kilobyte_t(1) - 1, 0.005);
@@ -2543,37 +2544,37 @@ TEST_F(UnitConversion, data)
 
 TEST_F(UnitConversion, data_transfer_rate)
 {
-	EXPECT_EQ(8, (convert<bytes_per_second, bits_per_second>(1)));
+	EXPECT_EQ(8, (convert<bits_per_second_t>(bytes_per_second_t(1))()));
 
-	EXPECT_EQ(1000, (convert<kilobytes_per_second, bytes_per_second>(1)));
-	EXPECT_EQ(1000, (convert<megabytes_per_second, kilobytes_per_second>(1)));
-	EXPECT_EQ(1000, (convert<gigabytes_per_second, megabytes_per_second>(1)));
-	EXPECT_EQ(1000, (convert<terabytes_per_second, gigabytes_per_second>(1)));
-	EXPECT_EQ(1000, (convert<petabytes_per_second, terabytes_per_second>(1)));
-	EXPECT_EQ(1000, (convert<exabytes_per_second, petabytes_per_second>(1)));
+	EXPECT_EQ(1000, (convert<bytes_per_second_t>(kilobytes_per_second_t(1))()));
+	EXPECT_EQ(1000, (convert<kilobytes_per_second_t>(megabytes_per_second_t(1))()));
+	EXPECT_EQ(1000, (convert<megabytes_per_second_t>(gigabytes_per_second_t(1))()));
+	EXPECT_EQ(1000, (convert<gigabytes_per_second_t>(terabytes_per_second_t(1))()));
+	EXPECT_EQ(1000, (convert<terabytes_per_second_t>(petabytes_per_second_t(1))()));
+	EXPECT_EQ(1000, (convert<petabytes_per_second_t>(exabytes_per_second_t(1))()));
 
-	EXPECT_EQ(1024, (convert<kibibytes_per_second, bytes_per_second>(1)));
-	EXPECT_EQ(1024, (convert<mebibytes_per_second, kibibytes_per_second>(1)));
-	EXPECT_EQ(1024, (convert<gibibytes_per_second, mebibytes_per_second>(1)));
-	EXPECT_EQ(1024, (convert<tebibytes_per_second, gibibytes_per_second>(1)));
-	EXPECT_EQ(1024, (convert<pebibytes_per_second, tebibytes_per_second>(1)));
-	EXPECT_EQ(1024, (convert<exbibytes_per_second, pebibytes_per_second>(1)));
+	EXPECT_EQ(1024, (convert<bytes_per_second_t>(kibibytes_per_second_t(1))()));
+	EXPECT_EQ(1024, (convert<kibibytes_per_second_t>(mebibytes_per_second_t(1))()));
+	EXPECT_EQ(1024, (convert<mebibytes_per_second_t>(gibibytes_per_second_t(1))()));
+	EXPECT_EQ(1024, (convert<gibibytes_per_second_t>(tebibytes_per_second_t(1))()));
+	EXPECT_EQ(1024, (convert<tebibytes_per_second_t>(pebibytes_per_second_t(1))()));
+	EXPECT_EQ(1024, (convert<pebibytes_per_second_t>(exbibytes_per_second_t(1))()));
 
-	EXPECT_EQ(93750000, (convert<gigabytes_per_second, kibibits_per_second>(12)));
+	EXPECT_EQ(93750000, (convert<kibibits_per_second_t>(gigabytes_per_second_t(12))()));
 
-	EXPECT_EQ(1000, (convert<kilobits_per_second, bits_per_second>(1)));
-	EXPECT_EQ(1000, (convert<megabits_per_second, kilobits_per_second>(1)));
-	EXPECT_EQ(1000, (convert<gigabits_per_second, megabits_per_second>(1)));
-	EXPECT_EQ(1000, (convert<terabits_per_second, gigabits_per_second>(1)));
-	EXPECT_EQ(1000, (convert<petabits_per_second, terabits_per_second>(1)));
-	EXPECT_EQ(1000, (convert<exabits_per_second, petabits_per_second>(1)));
+	EXPECT_EQ(1000, (convert<bits_per_second_t>(kilobits_per_second_t(1))()));
+	EXPECT_EQ(1000, (convert<kilobits_per_second_t>(megabits_per_second_t(1))()));
+	EXPECT_EQ(1000, (convert<megabits_per_second_t>(gigabits_per_second_t(1))()));
+	EXPECT_EQ(1000, (convert<gigabits_per_second_t>(terabits_per_second_t(1))()));
+	EXPECT_EQ(1000, (convert<terabits_per_second_t>(petabits_per_second_t(1))()));
+	EXPECT_EQ(1000, (convert<petabits_per_second_t>(exabits_per_second_t(1))()));
 
-	EXPECT_EQ(1024, (convert<kibibits_per_second, bits_per_second>(1)));
-	EXPECT_EQ(1024, (convert<mebibits_per_second, kibibits_per_second>(1)));
-	EXPECT_EQ(1024, (convert<gibibits_per_second, mebibits_per_second>(1)));
-	EXPECT_EQ(1024, (convert<tebibits_per_second, gibibits_per_second>(1)));
-	EXPECT_EQ(1024, (convert<pebibits_per_second, tebibits_per_second>(1)));
-	EXPECT_EQ(1024, (convert<exbibits_per_second, pebibits_per_second>(1)));
+	EXPECT_EQ(1024, (convert<bits_per_second_t>(kibibits_per_second_t(1))()));
+	EXPECT_EQ(1024, (convert<kibibits_per_second_t>(mebibits_per_second_t(1))()));
+	EXPECT_EQ(1024, (convert<mebibits_per_second_t>(gibibits_per_second_t(1))()));
+	EXPECT_EQ(1024, (convert<gibibits_per_second_t>(tebibits_per_second_t(1))()));
+	EXPECT_EQ(1024, (convert<tebibits_per_second_t>(pebibits_per_second_t(1))()));
+	EXPECT_EQ(1024, (convert<pebibits_per_second_t>(exbibits_per_second_t(1))()));
 
 	// Source: https://en.wikipedia.org/wiki/Binary_prefix
 	EXPECT_NEAR(percent_t(2.4), kibibytes_per_second_t(1) / kilobytes_per_second_t(1) - 1, 0.005);

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -2865,17 +2865,17 @@ TEST_F(UnitConversion, std_chrono)
 	hour_t f = std::chrono::hours(2);
 	EXPECT_EQ(hour_t(2), f);
 
-	std::chrono::nanoseconds g = nanosecond_t(100);
+	std::chrono::nanoseconds g = unit<nanosecond, int>(100);
 	EXPECT_EQ(std::chrono::duration_cast<std::chrono::nanoseconds>(g).count(), 100);
-	std::chrono::nanoseconds h = microsecond_t(2);
+	std::chrono::nanoseconds h = unit<microsecond, int>(2);
 	EXPECT_EQ(std::chrono::duration_cast<std::chrono::nanoseconds>(h).count(), 2000);
-	std::chrono::nanoseconds i = millisecond_t(1);
+	std::chrono::nanoseconds i = unit<millisecond, int>(1);
 	EXPECT_EQ(std::chrono::duration_cast<std::chrono::nanoseconds>(i).count(), 1000000);
-	std::chrono::nanoseconds j = second_t(1);
+	std::chrono::nanoseconds j = unit<second, int>(1);
 	EXPECT_EQ(std::chrono::duration_cast<std::chrono::nanoseconds>(j).count(), 1000000000);
-	std::chrono::nanoseconds k = minute_t(1);
+	std::chrono::nanoseconds k = unit<minute, int>(1);
 	EXPECT_EQ(std::chrono::duration_cast<std::chrono::nanoseconds>(k).count(), 60000000000);
-	std::chrono::nanoseconds l = hour_t(1);
+	std::chrono::nanoseconds l = unit<hour, int>(1);
 	EXPECT_EQ(std::chrono::duration_cast<std::chrono::nanoseconds>(l).count(), 3600000000000);
 }
 

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -1566,7 +1566,7 @@ TEST_F(UnitContainer, valueMethod)
 
 TEST_F(UnitContainer, convertMethod)
 {
-	double test = foot_t(meter_t(3.0)).to<double>();
+	double test = meter_t(3.0).convert<feet>().to<double>();
 	EXPECT_NEAR(9.84252, test, 5.0e-6);
 }
 


### PR DESCRIPTION
Resolves #125.

- [x] Prevent lossy initialization of units from arithmetic types.
- [x] Prevent lossy conversions and truncation of units in its converting constructor.
- [x] Provide an alternative to `convert` that carries intermediate computations in the widest representation and has a type safe interface.
- [x] Specialize `std::common_type` for units of the same dimension. The common type should be the least precise unit that both units can be exactly converted to.
- [x] Implement the modulus operators with the new framework.
- [x] Use the new framework in the equality operators.
- [x] Use the new framework in the relational operators.
- [x] Use the new framework in the arithmetic linear operators.
- [x] Use the new framework in the arithmetic decibel operators.
- [x] Use the new framework in the cmath functions.

Along the way, some of the supporting traits and other utilities might need to be changed to support mixed underlying types.