### PR TITLE
Hash fixes

### DIFF
--- a/include/units.h
+++ b/include/units.h
@@ -4537,9 +4537,17 @@ namespace std
 	template<class UnitConversion, typename T, template<typename> class NonLinearScale>
 	struct hash<units::unit<UnitConversion, T, NonLinearScale>>
 	{
+		template<typename U = T>
 		constexpr std::size_t operator()(const units::unit<UnitConversion, T, NonLinearScale>& x) const noexcept
 		{
-			return x.template toLinearized<T>();
+			if constexpr(std::is_integral_v<U>)
+			{
+				return x.template toLinearized<T>();
+			}
+			else
+			{
+				return hash<T>()(x.template toLinearized<T>());
+			}
 		}
 	};
 

--- a/include/units.h
+++ b/include/units.h
@@ -4537,7 +4537,7 @@ namespace std
 	template<class UnitConversion, typename T, template<typename> class NonLinearScale>
 	struct hash<units::unit<UnitConversion, T, NonLinearScale>>
 	{
-		constexpr std::size_t operator()(const units::unit<UnitConversion, T, NonLinearScale>& x) noexcept
+		constexpr std::size_t operator()(const units::unit<UnitConversion, T, NonLinearScale>& x) const noexcept
 		{
 			return x.template toLinearized<T>();
 		}

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -885,11 +885,11 @@ TEST_F(STDTypeTraits, std_common_type)
 
 TEST_F(STDSpecializations, hash)
 {
-	EXPECT_EQ(std::hash<meter_t>()(3.14_m), 3);
-	EXPECT_EQ(std::hash<millimeter_t>()(3.14_m), 3140);
-	EXPECT_EQ(std::hash<millimeter_t>()(3.14_mm), 3);
-	EXPECT_EQ(std::hash<kilometer_t>()(3.14_m), 0);
-	EXPECT_EQ(std::hash<kilometer_t>()(3.14_km), 3);
+	EXPECT_EQ(std::hash<meter_t>()(3.14_m), std::hash<double>()(3.14));
+	EXPECT_EQ(std::hash<millimeter_t>()(3.14_m), std::hash<double>()(3.14e3));
+	EXPECT_EQ(std::hash<millimeter_t>()(3.14_mm), std::hash<double>()(3.14));
+	EXPECT_EQ(std::hash<kilometer_t>()(3.14_m), std::hash<double>()(3.14e-3));
+	EXPECT_EQ(std::hash<kilometer_t>()(3.14_km), std::hash<double>()(3.14));
 
 	EXPECT_EQ((std::hash<unit<meters, int>>()(unit<meters, int>(42))), 42);
 	EXPECT_EQ((std::hash<unit<millimeters, int>>()(unit<meters, int>(42))), 42000);


### PR DESCRIPTION
I noticed that hashing floating-point units didn't meet [this requirement](https://wg21.link/hash.requirements#2.sentence-9). I took the easy way out of using the non-`constexpr` `std::hash<`_floating-point_`>` in that case.