### PR TITLE
DRY in return types

### DIFF
--- a/include/units/core.h
+++ b/include/units/core.h
@@ -3231,10 +3231,7 @@ namespace units
 			detail::floating_point_promotion_t<typename units::traits::unit_traits<UnitType>::underlying_type>,
 			linear_scale>
 	{
-		return unit<traits::strong_t<typename units::detail::power_of_unit<power,
-						typename units::traits::unit_traits<UnitType>::conversion_factor>::type>,
-			detail::floating_point_promotion_t<typename units::traits::unit_traits<UnitType>::underlying_type>,
-			linear_scale>(pow(value(), power));
+		return decltype(units::pow<power>(value))(pow(value(), power));
 	}
 
 	//------------------------------
@@ -3582,9 +3579,7 @@ namespace units
 			detail::floating_point_promotion_t<typename units::traits::unit_traits<UnitType>::underlying_type>,
 			linear_scale>
 	{
-		return unit<traits::strong_t<square_root<typename units::traits::unit_traits<UnitType>::conversion_factor>>,
-			detail::floating_point_promotion_t<typename units::traits::unit_traits<UnitType>::underlying_type>,
-			linear_scale>(sqrt(value()));
+		return decltype(units::sqrt(value))(sqrt(value()));
 	}
 
 	/**

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -2808,7 +2808,7 @@ namespace units
 	constexpr std::common_type_t<UnitTypeLhs, UnitTypeRhs> operator+(
 		const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using CommonUnit = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
+		using CommonUnit = decltype(lhs + rhs);
 		return CommonUnit(CommonUnit(lhs)() + CommonUnit(rhs)());
 	}
 
@@ -2821,7 +2821,7 @@ namespace units
 	constexpr unit<dimensionless_unit, std::common_type_t<typename UnitTypeLhs::underlying_type, T>> operator+(
 		const UnitTypeLhs& lhs, T rhs) noexcept
 	{
-		using CommonUnit = unit<dimensionless_unit, std::common_type_t<typename UnitTypeLhs::underlying_type, T>>;
+		using CommonUnit = decltype(lhs + rhs);
 		return CommonUnit(CommonUnit(lhs)() + rhs);
 	}
 
@@ -2834,7 +2834,7 @@ namespace units
 	constexpr unit<dimensionless_unit, std::common_type_t<T, typename UnitTypeRhs::underlying_type>> operator+(
 		T lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using CommonUnit = unit<dimensionless_unit, std::common_type_t<T, typename UnitTypeRhs::underlying_type>>;
+		using CommonUnit = decltype(lhs + rhs);
 		return CommonUnit(lhs + CommonUnit(rhs)());
 	}
 
@@ -2846,7 +2846,7 @@ namespace units
 	constexpr std::common_type_t<UnitTypeLhs, UnitTypeRhs> operator-(
 		const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using CommonUnit = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
+		using CommonUnit = decltype(lhs - rhs);
 		return CommonUnit(CommonUnit(lhs)() - CommonUnit(rhs)());
 	}
 
@@ -2859,7 +2859,7 @@ namespace units
 	constexpr unit<dimensionless_unit, std::common_type_t<typename UnitTypeLhs::underlying_type, T>> operator-(
 		const UnitTypeLhs& lhs, T rhs) noexcept
 	{
-		using CommonUnit = unit<dimensionless_unit, std::common_type_t<typename UnitTypeLhs::underlying_type, T>>;
+		using CommonUnit = decltype(lhs - rhs);
 		return CommonUnit(CommonUnit(lhs)() - rhs);
 	}
 
@@ -2872,7 +2872,7 @@ namespace units
 	constexpr unit<dimensionless_unit, std::common_type_t<T, typename UnitTypeRhs::underlying_type>> operator-(
 		T lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using CommonUnit = unit<dimensionless_unit, std::common_type_t<T, typename UnitTypeRhs::underlying_type>>;
+		using CommonUnit = decltype(lhs - rhs);
 		return CommonUnit(lhs - CommonUnit(rhs)());
 	}
 
@@ -2887,9 +2887,9 @@ namespace units
 					std::common_type_t<UnitTypeLhs, UnitTypeRhs>>::conversion_factor>>,
 			typename std::common_type_t<UnitTypeLhs, UnitTypeRhs>::underlying_type>
 	{
-		using CommonUnit = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
-		return unit<traits::strong_t<squared<typename units::traits::unit_traits<CommonUnit>::conversion_factor>>,
-			typename CommonUnit::underlying_type>(CommonUnit(lhs)() * CommonUnit(rhs)());
+		using SquaredUnit = decltype(lhs * rhs);
+		using CommonUnit  = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
+		return SquaredUnit(CommonUnit(lhs)() * CommonUnit(rhs)());
 	}
 
 	/// Multiplication type for non-convertible unit types with a linear scale. @returns the multiplied value, whose
@@ -2904,12 +2904,9 @@ namespace units
 			typename units::traits::unit_traits<UnitTypeRhs>::conversion_factor>>,
 		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>
 	{
-		using UnitConversionLhs = typename units::traits::unit_traits<UnitTypeLhs>::conversion_factor;
-		using UnitConversionRhs = typename units::traits::unit_traits<UnitTypeRhs>::conversion_factor;
-		using CommonUnderlying =
-			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>;
-		return unit<traits::strong_t<compound_conversion_factor<UnitConversionLhs, UnitConversionRhs>>,
-			CommonUnderlying>(static_cast<CommonUnderlying>(lhs) * static_cast<CommonUnderlying>(rhs));
+		using CompoundUnit     = decltype(lhs * rhs);
+		using CommonUnderlying = typename CompoundUnit::underlying_type;
+		return CompoundUnit(static_cast<CommonUnderlying>(lhs) * static_cast<CommonUnderlying>(rhs));
 	}
 
 	/// Multiplication by a dimensionless unit for unit types with a linear scale.
@@ -2921,9 +2918,8 @@ namespace units
 		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>
 	operator*(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using CommonUnderlying =
-			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>;
-		using CommonUnit = unit<typename UnitTypeLhs::conversion_factor, CommonUnderlying>;
+		using CommonUnit       = decltype(lhs * rhs);
+		using CommonUnderlying = typename CommonUnit::underlying_type;
 		// the cast makes sure factors of PI are handled as expected
 		return CommonUnit(CommonUnit(lhs)() * static_cast<CommonUnderlying>(rhs));
 	}
@@ -2937,9 +2933,8 @@ namespace units
 		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>
 	operator*(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using CommonUnderlying =
-			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>;
-		using CommonUnit = unit<typename UnitTypeRhs::conversion_factor, CommonUnderlying>;
+		using CommonUnit       = decltype(lhs * rhs);
+		using CommonUnderlying = typename CommonUnit::underlying_type;
 		// the cast makes sure factors of PI are handled as expected
 		return CommonUnit(static_cast<CommonUnderlying>(lhs) * CommonUnit(rhs)());
 	}
@@ -2951,8 +2946,7 @@ namespace units
 		std::common_type_t<typename UnitTypeLhs::underlying_type, T>>
 	operator*(const UnitTypeLhs& lhs, T rhs) noexcept
 	{
-		using CommonUnit =
-			unit<typename UnitTypeLhs::conversion_factor, std::common_type_t<typename UnitTypeLhs::underlying_type, T>>;
+		using CommonUnit = decltype(lhs * rhs);
 		return CommonUnit(CommonUnit(lhs)() * rhs);
 	}
 
@@ -2963,8 +2957,7 @@ namespace units
 		std::common_type_t<T, typename UnitTypeRhs::underlying_type>>
 	operator*(T lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using CommonUnit =
-			unit<typename UnitTypeRhs::conversion_factor, std::common_type_t<T, typename UnitTypeRhs::underlying_type>>;
+		using CommonUnit = decltype(lhs * rhs);
 		return CommonUnit(lhs * CommonUnit(rhs)());
 	}
 
@@ -2978,8 +2971,9 @@ namespace units
 		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>
 	operator/(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using CommonUnit = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
-		return unit<dimensionless_unit, typename CommonUnit::underlying_type>(CommonUnit(lhs)() / CommonUnit(rhs)());
+		using Dimensionless = decltype(lhs / rhs);
+		using CommonUnit    = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
+		return Dimensionless(CommonUnit(lhs)() / CommonUnit(rhs)());
 	}
 
 	/// Division for non-convertible unit types with a linear scale. @returns the lhs divided by the rhs, with a
@@ -2994,12 +2988,9 @@ namespace units
 			inverse<typename units::traits::unit_traits<UnitTypeRhs>::conversion_factor>>>,
 		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>
 	{
-		using UnitConversionLhs = typename units::traits::unit_traits<UnitTypeLhs>::conversion_factor;
-		using UnitConversionRhs = typename units::traits::unit_traits<UnitTypeRhs>::conversion_factor;
-		using CommonUnderlying =
-			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>;
-		return unit<traits::strong_t<compound_conversion_factor<UnitConversionLhs, inverse<UnitConversionRhs>>>,
-			CommonUnderlying>(static_cast<CommonUnderlying>(lhs) / static_cast<CommonUnderlying>(rhs));
+		using CompoundUnit     = decltype(lhs / rhs);
+		using CommonUnderlying = typename CompoundUnit::underlying_type;
+		return CompoundUnit(static_cast<CommonUnderlying>(lhs) / static_cast<CommonUnderlying>(rhs));
 	}
 
 	/// Division by a dimensionless unit for unit types with a linear scale
@@ -3011,9 +3002,8 @@ namespace units
 		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>
 	operator/(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using CommonUnderlying =
-			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>;
-		using CommonUnit = unit<typename UnitTypeLhs::conversion_factor, CommonUnderlying>;
+		using CommonUnit       = decltype(lhs / rhs);
+		using CommonUnderlying = typename CommonUnit::underlying_type;
 		return CommonUnit(CommonUnit(lhs)() / static_cast<CommonUnderlying>(rhs));
 	}
 
@@ -3026,10 +3016,9 @@ namespace units
 		-> unit<traits::strong_t<inverse<typename units::traits::unit_traits<UnitTypeRhs>::conversion_factor>>,
 			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>
 	{
-		using CommonUnderlying =
-			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>;
-		return unit<traits::strong_t<inverse<typename units::traits::unit_traits<UnitTypeRhs>::conversion_factor>>,
-			CommonUnderlying>(static_cast<CommonUnderlying>(lhs) / static_cast<CommonUnderlying>(rhs));
+		using InverseUnit      = decltype(lhs / rhs);
+		using CommonUnderlying = typename InverseUnit::underlying_type;
+		return InverseUnit(static_cast<CommonUnderlying>(lhs) / static_cast<CommonUnderlying>(rhs));
 	}
 
 	/// Division by a dimensionless for unit types with a linear scale
@@ -3039,8 +3028,7 @@ namespace units
 		std::common_type_t<typename UnitTypeLhs::underlying_type, T>>
 	operator/(const UnitTypeLhs& lhs, T rhs) noexcept
 	{
-		using CommonUnit =
-			unit<typename UnitTypeLhs::conversion_factor, std::common_type_t<typename UnitTypeLhs::underlying_type, T>>;
+		using CommonUnit = decltype(lhs / rhs);
 		return CommonUnit(CommonUnit(lhs)() / rhs);
 	}
 
@@ -3051,10 +3039,11 @@ namespace units
 		-> unit<traits::strong_t<inverse<typename units::traits::unit_traits<UnitTypeRhs>::conversion_factor>>,
 			std::common_type_t<T, typename UnitTypeRhs::underlying_type>>
 	{
-		using UnitConversionRhs = typename units::traits::unit_traits<UnitTypeRhs>::conversion_factor;
-		using CommonUnderlying  = std::common_type_t<T, typename UnitTypeRhs::underlying_type>;
-		using CommonUnitRhs     = unit<UnitConversionRhs, CommonUnderlying>;
-		return unit<traits::strong_t<inverse<UnitConversionRhs>>, CommonUnderlying>(lhs / CommonUnitRhs(rhs)());
+		using InverseUnit      = decltype(lhs / rhs);
+		using UnitConversion   = typename units::traits::unit_traits<UnitTypeRhs>::conversion_factor;
+		using CommonUnderlying = std::common_type_t<T, typename UnitTypeRhs::underlying_type>;
+		using CommonUnit       = unit<UnitConversion, CommonUnderlying>;
+		return InverseUnit(lhs / CommonUnit(rhs)());
 	}
 
 	/// Modulo for convertible unit types with a linear scale. @returns the lhs value modulo the rhs value, whose type
@@ -3066,7 +3055,7 @@ namespace units
 	constexpr std::common_type_t<UnitTypeLhs, UnitTypeRhs> operator%(
 		const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using CommonUnit = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
+		using CommonUnit = decltype(lhs % rhs);
 		return CommonUnit(CommonUnit(lhs)() % CommonUnit(rhs)());
 	}
 
@@ -3079,9 +3068,8 @@ namespace units
 		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>
 	operator%(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using CommonUnderlying =
-			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>;
-		using CommonUnit = unit<typename UnitTypeLhs::conversion_factor, CommonUnderlying>;
+		using CommonUnit       = decltype(lhs % rhs);
+		using CommonUnderlying = typename CommonUnit::underlying_type;
 		return CommonUnit(CommonUnit(lhs)() % static_cast<CommonUnderlying>(rhs));
 	}
 
@@ -3092,8 +3080,7 @@ namespace units
 		std::common_type_t<typename UnitTypeLhs::underlying_type, T>>
 	operator%(const UnitTypeLhs& lhs, const T& rhs) noexcept
 	{
-		using CommonUnit =
-			unit<typename UnitTypeLhs::conversion_factor, std::common_type_t<typename UnitTypeLhs::underlying_type, T>>;
+		using CommonUnit = decltype(lhs % rhs);
 		return CommonUnit(CommonUnit(lhs)() % rhs);
 	}
 
@@ -3322,11 +3309,10 @@ namespace units
 					std::common_type_t<UnitTypeLhs, UnitTypeRhs>>::conversion_factor>>,
 			typename std::common_type_t<UnitTypeLhs, UnitTypeRhs>::underlying_type, decibel_scale>
 	{
-		using CommonUnit       = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
-		using CommonUnderlying = typename CommonUnit::underlying_type;
+		using SquaredUnit = decltype(lhs + rhs);
+		using CommonUnit  = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
 
-		return unit<traits::strong_t<squared<typename CommonUnit::conversion_factor>>, CommonUnderlying, decibel_scale>(
-			CommonUnit(lhs).to_linearized() * CommonUnit(rhs).to_linearized(), linearized_value);
+		return SquaredUnit(CommonUnit(lhs).to_linearized() * CommonUnit(rhs).to_linearized(), linearized_value);
 	}
 
 	/// Addition between unit types with a decibel_scale and dimensionless dB units
@@ -3338,10 +3324,8 @@ namespace units
 		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>, decibel_scale>
 	operator+(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using CommonUnderlying =
-			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>;
-		return unit<typename UnitTypeLhs::conversion_factor, CommonUnderlying, decibel_scale>(
-			lhs.to_linearized() * rhs.to_linearized(), linearized_value);
+		using CommonUnit = decltype(lhs + rhs);
+		return CommonUnit(lhs.to_linearized() * rhs.to_linearized(), linearized_value);
 	}
 
 	/// Addition between unit types with a decibel_scale and dimensionless dB units
@@ -3353,10 +3337,8 @@ namespace units
 		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>, decibel_scale>
 	operator+(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using CommonUnderlying =
-			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>;
-		return unit<typename UnitTypeRhs::conversion_factor, CommonUnderlying, decibel_scale>(
-			lhs.to_linearized() * rhs.to_linearized(), linearized_value);
+		using CommonUnit = decltype(lhs + rhs);
+		return CommonUnit(lhs.to_linearized() * rhs.to_linearized(), linearized_value);
 	}
 
 	/// Subtraction for convertible unit types with a decibel_scale
@@ -3367,11 +3349,10 @@ namespace units
 	constexpr auto operator-(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 		-> dB_t<typename std::common_type_t<UnitTypeLhs, UnitTypeRhs>::underlying_type>
 	{
-		using CommonUnit       = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
-		using CommonUnderlying = typename CommonUnit::underlying_type;
+		using Dimensionless = decltype(lhs - rhs);
+		using CommonUnit    = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
 
-		return dB_t<CommonUnderlying>(
-			CommonUnit(lhs).to_linearized() / CommonUnit(rhs).to_linearized(), linearized_value);
+		return Dimensionless(CommonUnit(lhs).to_linearized() / CommonUnit(rhs).to_linearized(), linearized_value);
 	}
 
 	/// Subtraction between unit types with a decibel_scale and dimensionless dB units
@@ -3383,10 +3364,8 @@ namespace units
 		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>, decibel_scale>
 	operator-(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using CommonUnderlying =
-			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>;
-		return unit<typename UnitTypeLhs::conversion_factor, CommonUnderlying, decibel_scale>(
-			lhs.to_linearized() / rhs.to_linearized(), linearized_value);
+		using CommonUnit = decltype(lhs - rhs);
+		return CommonUnit(lhs.to_linearized() / rhs.to_linearized(), linearized_value);
 	}
 
 	/// Subtraction between unit types with a decibel_scale and dimensionless dB units
@@ -3399,12 +3378,8 @@ namespace units
 			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>,
 			decibel_scale>
 	{
-		using UnitConversionRhs = typename units::traits::unit_traits<UnitTypeRhs>::conversion_factor;
-		using CommonUnderlying =
-			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>;
-
-		return unit<traits::strong_t<inverse<UnitConversionRhs>>, CommonUnderlying, decibel_scale>(
-			lhs.to_linearized() / rhs.to_linearized(), linearized_value);
+		using InverseUnit = decltype(lhs - rhs);
+		return InverseUnit(lhs.to_linearized() / rhs.to_linearized(), linearized_value);
 	}
 
 	//------------------------------

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -1798,9 +1798,8 @@ namespace units
 	template<class UnitTo, class UnitFrom, std::enable_if_t<detail::is_convertible_unit<UnitFrom, UnitTo>, int> = 0>
 	constexpr UnitTo convert(const UnitFrom& from) noexcept
 	{
-		return UnitTo(
-			convert<typename UnitFrom::conversion_factor, typename UnitTo::conversion_factor,
-				typename UnitTo::underlying_type>(from.to_linearized()),
+		return UnitTo(convert<typename UnitFrom::conversion_factor, typename UnitTo::conversion_factor,
+						  typename UnitTo::underlying_type>(from.to_linearized()),
 			linearized_value);
 	}
 
@@ -3327,9 +3326,7 @@ namespace units
 		using CommonUnderlying = typename CommonUnit::underlying_type;
 
 		return unit<traits::strong_t<squared<typename CommonUnit::conversion_factor>>, CommonUnderlying, decibel_scale>(
-			CommonUnit(lhs).to_linearized() *
-				CommonUnit(rhs).to_linearized(),
-			linearized_value);
+			CommonUnit(lhs).to_linearized() * CommonUnit(rhs).to_linearized(), linearized_value);
 	}
 
 	/// Addition between unit types with a decibel_scale and dimensionless dB units
@@ -3344,8 +3341,7 @@ namespace units
 		using CommonUnderlying =
 			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>;
 		return unit<typename UnitTypeLhs::conversion_factor, CommonUnderlying, decibel_scale>(
-			lhs.to_linearized() * rhs.to_linearized(),
-			linearized_value);
+			lhs.to_linearized() * rhs.to_linearized(), linearized_value);
 	}
 
 	/// Addition between unit types with a decibel_scale and dimensionless dB units
@@ -3360,8 +3356,7 @@ namespace units
 		using CommonUnderlying =
 			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>;
 		return unit<typename UnitTypeRhs::conversion_factor, CommonUnderlying, decibel_scale>(
-			lhs.to_linearized() * rhs.to_linearized(),
-			linearized_value);
+			lhs.to_linearized() * rhs.to_linearized(), linearized_value);
 	}
 
 	/// Subtraction for convertible unit types with a decibel_scale
@@ -3375,9 +3370,8 @@ namespace units
 		using CommonUnit       = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
 		using CommonUnderlying = typename CommonUnit::underlying_type;
 
-		return dB_t<CommonUnderlying>(CommonUnit(lhs).to_linearized() /
-				CommonUnit(rhs).to_linearized(),
-			linearized_value);
+		return dB_t<CommonUnderlying>(
+			CommonUnit(lhs).to_linearized() / CommonUnit(rhs).to_linearized(), linearized_value);
 	}
 
 	/// Subtraction between unit types with a decibel_scale and dimensionless dB units
@@ -3392,8 +3386,7 @@ namespace units
 		using CommonUnderlying =
 			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>;
 		return unit<typename UnitTypeLhs::conversion_factor, CommonUnderlying, decibel_scale>(
-			lhs.to_linearized() / rhs.to_linearized(),
-			linearized_value);
+			lhs.to_linearized() / rhs.to_linearized(), linearized_value);
 	}
 
 	/// Subtraction between unit types with a decibel_scale and dimensionless dB units
@@ -3411,8 +3404,7 @@ namespace units
 			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>;
 
 		return unit<traits::strong_t<inverse<UnitConversionRhs>>, CommonUnderlying, decibel_scale>(
-			lhs.to_linearized() / rhs.to_linearized(),
-			linearized_value);
+			lhs.to_linearized() / rhs.to_linearized(), linearized_value);
 	}
 
 	//------------------------------

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -2971,9 +2971,8 @@ namespace units
 		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>
 	operator/(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using Dimensionless = decltype(lhs / rhs);
-		using CommonUnit    = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
-		return Dimensionless(CommonUnit(lhs)() / CommonUnit(rhs)());
+		using CommonUnit = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
+		return CommonUnit(lhs)() / CommonUnit(rhs)();
 	}
 
 	/// Division for non-convertible unit types with a linear scale. @returns the lhs divided by the rhs, with a

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -3409,7 +3409,7 @@ namespace units
 		std::enable_if_t<traits::is_convertible_unit_v<UnitTypeLhs, UnitTypeRhs>, int> = 0>
 	constexpr std::common_type_t<UnitTypeLhs, UnitTypeRhs> min(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs)
 	{
-		using CommonUnit = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
+		using CommonUnit = decltype(units::min(lhs, rhs));
 		return (lhs < rhs ? CommonUnit(lhs) : CommonUnit(rhs));
 	}
 
@@ -3417,7 +3417,7 @@ namespace units
 		std::enable_if_t<traits::is_convertible_unit_v<UnitTypeLhs, UnitTypeRhs>, int> = 0>
 	constexpr std::common_type_t<UnitTypeLhs, UnitTypeRhs> max(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs)
 	{
-		using CommonUnit = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
+		using CommonUnit = decltype(units::max(lhs, rhs));
 		return (lhs > rhs ? CommonUnit(lhs) : CommonUnit(rhs));
 	}
 
@@ -3604,7 +3604,7 @@ namespace units
 	detail::floating_point_promotion_t<std::common_type_t<UnitTypeLhs, UnitTypeRhs>> hypot(
 		const UnitTypeLhs& x, const UnitTypeRhs& y)
 	{
-		using CommonUnit = detail::floating_point_promotion_t<std::common_type_t<UnitTypeLhs, UnitTypeRhs>>;
+		using CommonUnit = decltype(units::hypot(x, y));
 		return CommonUnit(std::hypot(CommonUnit(x)(), CommonUnit(y)()));
 	}
 
@@ -3653,7 +3653,7 @@ namespace units
 	detail::floating_point_promotion_t<std::common_type_t<UnitTypeLhs, UnitTypeRhs>> fmod(
 		const UnitTypeLhs numer, const UnitTypeRhs denom) noexcept
 	{
-		using CommonUnit = detail::floating_point_promotion_t<std::common_type_t<UnitTypeLhs, UnitTypeRhs>>;
+		using CommonUnit = decltype(units::fmod(numer, denom));
 		return CommonUnit(std::fmod(CommonUnit(numer)(), CommonUnit(denom)()));
 	}
 
@@ -3733,7 +3733,7 @@ namespace units
 	detail::floating_point_promotion_t<std::common_type_t<UnitTypeLhs, UnitTypeRhs>> fdim(
 		const UnitTypeLhs x, const UnitTypeRhs y) noexcept
 	{
-		using CommonUnit = detail::floating_point_promotion_t<std::common_type_t<UnitTypeLhs, UnitTypeRhs>>;
+		using CommonUnit = decltype(units::fdim(x, y));
 		return CommonUnit(std::fdim(CommonUnit(x)(), CommonUnit(y)()));
 	}
 
@@ -3752,7 +3752,7 @@ namespace units
 	detail::floating_point_promotion_t<std::common_type_t<UnitTypeLhs, UnitTypeRhs>> fmax(
 		const UnitTypeLhs x, const UnitTypeRhs y) noexcept
 	{
-		using CommonUnit = detail::floating_point_promotion_t<std::common_type_t<UnitTypeLhs, UnitTypeRhs>>;
+		using CommonUnit = decltype(units::fmax(x, y));
 		return CommonUnit(std::fmax(CommonUnit(x)(), CommonUnit(y)()));
 	}
 
@@ -3772,7 +3772,7 @@ namespace units
 	detail::floating_point_promotion_t<std::common_type_t<UnitTypeLhs, UnitTypeRhs>> fmin(
 		const UnitTypeLhs x, const UnitTypeRhs y) noexcept
 	{
-		using CommonUnit = detail::floating_point_promotion_t<std::common_type_t<UnitTypeLhs, UnitTypeRhs>>;
+		using CommonUnit = decltype(units::fmin(x, y));
 		return CommonUnit(std::fmin(CommonUnit(x)(), CommonUnit(y)()));
 	}
 
@@ -3829,9 +3829,7 @@ namespace units
 								  detail::floating_point_promotion_t<UnitMultiply>(y)),
 			UnitAdd>
 	{
-		using CommonUnit = std::common_type_t<decltype(detail::floating_point_promotion_t<UnitTypeLhs>(x) *
-												  detail::floating_point_promotion_t<UnitMultiply>(y)),
-			UnitAdd>;
+		using CommonUnit = decltype(units::fma(x, y, z));
 		return CommonUnit(std::fma(x(), y(), CommonUnit(z)()));
 	}
 } // end namespace units


### PR DESCRIPTION
This prevent the use of the return type in the function signature and return statement from desynchronizing. With the upcoming changes, such desynchronization would cause a temporary to be used to construct the actual return type.

The return types of the return statements were more readable than those of the function signature, as we used type aliases local to the functions. I didn't want to change the function signatures as that might be visible in the doxygen-generated documentation.