### PR TITLE
Normalize `std::enable_if_t` usage in template parameter lists

### DIFF
--- a/include/units/core.h
+++ b/include/units/core.h
@@ -1685,7 +1685,7 @@ namespace units
 	 * @returns		value, converted from units of `UnitFrom` to `UnitTo`.
 	 */
 	template<class UnitFrom, class UnitTo, typename To = UNIT_LIB_DEFAULT_TYPE, typename From,
-		class = std::enable_if_t<detail::is_convertible_conversion_factor<UnitFrom, UnitTo>>>
+		std::enable_if_t<detail::is_convertible_conversion_factor<UnitFrom, UnitTo>, int> = 0>
 	constexpr To convert(const From& value) noexcept
 	{
 		using Ratio   = std::ratio_divide<typename UnitFrom::conversion_ratio, typename UnitTo::conversion_ratio>;
@@ -1813,7 +1813,7 @@ namespace units
 	 *				and must be convertible from `UnitFrom` (i.e. is_convertible_unit<UnitFrom, UnitTo>::value == true).
 	 * @returns		from, converted from units of `UnitFrom` to `UnitTo`.
 	 */
-	template<class UnitTo, class UnitFrom, class = std::enable_if_t<detail::is_convertible_unit<UnitFrom, UnitTo>>>
+	template<class UnitTo, class UnitFrom, std::enable_if_t<detail::is_convertible_unit<UnitFrom, UnitTo>, int> = 0>
 	constexpr UnitTo convert(const UnitFrom& from) noexcept
 	{
 		return UnitTo(
@@ -2138,7 +2138,7 @@ namespace units
 		 *				Which args are required depends on which scale is used. For the default (linear) scale, no
 		 *				additional args are necessary.
 		 */
-		template<class Ty, class... Args, class = std::enable_if_t<detail::is_non_lossy_convertible<Ty, T>>>
+		template<class Ty, class... Args, std::enable_if_t<detail::is_non_lossy_convertible<Ty, T>, int> = 0>
 		explicit constexpr unit(const Ty value, const Args&... args) noexcept : nls(value, args...)
 		{
 		}
@@ -2149,8 +2149,8 @@ namespace units
 		 * @param[in]	value value of the unit
 		 */
 		template<class Ty,
-			class = std::enable_if_t<traits::is_dimensionless_unit<UnitType>::value &&
-				detail::is_non_lossy_convertible<Ty, T>>>
+			std::enable_if_t<traits::is_dimensionless_unit<UnitType>::value && detail::is_non_lossy_convertible<Ty, T>,
+				int> = 0>
 		constexpr unit(const Ty value) noexcept : nls(value)
 		{
 		}
@@ -2161,7 +2161,7 @@ namespace units
 		 * @param[in]	value value of the unit
 		 */
 		template<class Rep, class Period, typename U = UnitType,
-			class = std::enable_if_t<detail::is_time_conversion_factor<U> && detail::is_non_lossy_convertible<Rep, T>>>
+			std::enable_if_t<detail::is_time_conversion_factor<U> && detail::is_non_lossy_convertible<Rep, T>, int> = 0>
 		constexpr unit(const std::chrono::duration<Rep, Period>& value) noexcept
 		  : nls(units::convert<unit>(
 				units::unit<units::conversion_factor<Period, dimension::time>, Rep>(value.count()))())
@@ -2174,7 +2174,7 @@ namespace units
 		 * @param[in]	rhs unit to copy.
 		 */
 		template<class UnitTypeRhs, typename Ty, template<typename> class NlsRhs,
-			class = std::enable_if_t<detail::is_non_lossy_convertible_unit<unit<UnitTypeRhs, Ty, NlsRhs>, unit>>>
+			std::enable_if_t<detail::is_non_lossy_convertible_unit<unit<UnitTypeRhs, Ty, NlsRhs>, unit>, int> = 0>
 		constexpr unit(const unit<UnitTypeRhs, Ty, NlsRhs>& rhs) noexcept
 		  : nls(units::convert<unit>(rhs).m_value, std::true_type() /*store linear value*/)
 		{
@@ -2193,8 +2193,8 @@ namespace units
 		 * @param[in]	rhs value to copy.
 		 */
 		template<class Ty,
-			class = std::enable_if_t<traits::is_dimensionless_unit<UnitType>::value &&
-				detail::is_non_lossy_convertible<Ty, T>>>
+			std::enable_if_t<traits::is_dimensionless_unit<UnitType>::value && detail::is_non_lossy_convertible<Ty, T>,
+				int> = 0>
 		constexpr unit& operator=(const Ty& rhs) noexcept
 		{
 			nls::m_value = rhs;
@@ -2309,7 +2309,7 @@ namespace units
 		 * @brief		unit value
 		 * @returns		value of the unit converted to an arithmetic, non-safe type.
 		 */
-		template<typename Ty, class = std::enable_if_t<std::is_arithmetic_v<Ty>>>
+		template<typename Ty, std::enable_if_t<std::is_arithmetic_v<Ty>, int> = 0>
 		constexpr Ty to() const noexcept
 		{
 			return static_cast<Ty>(*this);
@@ -2320,7 +2320,7 @@ namespace units
 		 * @returns		linearized value of unit which has a non-linear scale. For `unit` types with
 		 *				linear scales, this is equivalent to `value`.
 		 */
-		template<typename Ty, class = std::enable_if_t<std::is_arithmetic_v<Ty>>>
+		template<typename Ty, std::enable_if_t<std::is_arithmetic_v<Ty>, int> = 0>
 		constexpr Ty toLinearized() const noexcept
 		{
 			return static_cast<Ty>(m_value);
@@ -2418,7 +2418,7 @@ namespace units
 	 * @param[in]	value	Arithmetic value that represents a quantity in units of `UnitType`.
 	 */
 	template<class UnitType, typename T,
-		class = std::enable_if_t<detail::is_non_lossy_convertible<T, typename UnitType::underlying_type>>>
+		std::enable_if_t<detail::is_non_lossy_convertible<T, typename UnitType::underlying_type>, int> = 0>
 	constexpr UnitType make_unit(const T value) noexcept
 	{
 		static_assert(traits::is_unit_v<UnitType>, "Template parameter `UnitType` must be a unit type.");
@@ -2610,7 +2610,7 @@ namespace units
 
 	template<class UnitConversionLhs, typename T, template<typename> class NonLinearScaleLhs, class UnitConversionRhs,
 		template<typename> class NonLinearScaleRhs,
-		class = std::enable_if_t<traits::is_dimensionless_unit<UnitConversionRhs>::value>>
+		std::enable_if_t<traits::is_dimensionless_unit<UnitConversionRhs>::value, int> = 0>
 	constexpr unit<UnitConversionLhs, T, NonLinearScaleLhs>& operator%=(
 		unit<UnitConversionLhs, T, NonLinearScaleLhs>& lhs,
 		const unit<UnitConversionRhs, detail::type_identity_t<T>, NonLinearScaleRhs>& rhs) noexcept
@@ -3678,7 +3678,7 @@ namespace units
 	 * @param[in]	x	Unit value to round up.
 	 * @returns		The smallest integral value that is not less than x.
 	 */
-	template<class UnitType, class = std::enable_if_t<traits::is_unit_v<UnitType>>>
+	template<class UnitType, std::enable_if_t<traits::is_unit_v<UnitType>, int> = 0>
 	detail::floating_point_promotion_t<UnitType> ceil(const UnitType x) noexcept
 	{
 		return detail::floating_point_promotion_t<UnitType>(std::ceil(x()));
@@ -3691,7 +3691,7 @@ namespace units
 	 * @param[in]	x	Unit value to round down.
 	 * @returns		The value of x rounded downward.
 	 */
-	template<class UnitType, class = std::enable_if_t<traits::is_unit_v<UnitType>>>
+	template<class UnitType, std::enable_if_t<traits::is_unit_v<UnitType>, int> = 0>
 	detail::floating_point_promotion_t<UnitType> floor(const UnitType x) noexcept
 	{
 		return detail::floating_point_promotion_t<UnitType>(std::floor(x()));
@@ -3706,8 +3706,9 @@ namespace units
 	 * @returns		The remainder of dividing the arguments.
 	 */
 	template<class UnitTypeLhs, class UnitTypeRhs,
-		class = std::enable_if_t<traits::is_unit_v<UnitTypeLhs> && traits::is_unit_v<UnitTypeRhs> &&
-			traits::is_convertible_unit_v<UnitTypeLhs, UnitTypeRhs>>>
+		std::enable_if_t<traits::is_unit_v<UnitTypeLhs> && traits::is_unit_v<UnitTypeRhs> &&
+				traits::is_convertible_unit_v<UnitTypeLhs, UnitTypeRhs>,
+			int> = 0>
 	detail::floating_point_promotion_t<std::common_type_t<UnitTypeLhs, UnitTypeRhs>> fmod(
 		const UnitTypeLhs numer, const UnitTypeRhs denom) noexcept
 	{
@@ -3723,7 +3724,7 @@ namespace units
 	 * @param[in]	x	Value to truncate
 	 * @returns		The nearest integral value that is not larger in magnitude than x.
 	 */
-	template<class UnitType, class = std::enable_if_t<traits::is_unit_v<UnitType>>>
+	template<class UnitType, std::enable_if_t<traits::is_unit_v<UnitType>, int> = 0>
 	detail::floating_point_promotion_t<UnitType> trunc(const UnitType x) noexcept
 	{
 		return detail::floating_point_promotion_t<UnitType>(std::trunc(x()));
@@ -3737,7 +3738,7 @@ namespace units
 	 * @param[in]	x	value to round.
 	 * @returns		The value of x rounded to the nearest integral.
 	 */
-	template<class UnitType, class = std::enable_if_t<traits::is_unit_v<UnitType>>>
+	template<class UnitType, std::enable_if_t<traits::is_unit_v<UnitType>, int> = 0>
 	detail::floating_point_promotion_t<UnitType> round(const UnitType x) noexcept
 	{
 		return detail::floating_point_promotion_t<UnitType>(std::round(x()));
@@ -3757,7 +3758,7 @@ namespace units
 	 * @returns		value with the magnitude and dimension of x, and the sign of y.
 	 */
 	template<class UnitTypeLhs, class UnitTypeRhs,
-		class = std::enable_if_t<traits::is_unit_v<UnitTypeLhs> && traits::is_unit_v<UnitTypeRhs>>>
+		std::enable_if_t<traits::is_unit_v<UnitTypeLhs> && traits::is_unit_v<UnitTypeRhs>, int> = 0>
 	detail::floating_point_promotion_t<UnitTypeLhs> copysign(const UnitTypeLhs x, const UnitTypeRhs y) noexcept
 	{
 		return detail::floating_point_promotion_t<UnitTypeLhs>(
@@ -3766,7 +3767,7 @@ namespace units
 
 	/// Overload to copy the sign from a raw double
 	template<class UnitTypeLhs, typename T,
-		class = std::enable_if_t<std::is_arithmetic_v<T> && traits::is_unit_v<UnitTypeLhs>>>
+		std::enable_if_t<std::is_arithmetic_v<T> && traits::is_unit_v<UnitTypeLhs>, int> = 0>
 	detail::floating_point_promotion_t<UnitTypeLhs> copysign(const UnitTypeLhs x, const T& y) noexcept
 	{
 		return detail::floating_point_promotion_t<UnitTypeLhs>(std::copysign(x(), y));
@@ -3785,8 +3786,9 @@ namespace units
 	 * @returns		The positive difference between x and y.
 	 */
 	template<class UnitTypeLhs, class UnitTypeRhs,
-		class = std::enable_if_t<traits::is_unit_v<UnitTypeLhs> && traits::is_unit_v<UnitTypeRhs> &&
-			traits::is_convertible_unit_v<UnitTypeLhs, UnitTypeRhs>>>
+		std::enable_if_t<traits::is_unit_v<UnitTypeLhs> && traits::is_unit_v<UnitTypeRhs> &&
+				traits::is_convertible_unit_v<UnitTypeLhs, UnitTypeRhs>,
+			int> = 0>
 	detail::floating_point_promotion_t<std::common_type_t<UnitTypeLhs, UnitTypeRhs>> fdim(
 		const UnitTypeLhs x, const UnitTypeRhs y) noexcept
 	{
@@ -3803,8 +3805,9 @@ namespace units
 	 * @returns		The maximum numeric value of its arguments.
 	 */
 	template<class UnitTypeLhs, class UnitTypeRhs,
-		class = std::enable_if_t<traits::is_unit_v<UnitTypeLhs> && traits::is_unit_v<UnitTypeRhs> &&
-			traits::is_convertible_unit_v<UnitTypeLhs, UnitTypeRhs>>>
+		std::enable_if_t<traits::is_unit_v<UnitTypeLhs> && traits::is_unit_v<UnitTypeRhs> &&
+				traits::is_convertible_unit_v<UnitTypeLhs, UnitTypeRhs>,
+			int> = 0>
 	detail::floating_point_promotion_t<std::common_type_t<UnitTypeLhs, UnitTypeRhs>> fmax(
 		const UnitTypeLhs x, const UnitTypeRhs y) noexcept
 	{
@@ -3822,8 +3825,9 @@ namespace units
 	 * @returns		The minimum numeric value of its arguments.
 	 */
 	template<class UnitTypeLhs, class UnitTypeRhs,
-		class = std::enable_if_t<traits::is_unit_v<UnitTypeLhs> && traits::is_unit_v<UnitTypeRhs> &&
-			traits::is_convertible_unit_v<UnitTypeLhs, UnitTypeRhs>>>
+		std::enable_if_t<traits::is_unit_v<UnitTypeLhs> && traits::is_unit_v<UnitTypeRhs> &&
+				traits::is_convertible_unit_v<UnitTypeLhs, UnitTypeRhs>,
+			int> = 0>
 	detail::floating_point_promotion_t<std::common_type_t<UnitTypeLhs, UnitTypeRhs>> fmin(
 		const UnitTypeLhs x, const UnitTypeRhs y) noexcept
 	{
@@ -3842,7 +3846,7 @@ namespace units
 	 * @param[in]	x	Value whose absolute value is returned.
 	 * @returns		The absolute value of x.
 	 */
-	template<class UnitType, class = std::enable_if_t<traits::is_unit_v<UnitType>>>
+	template<class UnitType, std::enable_if_t<traits::is_unit_v<UnitType>, int> = 0>
 	detail::floating_point_promotion_t<UnitType> fabs(const UnitType x) noexcept
 	{
 		return detail::floating_point_promotion_t<UnitType>(std::fabs(x()));
@@ -3855,7 +3859,7 @@ namespace units
 	 * @param[in]	x	Value whose absolute value is returned.
 	 * @returns		The absolute value of x.
 	 */
-	template<class UnitType, class = std::enable_if_t<traits::is_unit_v<UnitType>>>
+	template<class UnitType, std::enable_if_t<traits::is_unit_v<UnitType>, int> = 0>
 	UnitType abs(const UnitType x) noexcept
 	{
 		return UnitType(std::abs(x()));
@@ -3872,12 +3876,13 @@ namespace units
 	 * @returns		The result of x*y+z
 	 */
 	template<class UnitTypeLhs, class UnitMultiply, class UnitAdd,
-		class = std::enable_if_t<traits::is_unit_v<UnitTypeLhs> && traits::is_unit_v<UnitMultiply> &&
-			traits::is_unit_v<UnitAdd> &&
-			traits::is_convertible_conversion_factor_v<
-				compound_conversion_factor<typename units::traits::unit_traits<UnitTypeLhs>::conversion_factor,
-					typename units::traits::unit_traits<UnitMultiply>::conversion_factor>,
-				typename units::traits::unit_traits<UnitAdd>::conversion_factor>>>
+		std::enable_if_t<traits::is_unit_v<UnitTypeLhs> && traits::is_unit_v<UnitMultiply> &&
+				traits::is_unit_v<UnitAdd> &&
+				traits::is_convertible_conversion_factor_v<
+					compound_conversion_factor<typename units::traits::unit_traits<UnitTypeLhs>::conversion_factor,
+						typename units::traits::unit_traits<UnitMultiply>::conversion_factor>,
+					typename units::traits::unit_traits<UnitAdd>::conversion_factor>,
+			int> = 0>
 	auto fma(const UnitTypeLhs x, const UnitMultiply y, const UnitAdd z) noexcept
 		-> std::common_type_t<decltype(detail::floating_point_promotion_t<UnitTypeLhs>(x) *
 								  detail::floating_point_promotion_t<UnitMultiply>(y)),

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -2148,9 +2148,9 @@ namespace units
 		 * @details		enable implicit conversions from T types ONLY for linear dimensionless units
 		 * @param[in]	value value of the unit
 		 */
-		template<class Ty,
-			std::enable_if_t<traits::is_dimensionless_unit<UnitType>::value && detail::is_non_lossy_convertible<Ty, T>,
-				int> = 0>
+		template<class Ty, class Cf = UnitType,
+			std::enable_if_t<traits::is_dimensionless_unit<Cf>::value && detail::is_non_lossy_convertible<Ty, T>, int> =
+				0>
 		constexpr unit(const Ty value) noexcept : nls(value)
 		{
 		}
@@ -2192,9 +2192,9 @@ namespace units
 		 * @details		performs implicit conversions from built-in types ONLY for dimensionless units
 		 * @param[in]	rhs value to copy.
 		 */
-		template<class Ty,
-			std::enable_if_t<traits::is_dimensionless_unit<UnitType>::value && detail::is_non_lossy_convertible<Ty, T>,
-				int> = 0>
+		template<class Ty, class Cf = UnitType,
+			std::enable_if_t<traits::is_dimensionless_unit<Cf>::value && detail::is_non_lossy_convertible<Ty, T>, int> =
+				0>
 		constexpr unit& operator=(const Ty& rhs) noexcept
 		{
 			nls::m_value = rhs;


### PR DESCRIPTION
Prefer `std::enable_if_t<..., int> = 0`
to `class = std::enable_if_t<...>`
as it works more generally.