### PR TITLE
Documentation improvements

### DIFF
--- a/include/units/core.h
+++ b/include/units/core.h
@@ -691,7 +691,7 @@ namespace units
 	} // namespace traits
 
 	//------------------------------
-	//	UNIT TRAITS
+	//	CONVERSION FACTOR TRAITS
 	//------------------------------
 
 	/**
@@ -1107,7 +1107,7 @@ namespace units
 	}                                                                      // namespace dimension
 
 	//------------------------------
-	//	UNIT CLASSES
+	//	CONVERSION FACTOR CLASSES
 	//------------------------------
 
 	/** @cond */ // DOXYGEN IGNORE
@@ -2118,7 +2118,7 @@ namespace units
 	} // namespace traits
 
 	//------------------------------
-	//	UNIT_T TYPE TRAITS
+	//	UNIT TYPE TRAITS
 	//------------------------------
 
 	namespace traits
@@ -2689,7 +2689,7 @@ namespace units
 	};
 
 	//------------------------------
-	//	UNIT_T NON-MEMBER FUNCTIONS
+	//	UNIT NON-MEMBER FUNCTIONS
 	//------------------------------
 
 	/**
@@ -2832,7 +2832,7 @@ namespace std
 namespace units
 {
 	//----------------------------------------
-	//	UNIT_T COMPOUND ASSIGNMENT OPERATORS
+	//	UNIT COMPOUND ASSIGNMENT OPERATORS
 	//----------------------------------------
 
 	/** @cond */ // DOXYGEN IGNORE
@@ -2895,7 +2895,7 @@ namespace units
 	}
 
 	//------------------------------
-	//	UNIT_T UNARY OPERATORS
+	//	UNIT UNARY OPERATORS
 	//------------------------------
 
 	// unary addition: +T

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -3222,8 +3222,7 @@ namespace units
 		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>
 	operator*(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using CommonUnit       = decltype(lhs * rhs);
-		using CommonUnderlying = typename CommonUnit::underlying_type;
+		using CommonUnit = decltype(lhs * rhs);
 		// the cast makes sure factors of PI are handled as expected
 		return CommonUnit(CommonUnit(lhs)() * static_cast<typename CommonUnit::underlying_type>(rhs));
 	}
@@ -3237,8 +3236,7 @@ namespace units
 		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>
 	operator*(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using CommonUnit       = decltype(lhs * rhs);
-		using CommonUnderlying = typename CommonUnit::underlying_type;
+		using CommonUnit = decltype(lhs * rhs);
 		// the cast makes sure factors of PI are handled as expected
 		return CommonUnit(static_cast<typename CommonUnit::underlying_type>(lhs) * CommonUnit(rhs)());
 	}

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -3574,7 +3574,7 @@ namespace units
 	//------------------------------
 
 	/**
-	 * @brief		namespace for unit types and containers for units that have no dimension (dimensionless units)
+	 * @brief		dimensionless unit with decibel scale
 	 * @sa			See unit for more information on unit type containers.
 	 */
 	UNIT_ADD_SCALED_UNIT_DEFINITION(dB_t, ::units::decibel_scale, dimensionless_unit)

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -3690,10 +3690,10 @@ namespace units
 	/**
 	 * @namespace	units::literals
 	 * @brief		namespace for unit literal definitions of all categories.
-	 * @details		Literals allow for declaring unit types using suffix values. For example, a type
-	 *				of `meter_t<double>(6.2)` could be declared as `6.2_m`. All literals use an underscore
+	 * @details		Literals allow using unit values by suffixing numbers. For example, a value
+	 *				of `meter_t<double>(6.2)` could be used as `6.2_m`. All literals use an underscore
 	 *				followed by the abbreviation for the unit. To enable literal syntax in your code,
-	 *				include the statement `using namespace units::literals`.
+	 *				include the statement `using namespace units::literals;`.
 	 * @anchor		unitLiterals
 	 * @sa			See unit for more information on unit type containers.
 	 */

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -1351,7 +1351,7 @@ namespace units
 		/**
 		 * @brief		implementation of `unit_multiply`.
 		 * @details		multiplies two units. The dimension becomes the dimensions of each with their exponents
-		 *				added together. The conversion factors of each are multiplied by each other. Pi exponent ratios
+		 *				added. The conversion factors of each are multiplied. Pi exponent ratios
 		 *				are added, and datum translations are removed.
 		 */
 		template<class Unit1, class Unit2>
@@ -1374,7 +1374,7 @@ namespace units
 		/**
 		 * @brief		implementation of `unit_divide`.
 		 * @details		divides two units. The dimension becomes the dimensions of each with their exponents
-		 *				subtracted from each other. The conversion factors of each are divided by each other. Pi
+		 *				subtracted. The conversion factors of each are divided. Pi
 		 *				exponent ratios are subtracted, and datum translations are removed.
 		 */
 		template<class Unit1, class Unit2>

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -2316,64 +2316,65 @@ namespace units
 
 	/**
 	 * @ingroup		UnitTypes
-	 * @brief		Container for values which represent quantities of a given unit.
-	 * @details		Stores a value which represents a quantity in the given units. Unit containers
-	 *				(except dimensionless values) are *not* convertible to built-in c++ types, in order to
-	 *				provide type safety in dimensional analysis. Unit containers *are* implicitly
-	 *				convertible to other compatible unit container types. Unit containers support
-	 *				various types of arithmetic operations, depending on their scale type.
+	 * @brief		Describes objects that represent quantities of a given unit.
+	 * @details		Stores a value which represents a quantity in the given units. Units
+	 *				(except dimensionless units) are *not* convertible to arithmetic types, in order to
+	 *				provide type safety in dimensional analysis. Units *are* implicitly
+	 *				convertible to other units types of the same dimension, if such conversion is lossless.
+	 *				Units support various types of arithmetic operations, depending on their scale type.
 	 *
-	 *				The value of a `unit` can only be changed on construction, or by assignment
+	 *				The value of an `unit` can only be set on construction, or changed by assignment
 	 *				from another `unit` type. If necessary, the underlying value can be accessed
 	 *				using `operator()`: @code
 	 *				meter_t m(5.0);
 	 *				double val = m(); // val == 5.0	@endcode.
-	 * @tparam		UnitConversion unit tag for which type of units the `conversion_factor` represents (e.g. meters)
-	 * @tparam		T underlying type of the storage. Defaults to double.
+	 * @tparam		ConversionFactor `conversion_factor` of the represented unit (e.g. meters)
+	 * @tparam		T underlying type of the storage. Defaults to `UNIT_LIB_DEFAULT_TYPE`.
 	 * @tparam		NumericalScale optional scale class for the units. Defaults to linear (i.e. does
 	 *				not scale the unit value). Examples of non-linear scales could be logarithmic,
 	 *				decibel, or richter scales. Numerical scales must adhere to the numerical-scale
 	 *				concept, i.e. `is_numerical_scale_v<...>` must be `true`.
 	 * @sa
-	 *				- \ref lengthContainers "length unit containers"
-	 *				- \ref massContainers "mass unit containers"
-	 *				- \ref timeContainers "time unit containers"
-	 *				- \ref angleContainers "angle unit containers"
-	 *				- \ref currentContainers "current unit containers"
-	 *				- \ref temperatureContainers "temperature unit containers"
-	 *				- \ref substanceContainers "substance unit containers"
-	 *				- \ref luminousIntensityContainers "luminous intensity unit containers"
-	 *				- \ref solidAngleContainers "solid angle unit containers"
-	 *				- \ref frequencyContainers "frequency unit containers"
-	 *				- \ref velocityContainers "velocity unit containers"
-	 *				- \ref angularVelocityContainers "angular velocity unit containers"
-	 *				- \ref accelerationContainers "acceleration unit containers"
-	 *				- \ref forceContainers "force unit containers"
-	 *				- \ref pressureContainers "pressure unit containers"
-	 *				- \ref chargeContainers "charge unit containers"
-	 *				- \ref energyContainers "energy unit containers"
-	 *				- \ref powerContainers "power unit containers"
-	 *				- \ref voltageContainers "voltage unit containers"
-	 *				- \ref capacitanceContainers "capacitance unit containers"
-	 *				- \ref impedanceContainers "impedance unit containers"
-	 *				- \ref magneticFluxContainers "magnetic flux unit containers"
-	 *				- \ref magneticFieldStrengthContainers "magnetic field strength unit containers"
-	 *				- \ref inductanceContainers "inductance unit containers"
-	 *				- \ref luminousFluxContainers "luminous flux unit containers"
-	 *				- \ref illuminanceContainers "illuminance unit containers"
-	 *				- \ref radiationContainers "radiation unit containers"
-	 *				- \ref torqueContainers "torque unit containers"
-	 *				- \ref areaContainers "area unit containers"
-	 *				- \ref volumeContainers "volume unit containers"
-	 *				- \ref densityContainers "density unit containers"
-	 *				- \ref concentrationContainers "concentration unit containers"
-	 *				- \ref constantContainers "constant unit containers"
+	 *				- \ref lengthUnits "length units"
+	 *				- \ref massUnits "mass units"
+	 *				- \ref timeUnits "time units"
+	 *				- \ref angleUnits "angle units"
+	 *				- \ref currentUnits "current units"
+	 *				- \ref temperatureUnits "temperature units"
+	 *				- \ref substanceUnits "substance units"
+	 *				- \ref luminousIntensityUnits "luminous intensity units"
+	 *				- \ref solidAngleUnits "solid angle units"
+	 *				- \ref frequencyUnits "frequency units"
+	 *				- \ref velocityUnits "velocity units"
+	 *				- \ref angularVelocityUnits "angular velocity units"
+	 *				- \ref accelerationUnits "acceleration units"
+	 *				- \ref forceUnits "force units"
+	 *				- \ref pressureUnits "pressure units"
+	 *				- \ref chargeUnits "charge units"
+	 *				- \ref energyUnits "energy units"
+	 *				- \ref powerUnits "power units"
+	 *				- \ref voltageUnits "voltage units"
+	 *				- \ref capacitanceUnits "capacitance units"
+	 *				- \ref impedanceUnits "impedance units"
+	 *				- \ref magneticFluxUnits "magnetic flux units"
+	 *				- \ref magneticFieldStrengthUnits "magnetic field strength units"
+	 *				- \ref inductanceUnits "inductance units"
+	 *				- \ref luminousFluxUnits "luminous flux units"
+	 *				- \ref illuminanceUnits "illuminance units"
+	 *				- \ref radiationUnits "radiation units"
+	 *				- \ref torqueUnits "torque units"
+	 *				- \ref areaUnits "area units"
+	 *				- \ref volumeUnits "volume units"
+	 *				- \ref densityUnits "density units"
+	 *				- \ref concentrationUnits "concentration units"
+	 *				- \ref constantUnits "constant units"
 	 */
-	template<class UnitType, typename T = UNIT_LIB_DEFAULT_TYPE, class NumericalScale = linear_scale>
+	template<class ConversionFactor, typename T = UNIT_LIB_DEFAULT_TYPE, class NumericalScale = linear_scale>
 	class unit : NumericalScale, units::detail::_unit
 	{
-		static_assert(traits::is_conversion_factor_v<UnitType>,
-			"Template parameter `UnitType` must be a unit tag. Check that you aren't using a unit type (_t).");
+		static_assert(traits::is_conversion_factor_v<ConversionFactor>,
+			"Template parameter `ConversionFactor` must be a conversion factor. Check that you aren't using an unit "
+			"type (_t).");
 		static_assert(traits::is_numerical_scale_v<NumericalScale, T>,
 			"Template parameter `NumericalScale` does not conform to the `is_numerical_scale` concept.");
 
@@ -2382,7 +2383,7 @@ namespace units
 		using underlying_type      = T;              ///< Type of the underlying storage of the unit (e.g. double)
 		using value_type =
 			T; ///< Synonym for underlying type. May be removed in future versions. Prefer underlying_type.
-		using conversion_factor = UnitType; ///< Type of `unit` the `unit` represents (e.g. meters)
+		using conversion_factor = ConversionFactor; ///< Type of `conversion_factor` the `unit` represents (e.g. meters)
 
 		/**
 		 * @ingroup		Constructors
@@ -2401,7 +2402,7 @@ namespace units
 		 * @details		constructs a new unit with `value`.
 		 * @param[in]	value	unit magnitude.
 		 */
-		template<class Ty, class Cf = UnitType,
+		template<class Ty, class Cf = ConversionFactor,
 			std::enable_if_t<!traits::is_dimensionless_unit<Cf>::value && detail::is_losslessly_convertible<Ty, T>,
 				int> = 0>
 		explicit constexpr unit(const Ty value) noexcept
@@ -2424,7 +2425,7 @@ namespace units
 		 * @details		enable implicit conversions from T types ONLY for linear dimensionless units
 		 * @param[in]	value value of the unit
 		 */
-		template<class Ty, class Cf = UnitType,
+		template<class Ty, class Cf = ConversionFactor,
 			std::enable_if_t<traits::is_dimensionless_unit<Cf>::value && detail::is_losslessly_convertible<Ty, T>,
 				int> = 0>
 		constexpr unit(const Ty value) noexcept : linearized_value(NumericalScale::linearize(static_cast<T>(value)))
@@ -2436,8 +2437,8 @@ namespace units
 		 * @details		enable implicit conversions from std::chrono::duration types ONLY for time units
 		 * @param[in]	value value of the unit
 		 */
-		template<class Rep, class Period, typename U = UnitType,
-			std::enable_if_t<detail::is_time_conversion_factor<U> && detail::is_losslessly_convertible<Rep, T>, int> =
+		template<class Rep, class Period, typename Cf = ConversionFactor,
+			std::enable_if_t<detail::is_time_conversion_factor<Cf> && detail::is_losslessly_convertible<Rep, T>, int> =
 				0>
 		constexpr unit(const std::chrono::duration<Rep, Period>& value) noexcept
 		  : linearized_value(NumericalScale::linearize(units::convert<unit>(
@@ -2450,9 +2451,10 @@ namespace units
 		 * @details		performs implicit unit conversions if required.
 		 * @param[in]	rhs unit to copy.
 		 */
-		template<class UnitTypeRhs, typename Ty, class NsRhs,
-			std::enable_if_t<detail::is_losslessly_convertible_unit<unit<UnitTypeRhs, Ty, NsRhs>, unit>, int> = 0>
-		constexpr unit(const unit<UnitTypeRhs, Ty, NsRhs>& rhs) noexcept
+		template<class ConversionFactorRhs, typename Ty, class NsRhs,
+			std::enable_if_t<detail::is_losslessly_convertible_unit<unit<ConversionFactorRhs, Ty, NsRhs>, unit>, int> =
+				0>
+		constexpr unit(const unit<ConversionFactorRhs, Ty, NsRhs>& rhs) noexcept
 		  : linearized_value(units::convert<unit>(rhs).linearized_value)
 		{
 		}
@@ -2469,7 +2471,7 @@ namespace units
 		 * @details		performs implicit conversions from built-in types ONLY for dimensionless units
 		 * @param[in]	rhs value to copy.
 		 */
-		template<class Cf = UnitType, class = std::enable_if_t<traits::is_dimensionless_unit<Cf>::value>>
+		template<class Cf = ConversionFactor, class = std::enable_if_t<traits::is_dimensionless_unit<Cf>::value>>
 		constexpr unit& operator=(const underlying_type& rhs) noexcept
 		{
 			linearized_value = rhs;
@@ -2482,10 +2484,10 @@ namespace units
 		 * @param[in]	rhs right-hand side unit for the comparison
 		 * @returns		true IFF the value of `this` is less than the value of `rhs`
 		 */
-		template<class UnitTypeRhs, typename Ty, class NsRhs>
-		constexpr bool operator<(const unit<UnitTypeRhs, Ty, NsRhs>& rhs) const noexcept
+		template<class ConversionFactorRhs, typename Ty, class NsRhs>
+		constexpr bool operator<(const unit<ConversionFactorRhs, Ty, NsRhs>& rhs) const noexcept
 		{
-			using CommonUnit = std::common_type_t<unit, unit<UnitTypeRhs, Ty, NsRhs>>;
+			using CommonUnit = std::common_type_t<unit, unit<ConversionFactorRhs, Ty, NsRhs>>;
 			return (CommonUnit(*this).linearized_value < CommonUnit(rhs).linearized_value);
 		}
 
@@ -2495,10 +2497,10 @@ namespace units
 		 * @param[in]	rhs right-hand side unit for the comparison
 		 * @returns		true IFF the value of `this` is less than or equal to the value of `rhs`
 		 */
-		template<class UnitTypeRhs, typename Ty, class NsRhs>
-		constexpr bool operator<=(const unit<UnitTypeRhs, Ty, NsRhs>& rhs) const noexcept
+		template<class ConversionFactorRhs, typename Ty, class NsRhs>
+		constexpr bool operator<=(const unit<ConversionFactorRhs, Ty, NsRhs>& rhs) const noexcept
 		{
-			using CommonUnit = std::common_type_t<unit, unit<UnitTypeRhs, Ty, NsRhs>>;
+			using CommonUnit = std::common_type_t<unit, unit<ConversionFactorRhs, Ty, NsRhs>>;
 			return (CommonUnit(*this).linearized_value <= CommonUnit(rhs).linearized_value);
 		}
 
@@ -2508,10 +2510,10 @@ namespace units
 		 * @param[in]	rhs right-hand side unit for the comparison
 		 * @returns		true IFF the value of `this` is greater than the value of `rhs`
 		 */
-		template<class UnitTypeRhs, typename Ty, class NsRhs>
-		constexpr bool operator>(const unit<UnitTypeRhs, Ty, NsRhs>& rhs) const noexcept
+		template<class ConversionFactorRhs, typename Ty, class NsRhs>
+		constexpr bool operator>(const unit<ConversionFactorRhs, Ty, NsRhs>& rhs) const noexcept
 		{
-			using CommonUnit = std::common_type_t<unit, unit<UnitTypeRhs, Ty, NsRhs>>;
+			using CommonUnit = std::common_type_t<unit, unit<ConversionFactorRhs, Ty, NsRhs>>;
 			return (CommonUnit(*this).linearized_value > CommonUnit(rhs).linearized_value);
 		}
 
@@ -2521,10 +2523,10 @@ namespace units
 		 * @param[in]	rhs right-hand side unit for the comparison
 		 * @returns		true IFF the value of `this` is greater than or equal to the value of `rhs`
 		 */
-		template<class UnitTypeRhs, typename Ty, class NsRhs>
-		constexpr bool operator>=(const unit<UnitTypeRhs, Ty, NsRhs>& rhs) const noexcept
+		template<class ConversionFactorRhs, typename Ty, class NsRhs>
+		constexpr bool operator>=(const unit<ConversionFactorRhs, Ty, NsRhs>& rhs) const noexcept
 		{
-			using CommonUnit = std::common_type_t<unit, unit<UnitTypeRhs, Ty, NsRhs>>;
+			using CommonUnit = std::common_type_t<unit, unit<ConversionFactorRhs, Ty, NsRhs>>;
 			return (CommonUnit(*this).linearized_value >= CommonUnit(rhs).linearized_value);
 		}
 
@@ -2535,11 +2537,11 @@ namespace units
 		 * @returns		true IFF the value of `this` exactly equal to the value of rhs.
 		 * @note		This may not be suitable for all applications when the underlying_type of unit is a double.
 		 */
-		template<class UnitTypeRhs, typename Ty, class NsRhs>
+		template<class ConversionFactorRhs, typename Ty, class NsRhs>
 		constexpr std::enable_if_t<std::is_floating_point_v<T> || std::is_floating_point_v<Ty>, bool> operator==(
-			const unit<UnitTypeRhs, Ty, NsRhs>& rhs) const noexcept
+			const unit<ConversionFactorRhs, Ty, NsRhs>& rhs) const noexcept
 		{
-			using CommonUnit       = std::common_type_t<unit, unit<UnitTypeRhs, Ty, NsRhs>>;
+			using CommonUnit       = std::common_type_t<unit, unit<ConversionFactorRhs, Ty, NsRhs>>;
 			using CommonUnderlying = typename CommonUnit::underlying_type;
 
 			const auto common_lhs(CommonUnit(*this).linearized_value);
@@ -2550,11 +2552,11 @@ namespace units
 				abs(common_lhs - common_rhs) < std::numeric_limits<CommonUnderlying>::min();
 		}
 
-		template<class UnitTypeRhs, typename Ty, class NsRhs>
+		template<class ConversionFactorRhs, typename Ty, class NsRhs>
 		constexpr std::enable_if_t<std::is_integral<T>::value && std::is_integral<Ty>::value, bool> operator==(
-			const unit<UnitTypeRhs, Ty, NsRhs>& rhs) const noexcept
+			const unit<ConversionFactorRhs, Ty, NsRhs>& rhs) const noexcept
 		{
-			using CommonUnit = std::common_type_t<unit, unit<UnitTypeRhs, Ty, NsRhs>>;
+			using CommonUnit = std::common_type_t<unit, unit<ConversionFactorRhs, Ty, NsRhs>>;
 			return CommonUnit(*this).linearized_value == CommonUnit(rhs).linearized_value;
 		}
 
@@ -2565,8 +2567,8 @@ namespace units
 		 * @returns		true IFF the value of `this` is not equal to the value of rhs.
 		 * @note		This may not be suitable for all applications when the underlying_type of unit is a double.
 		 */
-		template<class UnitTypeRhs, typename Ty, class NsRhs>
-		constexpr bool operator!=(const unit<UnitTypeRhs, Ty, NsRhs>& rhs) const noexcept
+		template<class ConversionFactorRhs, typename Ty, class NsRhs>
+		constexpr bool operator!=(const unit<ConversionFactorRhs, Ty, NsRhs>& rhs) const noexcept
 		{
 			return !(*this == rhs);
 		}
@@ -2611,27 +2613,28 @@ namespace units
 
 		/**
 		 * @brief		conversion
-		 * @details		Converts to a different unit container. UnitType can be converted to other containers
-		 *				implicitly, but this can be used in cases where explicit notation of a conversion
-		 *				is beneficial, or where an r-value container is needed.
-		 * @tparam		U unit (not unit) to convert to
-		 * @tparam		Ty underlying type to convert to
-		 * @returns		a unit container with the specified units containing the equivalent value to
+		 * @details		Converts to a different unit. Units can be converted to other units
+		 *				implicitly, but this can be used in cases where the explicit notation of a conversion
+		 *				is beneficial, or where an prvalue unit is needed.
+		 * @tparam		Cf conversion factor of the unit to convert to
+		 * @tparam		Ty underlying type of the unit to convert to
+		 * @returns		a unit with the specified parameters containing the equivalent value to
 		 *				*this.
 		 */
-		template<class U, typename Ty = T>
-		constexpr unit<U, Ty> convert() const noexcept
+		template<class Cf, typename Ty = T>
+		constexpr unit<Cf, Ty> convert() const noexcept
 		{
-			static_assert(traits::is_conversion_factor_v<U>, "Template parameter `U` must be a unit tag type.");
-			return unit<U, Ty>(*this);
+			static_assert(traits::is_conversion_factor_v<Cf>, "Template parameter `Cf` must be a conversion factor.");
+			return unit<Cf, Ty>(*this);
 		}
 
 		/**
-		 * @brief		implicit type conversion.
+		 * @brief		implicit type unsafe conversion.
 		 * @details		only enabled for dimensionless unit types.
 		 */
 		template<class Ty,
-			std::enable_if_t<traits::is_dimensionless_unit<UnitType>::value && std::is_arithmetic<Ty>::value, int> = 0>
+			std::enable_if_t<traits::is_dimensionless_unit<ConversionFactor>::value && std::is_arithmetic<Ty>::value,
+				int> = 0>
 		constexpr operator Ty() const noexcept
 		{
 			// this conversion also resolves any PI exponents, by converting from a non-zero PI ratio to a zero-pi
@@ -2641,11 +2644,12 @@ namespace units
 		}
 
 		/**
-		 * @brief		explicit type conversion.
+		 * @brief		explicit type unsafe conversion.
 		 * @details		only enabled for non-dimensionless unit types.
 		 */
 		template<class Ty,
-			std::enable_if_t<!traits::is_dimensionless_unit<UnitType>::value && std::is_arithmetic<Ty>::value, int> = 0>
+			std::enable_if_t<!traits::is_dimensionless_unit<ConversionFactor>::value && std::is_arithmetic<Ty>::value,
+				int> = 0>
 		constexpr explicit operator Ty() const noexcept
 		{
 			return static_cast<Ty>((*this)());
@@ -2655,8 +2659,8 @@ namespace units
 		 * @brief		chrono implicit type conversion.
 		 * @details		only enabled for time unit types.
 		 */
-		template<class Rep, class Period, typename U = UnitType,
-			std::enable_if_t<detail::is_time_conversion_factor<U> && detail::is_losslessly_convertible<T, Rep>, int> =
+		template<class Rep, class Period, typename Cf = ConversionFactor,
+			std::enable_if_t<detail::is_time_conversion_factor<Cf> && detail::is_losslessly_convertible<T, Rep>, int> =
 				0>
 		constexpr operator std::chrono::duration<Rep, Period>() const noexcept
 		{
@@ -2683,7 +2687,7 @@ namespace units
 		}
 
 	private:
-		template<class U, typename Ty, class Ns>
+		template<class Cf, typename Ty, class Ns>
 		friend class unit;
 
 		T linearized_value;

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -1397,7 +1397,7 @@ namespace units
 
 		/**
 		 * @brief		implementation of `inverse`
-		 * @details		inverts a unit (equivalent to 1/unit). The `dimension` and pi exponents are all multiplied by
+		 * @details		inverts a unit (equivalent to 1/unit). The `dimension_t` and pi exponents are all multiplied by
 		 *				-1. The conversion ratio numerator and denominator are swapped. Datum translation
 		 *				ratios are removed.
 		 */
@@ -1429,7 +1429,7 @@ namespace units
 	{
 		/**
 		 * @brief		implementation of `squared`
-		 * @details		Squares the conversion ratio, `dimension` exponents, pi exponents, and removes
+		 * @details		Squares the conversion ratio, `dimension_t` exponents, pi exponents, and removes
 		 *				datum translation ratios.
 		 */
 		template<class Unit>

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -3386,11 +3386,11 @@ namespace units
 	//	DIMENSIONLESS COMPARISONS
 	//----------------------------------
 
-	template<typename UnitConversion, typename T>
-	constexpr std::enable_if_t<units::traits::is_dimensionless_unit_v<UnitConversion> && std::is_arithmetic_v<T>, bool>
-	operator==(const T& lhs, const UnitConversion& rhs) noexcept
+	template<typename DimensionlessUnit, typename T>
+	constexpr std::enable_if_t<traits::is_dimensionless_unit_v<DimensionlessUnit> && std::is_arithmetic_v<T>, bool>
+	operator==(const T& lhs, const DimensionlessUnit& rhs) noexcept
 	{
-		using CommonUnderlying = std::common_type_t<T, typename UnitConversion::underlying_type>;
+		using CommonUnderlying = std::common_type_t<T, typename DimensionlessUnit::underlying_type>;
 
 		const auto common_lhs = static_cast<CommonUnderlying>(lhs);
 		const auto common_rhs = static_cast<CommonUnderlying>(rhs);
@@ -3407,88 +3407,88 @@ namespace units
 		}
 	}
 
-	template<typename UnitConversion, typename T>
-	constexpr std::enable_if_t<units::traits::is_dimensionless_unit_v<UnitConversion> && std::is_arithmetic_v<T>, bool>
-	operator==(const UnitConversion& lhs, const T& rhs) noexcept
+	template<typename DimensionlessUnit, typename T>
+	constexpr std::enable_if_t<traits::is_dimensionless_unit_v<DimensionlessUnit> && std::is_arithmetic_v<T>, bool>
+	operator==(const DimensionlessUnit& lhs, const T& rhs) noexcept
 	{
 		return rhs == lhs;
 	}
 
-	template<typename UnitConversion, typename T>
-	constexpr std::enable_if_t<units::traits::is_dimensionless_unit_v<UnitConversion> && std::is_arithmetic_v<T>, bool>
-	operator!=(const T& lhs, const UnitConversion& rhs) noexcept
+	template<typename DimensionlessUnit, typename T>
+	constexpr std::enable_if_t<traits::is_dimensionless_unit_v<DimensionlessUnit> && std::is_arithmetic_v<T>, bool>
+	operator!=(const T& lhs, const DimensionlessUnit& rhs) noexcept
 	{
 		return !(lhs == rhs);
 	}
 
-	template<typename UnitConversion, typename T>
-	constexpr std::enable_if_t<units::traits::is_dimensionless_unit_v<UnitConversion> && std::is_arithmetic_v<T>, bool>
-	operator!=(const UnitConversion& lhs, const T& rhs) noexcept
+	template<typename DimensionlessUnit, typename T>
+	constexpr std::enable_if_t<traits::is_dimensionless_unit_v<DimensionlessUnit> && std::is_arithmetic_v<T>, bool>
+	operator!=(const DimensionlessUnit& lhs, const T& rhs) noexcept
 	{
 		return !(lhs == rhs);
 	}
 
-	template<typename UnitConversion, typename T>
-	constexpr std::enable_if_t<units::traits::is_dimensionless_unit_v<UnitConversion> && std::is_arithmetic_v<T>, bool>
-	operator>=(const T& lhs, const UnitConversion& rhs) noexcept
+	template<typename DimensionlessUnit, typename T>
+	constexpr std::enable_if_t<traits::is_dimensionless_unit_v<DimensionlessUnit> && std::is_arithmetic_v<T>, bool>
+	operator>=(const T& lhs, const DimensionlessUnit& rhs) noexcept
 	{
-		using CommonUnderlying = std::common_type_t<T, typename UnitConversion::underlying_type>;
+		using CommonUnderlying = std::common_type_t<T, typename DimensionlessUnit::underlying_type>;
 		return lhs >= static_cast<CommonUnderlying>(rhs);
 	}
 
-	template<typename UnitConversion, typename T>
-	constexpr std::enable_if_t<units::traits::is_dimensionless_unit_v<UnitConversion> && std::is_arithmetic_v<T>, bool>
-	operator>=(const UnitConversion& lhs, const T& rhs) noexcept
+	template<typename DimensionlessUnit, typename T>
+	constexpr std::enable_if_t<traits::is_dimensionless_unit_v<DimensionlessUnit> && std::is_arithmetic_v<T>, bool>
+	operator>=(const DimensionlessUnit& lhs, const T& rhs) noexcept
 	{
-		using CommonUnderlying = std::common_type_t<typename UnitConversion::underlying_type, T>;
+		using CommonUnderlying = std::common_type_t<typename DimensionlessUnit::underlying_type, T>;
 		return static_cast<CommonUnderlying>(lhs) >= rhs;
 	}
 
-	template<typename UnitConversion, typename T>
-	constexpr std::enable_if_t<units::traits::is_dimensionless_unit_v<UnitConversion> && std::is_arithmetic_v<T>, bool>
-	operator>(const T& lhs, const UnitConversion& rhs) noexcept
+	template<typename DimensionlessUnit, typename T>
+	constexpr std::enable_if_t<traits::is_dimensionless_unit_v<DimensionlessUnit> && std::is_arithmetic_v<T>, bool>
+	operator>(const T& lhs, const DimensionlessUnit& rhs) noexcept
 	{
-		using CommonUnderlying = std::common_type_t<T, typename UnitConversion::underlying_type>;
+		using CommonUnderlying = std::common_type_t<T, typename DimensionlessUnit::underlying_type>;
 		return lhs > static_cast<CommonUnderlying>(rhs);
 	}
 
-	template<typename UnitConversion, typename T>
-	constexpr std::enable_if_t<units::traits::is_dimensionless_unit_v<UnitConversion> && std::is_arithmetic_v<T>, bool>
-	operator>(const UnitConversion& lhs, const T& rhs) noexcept
+	template<typename DimensionlessUnit, typename T>
+	constexpr std::enable_if_t<traits::is_dimensionless_unit_v<DimensionlessUnit> && std::is_arithmetic_v<T>, bool>
+	operator>(const DimensionlessUnit& lhs, const T& rhs) noexcept
 	{
-		using CommonUnderlying = std::common_type_t<typename UnitConversion::underlying_type, T>;
+		using CommonUnderlying = std::common_type_t<typename DimensionlessUnit::underlying_type, T>;
 		return static_cast<CommonUnderlying>(lhs) > rhs;
 	}
 
-	template<typename UnitConversion, typename T>
-	constexpr std::enable_if_t<units::traits::is_dimensionless_unit_v<UnitConversion> && std::is_arithmetic_v<T>, bool>
-	operator<=(const T& lhs, const UnitConversion& rhs) noexcept
+	template<typename DimensionlessUnit, typename T>
+	constexpr std::enable_if_t<traits::is_dimensionless_unit_v<DimensionlessUnit> && std::is_arithmetic_v<T>, bool>
+	operator<=(const T& lhs, const DimensionlessUnit& rhs) noexcept
 	{
-		using CommonUnderlying = std::common_type_t<T, typename UnitConversion::underlying_type>;
+		using CommonUnderlying = std::common_type_t<T, typename DimensionlessUnit::underlying_type>;
 		return lhs <= static_cast<CommonUnderlying>(rhs);
 	}
 
-	template<typename UnitConversion, typename T>
-	constexpr std::enable_if_t<units::traits::is_dimensionless_unit_v<UnitConversion> && std::is_arithmetic_v<T>, bool>
-	operator<=(const UnitConversion& lhs, const T& rhs) noexcept
+	template<typename DimensionlessUnit, typename T>
+	constexpr std::enable_if_t<traits::is_dimensionless_unit_v<DimensionlessUnit> && std::is_arithmetic_v<T>, bool>
+	operator<=(const DimensionlessUnit& lhs, const T& rhs) noexcept
 	{
-		using CommonUnderlying = std::common_type_t<typename UnitConversion::underlying_type, T>;
+		using CommonUnderlying = std::common_type_t<typename DimensionlessUnit::underlying_type, T>;
 		return static_cast<CommonUnderlying>(lhs) <= rhs;
 	}
 
-	template<typename UnitConversion, typename T>
-	constexpr std::enable_if_t<units::traits::is_dimensionless_unit_v<UnitConversion> && std::is_arithmetic_v<T>, bool>
-	operator<(const T& lhs, const UnitConversion& rhs) noexcept
+	template<typename DimensionlessUnit, typename T>
+	constexpr std::enable_if_t<traits::is_dimensionless_unit_v<DimensionlessUnit> && std::is_arithmetic_v<T>, bool>
+	operator<(const T& lhs, const DimensionlessUnit& rhs) noexcept
 	{
-		using CommonUnderlying = std::common_type_t<T, typename UnitConversion::underlying_type>;
+		using CommonUnderlying = std::common_type_t<T, typename DimensionlessUnit::underlying_type>;
 		return lhs < static_cast<CommonUnderlying>(rhs);
 	}
 
-	template<typename UnitConversion, typename T>
-	constexpr std::enable_if_t<units::traits::is_dimensionless_unit_v<UnitConversion> && std::is_arithmetic_v<T>, bool>
-	operator<(const UnitConversion& lhs, const T& rhs) noexcept
+	template<typename DimensionlessUnit, typename T>
+	constexpr std::enable_if_t<traits::is_dimensionless_unit_v<DimensionlessUnit> && std::is_arithmetic_v<T>, bool>
+	operator<(const DimensionlessUnit& lhs, const T& rhs) noexcept
 	{
-		using CommonUnderlying = std::common_type_t<typename UnitConversion::underlying_type, T>;
+		using CommonUnderlying = std::common_type_t<typename DimensionlessUnit::underlying_type, T>;
 		return static_cast<CommonUnderlying>(lhs) < rhs;
 	}
 

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -1300,25 +1300,26 @@ namespace units
 	} // namespace traits
 
 	/**
-	 * @brief		Type representing an arbitrary unit.
+	 * @brief		Type representing an arbitrary conversion factor between units.
 	 * @ingroup		ConversionFactor
-	 * @details		`conversion_factor` types are used as tags for the `conversion` function. They are *not* containers
-	 *				(see `unit` for a  container class). Each unit is defined by:
+	 * @details		`conversion_factor`s are used as tags for the `convert` function.
+	 *				Each unit is defined by:
 	 *
 	 *				- A `std::ratio` defining the conversion factor to the dimension type. (e.g. `std::ratio<1,12>` for
 	 *					inches to feet)
 	 *				- A dimension that the unit is derived from (or a unit dimension. Must be of type
-	 *				`conversion_factor` or `dimension`)
+	 *				`conversion_factor` or `dimension_t`)
 	 *				- An exponent representing factors of PI required by the conversion. (e.g. `std::ratio<-1>` for a
 	 *					radians to degrees conversion)
 	 *				- a ratio representing a datum translation required for the conversion (e.g. `std::ratio<32>` for a
 	 *					farenheit to celsius conversion)
 	 *
-	 *				Typically, a specific unit, like `meters`, would be implemented as a type alias
-	 *				of `conversion_factor`, i.e. `using meters = conversion_factor<std::ratio<1>,
-	 *				units::dimension::length>`, or `using inches = conversion_factor<std::ratio<1,12>, feet>`.
+	 *				Typically, a specific conversion factor, like `meters`,
+	 *				would be implemented as a strong type alias of `conversion_factor`, i.e.
+	 *				`struct meters : conversion_factor<std::ratio<1>, units::dimension::length> {};`,
+	 *				or type alias, i.e. `using inches = conversion_factor<std::ratio<1,12>, feet>`.
 	 * @tparam		Conversion	std::ratio representing dimensionless multiplication factor.
-	 * @tparam		BaseUnit	Unit type which this unit is derived from. May be a `dimension`, or another
+	 * @tparam		BaseUnit	Unit type which this unit is derived from. May be a `dimension_t`, or another
 	 *				`conversion_factor`.
 	 * @tparam		PiExponent	std::ratio representing the exponent of pi required by the conversion.
 	 * @tparam		Translation	std::ratio representing any datum translation required by the conversion.

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -2957,20 +2957,21 @@ namespace units
 
 	/**
 	 * @ingroup		Conversion
-	 * @brief		Casts a unit container to an arithmetic type.
-	 * @details		unit_cast can be used to remove the strong typing from a unit class, and convert it
-	 *				to a built-in arithmetic type. This may be useful for compatibility with libraries
+	 * @brief		Casts an unit to an arithmetic type.
+	 * @details		unit_cast can be used to remove the strong typing from an unit class, and convert it
+	 *				to an arithmetic type. This may be useful for compatibility with libraries
 	 *				and legacy code that don't support `unit` types. E.g
 	 * @code		meter_t unitVal(5);
 	 *				double value = units::unit_cast<double>(unitVal);	// value == 5.0
 	 * @endcode
-	 * @tparam		T		Type to cast the unit type to. Must be a built-in arithmetic type.
+	 * @tparam		T		Type to cast the unit type to. Shall be an arithmetic type.
+	 * @tparam		UnitType	Type of the unit to cast to.
 	 * @param		value	Unit value to cast.
 	 * @sa			unit::to
 	 */
-	template<typename T, typename UnitConversion>
-	constexpr std::enable_if_t<std::is_arithmetic_v<T> && traits::is_unit_v<UnitConversion>, T> unit_cast(
-		const UnitConversion& value) noexcept
+	template<typename T, typename UnitType>
+	constexpr std::enable_if_t<std::is_arithmetic_v<T> && traits::is_unit_v<UnitType>, T> unit_cast(
+		const UnitType& value) noexcept
 	{
 		return static_cast<T>(value);
 	}

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -607,10 +607,10 @@ namespace units
 	 */
 
 	/**
-	 * @defgroup	UnitTypes Unit Types
-	 * @brief		Defines a series of classes which represent units. These types are tags used by
-	 *				the conversion function, to create compound units, or to create `unit` types.
-	 *				By themselves, they are not containers and have no stored value.
+	 * @defgroup	ConversionFactors Conversion Factors
+	 * @brief		Defines a series of classes which represent compile-time conversion factor between units.
+	 *				These types are tags used by the conversion function, to create compound units,
+	 *				or to create `unit` types.
 	 */
 
 	/**
@@ -1301,7 +1301,7 @@ namespace units
 
 	/**
 	 * @brief		Type representing an arbitrary unit.
-	 * @ingroup		UnitTypes
+	 * @ingroup		ConversionFactor
 	 * @details		`conversion_factor` types are used as tags for the `conversion` function. They are *not* containers
 	 *				(see `unit` for a  container class). Each unit is defined by:
 	 *
@@ -1722,7 +1722,7 @@ namespace units
 	 *				`squared` are supported. E.g. to specify acceleration, on could create
 	 *				`using acceleration = compound_unit<length::meters, inverse<squared<seconds>>;`
 	 * @tparam		U...	units which, when multiplied together, form the desired compound unit.
-	 * @ingroup		UnitTypes
+	 * @ingroup		ConversionFactor
 	 */
 	template<class U, class... Us>
 	using compound_conversion_factor = typename units::detail::compound_impl<U, Us...>::type;

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -601,8 +601,8 @@ namespace units
 	//----------------------------------
 
 	/**
-	 * @defgroup	UnitContainers Unit Containers
-	 * @brief		Defines a series of classes which contain dimensioned values. Unit containers
+	 * @defgroup	UnitTypes Unit Types
+	 * @brief		Defines a series of classes which contain dimensioned values. Unit types
 	 *				store a value, and support various arithmetic operations.
 	 */
 
@@ -2316,7 +2316,7 @@ namespace units
 	} // namespace traits
 
 	/**
-	 * @ingroup		UnitContainers
+	 * @ingroup		UnitTypes
 	 * @brief		Container for values which represent quantities of a given unit.
 	 * @details		Stores a value which represents a quantity in the given units. Unit containers
 	 *				(except dimensionless values) are *not* convertible to built-in c++ types, in order to
@@ -2693,7 +2693,7 @@ namespace units
 	//------------------------------
 
 	/**
-	 * @ingroup		UnitContainers
+	 * @ingroup		UnitTypes
 	 * @brief		Constructs a unit container from an arithmetic type.
 	 * @details		make_unit can be used to construct a unit container from an arithmetic type, as an alternative to
 	 *				using the explicit constructor. Unlike the explicit constructor it forces the user to explicitly

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -1049,7 +1049,7 @@ TEST_F(UnitType, constructionFromArithmeticType)
 	EXPECT_EQ(1, f_dim());
 }
 
-TEST_F(UnitType, constructionFromUnitContainer)
+TEST_F(UnitType, constructionFromUnitType)
 {
 	const unit<meters, int> a_m(1);
 
@@ -1104,7 +1104,7 @@ TEST_F(UnitType, constructionFromUnitContainer)
 	EXPECT_EQ(1, g_dim());
 }
 
-TEST_F(UnitContainer, CTAD)
+TEST_F(UnitType, CTAD)
 {
 	// Default ctor
 	meter_t y_m;
@@ -1230,7 +1230,7 @@ TEST_F(UnitContainer, CTAD)
 	static_assert(std::is_same_v<std::remove_const_t<decltype(m_dim)>, dimensionless<double>>);
 }
 
-TEST_F(UnitContainer, assignmentFromArithmeticType)
+TEST_F(UnitType, assignmentFromArithmeticType)
 {
 	unit<dimensionless_unit, int> a_dim;
 	a_dim = 1;
@@ -1257,7 +1257,7 @@ TEST_F(UnitContainer, assignmentFromArithmeticType)
 	EXPECT_EQ(1, d_dim());
 }
 
-TEST_F(UnitType, assignmentFromUnitContainer)
+TEST_F(UnitType, assignmentFromUnitType)
 {
 	unit<meters, int> a_m(1);
 	a_m = +a_m;
@@ -1512,7 +1512,7 @@ TEST_F(UnitType, unitTypeMixedRelational)
 	EXPECT_TRUE(b_m >= a_f);
 }
 
-TEST_F(UnitContainer, unitTypeArithmeticOperatorReturnType)
+TEST_F(UnitType, unitTypeArithmeticOperatorReturnType)
 {
 	using dimless      = dimensionless<int>;
 	using dimless_base = traits::unit_base_t<dimless>;
@@ -1644,7 +1644,7 @@ TEST_F(UnitContainer, unitTypeArithmeticOperatorReturnType)
 	static_assert(std::is_same_v<meter_base, decltype(b_m % b_m)>);
 }
 
-TEST_F(UnitContainer, unitTypeAddition)
+TEST_F(UnitType, unitTypeAddition)
 {
 	// units
 	meter_t<double> a_m(1.0), c_m;

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -191,20 +191,20 @@ TEST_F(TypeTraits, unit_traits)
 	EXPECT_TRUE((std::is_same_v<double, traits::unit_traits<meter_t<double>>::value_type>));
 }
 
-TEST_F(TypeTraits, is_convertible_unit)
+TEST_F(TypeTraits, is_same_dimension)
 {
-	EXPECT_TRUE((traits::is_convertible_conversion_factor_v<meters, meters>));
-	EXPECT_TRUE((traits::is_convertible_conversion_factor_v<meters, astronomical_units>));
-	EXPECT_TRUE((traits::is_convertible_conversion_factor_v<meters, parsecs>));
+	EXPECT_TRUE((traits::is_same_dimension_v<meters, meters>));
+	EXPECT_TRUE((traits::is_same_dimension_v<meters, astronomical_units>));
+	EXPECT_TRUE((traits::is_same_dimension_v<meters, parsecs>));
 
-	EXPECT_TRUE((traits::is_convertible_conversion_factor_v<meters, meters>));
-	EXPECT_TRUE((traits::is_convertible_conversion_factor_v<astronomical_units, meters>));
-	EXPECT_TRUE((traits::is_convertible_conversion_factor_v<parsecs, meters>));
-	EXPECT_TRUE((traits::is_convertible_conversion_factor_v<years, weeks>));
+	EXPECT_TRUE((traits::is_same_dimension_v<meters, meters>));
+	EXPECT_TRUE((traits::is_same_dimension_v<astronomical_units, meters>));
+	EXPECT_TRUE((traits::is_same_dimension_v<parsecs, meters>));
+	EXPECT_TRUE((traits::is_same_dimension_v<years, weeks>));
 
-	EXPECT_FALSE((traits::is_convertible_conversion_factor_v<meters, seconds>));
-	EXPECT_FALSE((traits::is_convertible_conversion_factor_v<seconds, meters>));
-	EXPECT_FALSE((traits::is_convertible_conversion_factor_v<years, meters>));
+	EXPECT_FALSE((traits::is_same_dimension_v<meters, seconds>));
+	EXPECT_FALSE((traits::is_same_dimension_v<seconds, meters>));
+	EXPECT_FALSE((traits::is_same_dimension_v<years, meters>));
 }
 
 TEST_F(TypeTraits, inverse)

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -145,7 +145,7 @@ TEST_F(TypeTraits, is_conversion_factor)
 	EXPECT_FALSE(traits::is_conversion_factor_v<meter_t<double>>);
 }
 
-TEST_F(TypeTraits, is_unit_t)
+TEST_F(TypeTraits, is_unit)
 {
 	EXPECT_FALSE(traits::is_unit_v<std::ratio<1>>);
 	EXPECT_FALSE(traits::is_unit_v<double>);

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -56,11 +56,11 @@ namespace
 		void TearDown() override{};
 	};
 
-	class UnitConversion : public ::testing::Test
+	class ConversionFactor : public ::testing::Test
 	{
 	protected:
-		UnitConversion(){};
-		virtual ~UnitConversion(){};
+		ConversionFactor(){};
+		virtual ~ConversionFactor(){};
 		void SetUp() override{};
 		void TearDown() override{};
 	};
@@ -2894,7 +2894,7 @@ TEST_F(UnitType, literals)
 	EXPECT_TRUE(c == 5.0_m);
 }
 
-TEST_F(UnitConversion, length)
+TEST_F(ConversionFactor, length)
 {
 	double test;
 	test = nanometer_t<double>(0.000000001_m)();
@@ -2942,7 +2942,7 @@ TEST_F(UnitConversion, length)
 	EXPECT_EQ(metre_t<double>(1), meter_t<double>(1));
 }
 
-TEST_F(UnitConversion, mass)
+TEST_F(ConversionFactor, mass)
 {
 	double test;
 
@@ -2973,7 +2973,7 @@ TEST_F(UnitConversion, mass)
 	EXPECT_NEAR(14288.2, test, 5.0e-2);
 }
 
-TEST_F(UnitConversion, time)
+TEST_F(ConversionFactor, time)
 {
 	double result      = 0;
 	double daysPerYear = 365;
@@ -3021,7 +3021,7 @@ TEST_F(UnitConversion, time)
 	EXPECT_NEAR(365.2425, test, 5.0e-14);
 }
 
-TEST_F(UnitConversion, angle)
+TEST_F(ConversionFactor, angle)
 {
 	angle::degree_t<double> quarterCircleDeg(90.0);
 	angle::radian_t<double> quarterCircleRad = quarterCircleDeg;
@@ -3054,7 +3054,7 @@ TEST_F(UnitConversion, angle)
 	EXPECT_NEAR(detail::PI_VAL / 2, test, 5.0e-6);
 }
 
-TEST_F(UnitConversion, current)
+TEST_F(ConversionFactor, current)
 {
 	double test;
 
@@ -3062,7 +3062,7 @@ TEST_F(UnitConversion, current)
 	EXPECT_NEAR(2100.0, test, 5.0e-6);
 }
 
-TEST_F(UnitConversion, temperature)
+TEST_F(ConversionFactor, temperature)
 {
 	// temp conversion are weird/hard since they involve translations AND scaling.
 	double test;
@@ -3107,7 +3107,7 @@ TEST_F(UnitConversion, temperature)
 	EXPECT_NEAR(2.222, test, 5.0e-3);
 }
 
-TEST_F(UnitConversion, luminous_intensity)
+TEST_F(ConversionFactor, luminous_intensity)
 {
 	double test;
 
@@ -3117,13 +3117,13 @@ TEST_F(UnitConversion, luminous_intensity)
 	EXPECT_NEAR(0.376, test, 5.0e-5);
 }
 
-TEST_F(UnitConversion, substance)
+TEST_F(ConversionFactor, substance)
 {
 	static_assert(1_g / 1_mol == 1_g_per_mol);
 	static_assert(1_mol / 1_g == 1_M);
 }
 
-TEST_F(UnitConversion, solid_angle)
+TEST_F(ConversionFactor, solid_angle)
 {
 	double test;
 	bool same;
@@ -3151,7 +3151,7 @@ TEST_F(UnitConversion, solid_angle)
 	EXPECT_NEAR(72.0, test, 5.0e-5);
 }
 
-TEST_F(UnitConversion, frequency)
+TEST_F(ConversionFactor, frequency)
 {
 	double test;
 
@@ -3165,7 +3165,7 @@ TEST_F(UnitConversion, frequency)
 	EXPECT_NEAR(1.0e6, test, 5.0e-5);
 }
 
-TEST_F(UnitConversion, velocity)
+TEST_F(ConversionFactor, velocity)
 {
 	double test;
 	bool same;
@@ -3187,7 +3187,7 @@ TEST_F(UnitConversion, velocity)
 	EXPECT_NEAR(3.048, test, 5.0e-5);
 }
 
-TEST_F(UnitConversion, angular_velocity)
+TEST_F(ConversionFactor, angular_velocity)
 {
 	double test;
 	bool same;
@@ -3208,7 +3208,7 @@ TEST_F(UnitConversion, angular_velocity)
 	EXPECT_NEAR(1.537e-16, test, 5.0e-20);
 }
 
-TEST_F(UnitConversion, acceleration)
+TEST_F(ConversionFactor, acceleration)
 {
 	double test;
 
@@ -3216,7 +3216,7 @@ TEST_F(UnitConversion, acceleration)
 	EXPECT_NEAR(9.80665, test, 5.0e-10);
 }
 
-TEST_F(UnitConversion, force)
+TEST_F(ConversionFactor, force)
 {
 	double test;
 
@@ -3234,7 +3234,7 @@ TEST_F(UnitConversion, force)
 	EXPECT_NEAR(0.308451933, test, 5.0e-10);
 }
 
-TEST_F(UnitConversion, area)
+TEST_F(ConversionFactor, area)
 {
 	double test;
 
@@ -3250,7 +3250,7 @@ TEST_F(UnitConversion, area)
 	EXPECT_NEAR(10.7639, test, 5.0e-5);
 }
 
-TEST_F(UnitConversion, pressure)
+TEST_F(ConversionFactor, pressure)
 {
 	double test;
 
@@ -3278,7 +3278,7 @@ TEST_F(UnitConversion, pressure)
 	EXPECT_EQ(133.322387415_Pa, 1.0_mmHg);
 }
 
-TEST_F(UnitConversion, charge)
+TEST_F(ConversionFactor, charge)
 {
 	double test;
 
@@ -3288,7 +3288,7 @@ TEST_F(UnitConversion, charge)
 	EXPECT_NEAR(3600.0, test, 5.0e-6);
 }
 
-TEST_F(UnitConversion, energy)
+TEST_F(ConversionFactor, energy)
 {
 	double test;
 
@@ -3320,7 +3320,7 @@ TEST_F(UnitConversion, energy)
 	EXPECT_NEAR(0.396567, test, 5.0e-5);
 }
 
-TEST_F(UnitConversion, power)
+TEST_F(ConversionFactor, power)
 {
 	double test;
 
@@ -3340,7 +3340,7 @@ TEST_F(UnitConversion, power)
 	EXPECT_NEAR(0.001342363, test, 5.0e-9);
 }
 
-TEST_F(UnitConversion, voltage)
+TEST_F(ConversionFactor, voltage)
 {
 	double test;
 
@@ -3370,7 +3370,7 @@ TEST_F(UnitConversion, voltage)
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
-TEST_F(UnitConversion, capacitance)
+TEST_F(ConversionFactor, capacitance)
 {
 	double test;
 
@@ -3400,7 +3400,7 @@ TEST_F(UnitConversion, capacitance)
 	EXPECT_EQ(1.0_F, one_farad());
 }
 
-TEST_F(UnitConversion, impedance)
+TEST_F(ConversionFactor, impedance)
 {
 	double test;
 
@@ -3422,7 +3422,7 @@ TEST_F(UnitConversion, impedance)
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
-TEST_F(UnitConversion, conductance)
+TEST_F(ConversionFactor, conductance)
 {
 	double test;
 
@@ -3444,7 +3444,7 @@ TEST_F(UnitConversion, conductance)
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
-TEST_F(UnitConversion, magnetic_flux)
+TEST_F(ConversionFactor, magnetic_flux)
 {
 	double test;
 
@@ -3470,7 +3470,7 @@ TEST_F(UnitConversion, magnetic_flux)
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
-TEST_F(UnitConversion, magnetic_field_strength)
+TEST_F(ConversionFactor, magnetic_field_strength)
 {
 	double test;
 
@@ -3496,7 +3496,7 @@ TEST_F(UnitConversion, magnetic_field_strength)
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
-TEST_F(UnitConversion, inductance)
+TEST_F(ConversionFactor, inductance)
 {
 	double test;
 
@@ -3518,7 +3518,7 @@ TEST_F(UnitConversion, inductance)
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
-TEST_F(UnitConversion, luminous_flux)
+TEST_F(ConversionFactor, luminous_flux)
 {
 	double test;
 
@@ -3540,7 +3540,7 @@ TEST_F(UnitConversion, luminous_flux)
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
-TEST_F(UnitConversion, illuminance)
+TEST_F(ConversionFactor, illuminance)
 {
 	double test;
 
@@ -3569,7 +3569,7 @@ TEST_F(UnitConversion, illuminance)
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
-TEST_F(UnitConversion, radiation)
+TEST_F(ConversionFactor, radiation)
 {
 	double test;
 
@@ -3632,7 +3632,7 @@ TEST_F(UnitConversion, radiation)
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
-TEST_F(UnitConversion, torque)
+TEST_F(ConversionFactor, torque)
 {
 	double test;
 
@@ -3650,7 +3650,7 @@ TEST_F(UnitConversion, torque)
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 }
 
-TEST_F(UnitConversion, volume)
+TEST_F(ConversionFactor, volume)
 {
 	double test;
 
@@ -3718,7 +3718,7 @@ TEST_F(UnitConversion, volume)
 	EXPECT_NEAR(29.5735, test, 5.0e-5);
 }
 
-TEST_F(UnitConversion, density)
+TEST_F(ConversionFactor, density)
 {
 	double test;
 
@@ -3744,7 +3744,7 @@ TEST_F(UnitConversion, density)
 	EXPECT_NEAR(515.3788184, test, 5.0e-6);
 }
 
-TEST_F(UnitConversion, concentration)
+TEST_F(ConversionFactor, concentration)
 {
 	double test;
 
@@ -3758,7 +3758,7 @@ TEST_F(UnitConversion, concentration)
 	EXPECT_NEAR(0.18, test, 5.0e-12);
 }
 
-TEST_F(UnitConversion, data)
+TEST_F(ConversionFactor, data)
 {
 	EXPECT_EQ(8, (bit_t<double>(byte_t<double>(1))()));
 
@@ -3801,7 +3801,7 @@ TEST_F(UnitConversion, data)
 	EXPECT_NEAR(percent_t<double>(15.3), exbibyte_t<double>(1) / exabyte_t<double>(1) - 1, 0.005);
 }
 
-TEST_F(UnitConversion, data_transfer_rate)
+TEST_F(ConversionFactor, data_transfer_rate)
 {
 	EXPECT_EQ(8, (bits_per_second_t<double>(bytes_per_second_t<double>(1))()));
 
@@ -3850,7 +3850,7 @@ TEST_F(UnitConversion, data_transfer_rate)
 		percent_t<double>(15.3), exbibytes_per_second_t<double>(1) / exabytes_per_second_t<double>(1) - 1, 0.005);
 }
 
-TEST_F(UnitConversion, pi)
+TEST_F(ConversionFactor, pi)
 {
 	EXPECT_TRUE(units::traits::is_dimensionless_unit_v<decltype(constants::pi)>);
 	EXPECT_TRUE(units::traits::is_dimensionless_unit_v<detail::PI>);
@@ -3901,7 +3901,7 @@ TEST_F(UnitConversion, pi)
 	EXPECT_NEAR(1.0 / detail::PI_VAL, d.to<double>(), 5.0e-10);
 }
 
-TEST_F(UnitConversion, constants)
+TEST_F(ConversionFactor, constants)
 {
 	// Source: NIST "2014 CODATA recommended values"
 	EXPECT_NEAR(299792458, constants::c(), 5.0e-9);
@@ -3922,7 +3922,7 @@ TEST_F(UnitConversion, constants)
 	EXPECT_NEAR(5.670367e-8, constants::sigma(), 5.0e-14);
 }
 
-TEST_F(UnitConversion, std_chrono)
+TEST_F(ConversionFactor, std_chrono)
 {
 	nanosecond_t<double> a = std::chrono::nanoseconds(10);
 	EXPECT_EQ(nanosecond_t<double>(10), a);
@@ -3951,7 +3951,7 @@ TEST_F(UnitConversion, std_chrono)
 	EXPECT_EQ(std::chrono::duration_cast<std::chrono::nanoseconds>(l).count(), 3600000000000);
 }
 
-TEST_F(UnitConversion, squaredTemperature)
+TEST_F(ConversionFactor, squaredTemperature)
 {
 	using squared_celsius   = units::compound_conversion_factor<squared<celsius>>;
 	using squared_celsius_t = units::unit<squared_celsius>;

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -47,11 +47,11 @@ namespace
 		void TearDown() override{};
 	};
 
-	class UnitContainer : public ::testing::Test
+	class UnitType : public ::testing::Test
 	{
 	protected:
-		UnitContainer(){};
-		virtual ~UnitContainer(){};
+		UnitType(){};
+		virtual ~UnitType(){};
 		void SetUp() override{};
 		void TearDown() override{};
 	};
@@ -994,7 +994,7 @@ TEST_F(UnitManipulators, dimensionalAnalysis)
 	EXPECT_TRUE(shouldBeTrue);
 }
 
-TEST_F(UnitContainer, trivial)
+TEST_F(UnitType, trivial)
 {
 	EXPECT_TRUE((std::is_trivial_v<meter_t<double>>));
 	EXPECT_TRUE((std::is_trivially_assignable_v<meter_t<double>, meter_t<double>>));
@@ -1019,7 +1019,7 @@ TEST_F(UnitContainer, trivial)
 	EXPECT_TRUE((std::is_trivially_move_constructible_v<dB_t<double>>));
 }
 
-TEST_F(UnitContainer, constructionFromArithmeticType)
+TEST_F(UnitType, constructionFromArithmeticType)
 {
 	const meter_t<double> a_m(1.0);
 	EXPECT_EQ(1.0, a_m());
@@ -1049,7 +1049,7 @@ TEST_F(UnitContainer, constructionFromArithmeticType)
 	EXPECT_EQ(1, f_dim());
 }
 
-TEST_F(UnitContainer, constructionFromUnitContainer)
+TEST_F(UnitType, constructionFromUnitContainer)
 {
 	const unit<meters, int> a_m(1);
 
@@ -1257,7 +1257,7 @@ TEST_F(UnitContainer, assignmentFromArithmeticType)
 	EXPECT_EQ(1, d_dim());
 }
 
-TEST_F(UnitContainer, assignmentFromUnitContainer)
+TEST_F(UnitType, assignmentFromUnitContainer)
 {
 	unit<meters, int> a_m(1);
 	a_m = +a_m;
@@ -1314,7 +1314,7 @@ TEST_F(UnitContainer, assignmentFromUnitContainer)
 	EXPECT_EQ(1, c_dim());
 }
 
-TEST_F(UnitContainer, make_unit)
+TEST_F(UnitType, make_unit)
 {
 	const auto a_m = make_unit<meter_t<double>>(5.0);
 	EXPECT_EQ(meter_t<double>(5.0), a_m);
@@ -1335,7 +1335,7 @@ TEST_F(UnitContainer, make_unit)
 	EXPECT_EQ((unit<dimensionless_unit, int>(5)), c_dim);
 }
 
-TEST_F(UnitContainer, unitTypeEquality)
+TEST_F(UnitType, unitTypeEquality)
 {
 	const meter_t<double> a_m(0);
 	const meter_t<double> b_m(1);
@@ -1363,7 +1363,7 @@ TEST_F(UnitContainer, unitTypeEquality)
 	EXPECT_FALSE(d_m != b_m);
 }
 
-TEST_F(UnitContainer, unitTypeMixedEquality)
+TEST_F(UnitType, unitTypeMixedEquality)
 {
 	const meter_t<double> a_m(0);
 	const foot_t<double> a_f(meter_t<double>(1));
@@ -1383,7 +1383,7 @@ TEST_F(UnitContainer, unitTypeMixedEquality)
 	EXPECT_FALSE(b_m != a_f);
 }
 
-TEST_F(UnitContainer, unitTypeRelational)
+TEST_F(UnitType, unitTypeRelational)
 {
 	const meter_t<double> a_m(0);
 	const meter_t<double> b_m(1);
@@ -1476,7 +1476,7 @@ TEST_F(UnitContainer, unitTypeRelational)
 	EXPECT_FALSE(a_s >= d_s);
 }
 
-TEST_F(UnitContainer, unitTypeMixedRelational)
+TEST_F(UnitType, unitTypeMixedRelational)
 {
 	const meter_t<double> a_m(0);
 	const foot_t<double> a_f(meter_t<double>(1));
@@ -1740,7 +1740,7 @@ TEST_F(UnitContainer, unitTypeAddition)
 	EXPECT_NEAR(2.0, d, 5.0e-6);
 }
 
-TEST_F(UnitContainer, unitTypeUnaryAddition)
+TEST_F(UnitType, unitTypeUnaryAddition)
 {
 	meter_t<double> a_m(1.0);
 
@@ -1759,7 +1759,7 @@ TEST_F(UnitContainer, unitTypeUnaryAddition)
 	EXPECT_EQ(b_dBW, dBW_t<double>(3));
 }
 
-TEST_F(UnitContainer, unitTypeSubtraction)
+TEST_F(UnitType, unitTypeSubtraction)
 {
 	meter_t<double> a_m(1.0), c_m;
 	foot_t<double> b_ft(3.28084);
@@ -1848,7 +1848,7 @@ TEST_F(UnitContainer, unitTypeSubtraction)
 	EXPECT_NEAR(0.0, d, 5.0e-6);
 }
 
-TEST_F(UnitContainer, unitTypeUnarySubtraction)
+TEST_F(UnitType, unitTypeUnarySubtraction)
 {
 	meter_t<double> a_m(4.0);
 
@@ -1867,7 +1867,7 @@ TEST_F(UnitContainer, unitTypeUnarySubtraction)
 	EXPECT_EQ(b_dBW, dBW_t<double>(2));
 }
 
-TEST_F(UnitContainer, unitTypeMultiplication)
+TEST_F(UnitType, unitTypeMultiplication)
 {
 	meter_t<double> a_m(1.0), b_m(2.0);
 	foot_t<double> a_ft(3.28084);
@@ -1979,7 +1979,7 @@ TEST_F(UnitContainer, unitTypeMultiplication)
 	EXPECT_NEAR(20.0, result, 5.0e-5);
 }
 
-TEST_F(UnitContainer, unitTypeMixedUnitMultiplication)
+TEST_F(UnitType, unitTypeMixedUnitMultiplication)
 {
 	meter_t<double> a_m(1.0);
 	foot_t<double> b_ft(3.28084);
@@ -2074,7 +2074,7 @@ TEST_F(UnitContainer, unitTypeMixedUnitMultiplication)
 	EXPECT_EQ(mps, meters_per_second_t<double>(10));
 }
 
-TEST_F(UnitContainer, unitTypedimensionlessMultiplication)
+TEST_F(UnitType, unitTypedimensionlessMultiplication)
 {
 	meter_t<double> a_m(1.0);
 
@@ -2094,7 +2094,7 @@ TEST_F(UnitContainer, unitTypedimensionlessMultiplication)
 	EXPECT_TRUE(isSame);
 }
 
-TEST_F(UnitContainer, unitTypeDivision)
+TEST_F(UnitType, unitTypeDivision)
 {
 	meter_t<double> a_m(1.0), b_m(2.0);
 	foot_t<double> a_ft(3.28084);
@@ -2228,7 +2228,7 @@ TEST_F(UnitContainer, unitTypeDivision)
 	EXPECT_TRUE(isSame);
 }
 
-TEST_F(UnitContainer, unitTypeModulo)
+TEST_F(UnitType, unitTypeModulo)
 {
 	const unit<meters, int> a_m(2200);
 	const unit<meters, int> b_m(1800);
@@ -2262,7 +2262,7 @@ TEST_F(UnitContainer, unitTypeModulo)
 	static_assert(has_equivalent_conversion_factor(d_s, a_s));
 }
 
-TEST_F(UnitContainer, compoundAssignmentAddition)
+TEST_F(UnitType, compoundAssignmentAddition)
 {
 	// units
 	meter_t<double> a(0.0);
@@ -2319,7 +2319,7 @@ TEST_F(UnitContainer, compoundAssignmentAddition)
 	EXPECT_EQ((unit<dimensionless_unit, int>(2)), d);
 }
 
-TEST_F(UnitContainer, compoundAssignmentSubtraction)
+TEST_F(UnitType, compoundAssignmentSubtraction)
 {
 	// units
 	meter_t<double> a(2.0);
@@ -2376,7 +2376,7 @@ TEST_F(UnitContainer, compoundAssignmentSubtraction)
 	EXPECT_EQ((unit<dimensionless_unit, int>(0)), d);
 }
 
-TEST_F(UnitContainer, compoundAssignmentMultiplication)
+TEST_F(UnitType, compoundAssignmentMultiplication)
 {
 	// units
 	meter_t<double> a(2.0);
@@ -2449,7 +2449,7 @@ TEST_F(UnitContainer, compoundAssignmentMultiplication)
 	EXPECT_EQ((unit<dimensionless_unit, int>(32)), d);
 }
 
-TEST_F(UnitContainer, compoundAssignmentDivision)
+TEST_F(UnitType, compoundAssignmentDivision)
 {
 	// units
 	meter_t<double> a(8.0);
@@ -2522,7 +2522,7 @@ TEST_F(UnitContainer, compoundAssignmentDivision)
 	EXPECT_EQ((unit<dimensionless_unit, int>(2)), d);
 }
 
-TEST_F(UnitContainer, compoundAssignmentModulo)
+TEST_F(UnitType, compoundAssignmentModulo)
 {
 	// units
 	unit<meters, int> a_m(2200);
@@ -2561,7 +2561,7 @@ TEST_F(UnitContainer, compoundAssignmentModulo)
 	EXPECT_EQ(2, a_s());
 }
 
-TEST_F(UnitContainer, dimensionlessTypeImplicitConversion)
+TEST_F(UnitType, dimensionlessTypeImplicitConversion)
 {
 	double test = dimensionless<double>(3.0);
 	EXPECT_DOUBLE_EQ(3.0, test);
@@ -2577,7 +2577,7 @@ TEST_F(UnitContainer, dimensionlessTypeImplicitConversion)
 	EXPECT_DOUBLE_EQ(0.000001, test4);
 }
 
-TEST_F(UnitContainer, valueMethod)
+TEST_F(UnitType, valueMethod)
 {
 	double test = meter_t<double>(3.0).to<double>();
 	EXPECT_DOUBLE_EQ(3.0, test);
@@ -2587,14 +2587,14 @@ TEST_F(UnitContainer, valueMethod)
 	EXPECT_TRUE((std::is_same_v<decltype(test2), double>));
 }
 
-TEST_F(UnitContainer, convertMethod)
+TEST_F(UnitType, convertMethod)
 {
 	double test = meter_t<double>(3.0).convert<feet>().to<double>();
 	EXPECT_NEAR(9.84252, test, 5.0e-6);
 }
 
 #ifndef UNIT_LIB_DISABLE_IOSTREAM
-TEST_F(UnitContainer, cout)
+TEST_F(UnitType, cout)
 {
 	testing::internal::CaptureStdout();
 	std::cout << meters_per_second_t<double>(5);
@@ -2669,7 +2669,7 @@ TEST_F(UnitContainer, cout)
 	EXPECT_STREQ("5.670367e-08 kg K^-4 s^-3", output.c_str());
 }
 
-TEST_F(UnitContainer, to_string)
+TEST_F(UnitType, to_string)
 {
 	foot_t<double> a(3.5);
 	EXPECT_STREQ("3.5 ft", units::length::to_string(a).c_str());
@@ -2678,7 +2678,7 @@ TEST_F(UnitContainer, to_string)
 	EXPECT_STREQ("8 m", units::length::to_string(b).c_str());
 }
 
-TEST_F(UnitContainer, to_string_locale)
+TEST_F(UnitType, to_string_locale)
 {
 	struct lconv* lc;
 
@@ -2717,7 +2717,7 @@ TEST_F(UnitContainer, to_string_locale)
 	EXPECT_STREQ("2.5 mi", units::length::to_string(us).c_str());
 }
 
-TEST_F(UnitContainer, nameAndAbbreviation)
+TEST_F(UnitType, nameAndAbbreviation)
 {
 	foot_t<double> a(3.5);
 	EXPECT_STREQ("ft", unit_abbreviation_v<decltype(a)>);
@@ -2731,7 +2731,7 @@ TEST_F(UnitContainer, nameAndAbbreviation)
 }
 #endif
 
-TEST_F(UnitContainer, negative)
+TEST_F(UnitType, negative)
 {
 	meter_t<double> a(5.3);
 	meter_t<double> b(-5.3);
@@ -2748,7 +2748,7 @@ TEST_F(UnitContainer, negative)
 	EXPECT_NEAR(-0.00001, e, 5.0e-10);
 }
 
-TEST_F(UnitContainer, concentration)
+TEST_F(UnitType, concentration)
 {
 	ppb_t<double> a(ppm_t<double>(1));
 	EXPECT_EQ(ppb_t<double>(1000), a);
@@ -2762,7 +2762,7 @@ TEST_F(UnitContainer, concentration)
 	EXPECT_EQ(0.000000001, c);
 }
 
-TEST_F(UnitContainer, dBConversion)
+TEST_F(UnitType, dBConversion)
 {
 	dBW_t<double> a_dbw(23.1);
 	watt_t<double> a_w  = a_dbw;
@@ -2781,7 +2781,7 @@ TEST_F(UnitContainer, dBConversion)
 	EXPECT_NEAR(20.0, b_dbw(), 5.0e-7);
 }
 
-TEST_F(UnitContainer, dBAddition)
+TEST_F(UnitType, dBAddition)
 {
 	bool isSame;
 
@@ -2810,7 +2810,7 @@ TEST_F(UnitContainer, dBAddition)
 	EXPECT_TRUE(isSame);
 }
 
-TEST_F(UnitContainer, dBSubtraction)
+TEST_F(UnitType, dBSubtraction)
 {
 	bool isSame;
 
@@ -2844,7 +2844,7 @@ TEST_F(UnitContainer, dBSubtraction)
 	EXPECT_TRUE(isSame);
 }
 
-TEST_F(UnitContainer, unit_cast)
+TEST_F(UnitType, unit_cast)
 {
 	meter_t<double> test1(5.7);
 	hectare_t<double> test2(16);
@@ -2863,7 +2863,7 @@ TEST_F(UnitContainer, unit_cast)
 }
 
 // literal syntax is only supported in GCC 4.7+ and MSVC2015+
-TEST_F(UnitContainer, literals)
+TEST_F(UnitType, literals)
 {
 	// basic functionality testing
 	EXPECT_TRUE((std::is_same_v<decltype(16.2_m), meter_t<double>>));
@@ -3025,8 +3025,7 @@ TEST_F(UnitConversion, angle)
 {
 	angle::degree_t<double> quarterCircleDeg(90.0);
 	angle::radian_t<double> quarterCircleRad = quarterCircleDeg;
-	EXPECT_NEAR(
-		angle::radian_t<double>(detail::PI_VAL / 2.0).to<double>(), quarterCircleRad.to<double>(), 5.0e-12);
+	EXPECT_NEAR(angle::radian_t<double>(detail::PI_VAL / 2.0).to<double>(), quarterCircleRad.to<double>(), 5.0e-12);
 
 	double test;
 


### PR DESCRIPTION
- Mostly removes uses of the word container in unit containers and updates code/comments based on `conversion_factor` renaming.
- Renames `is_convertible_conversion_factor` to `is_same_dimension` as per https://github.com/nholthaus/units/issues/185#issuecomment-423004260.
- ~~Adds `store_linear_value_t` tag type, as per https://github.com/nholthaus/units/issues/185#issuecomment-423350563. `unit` still forwards extra arguments to the scale, but `units`' scales now only know about `store_linear_value_t`~~.
