### PR TITLE
Simplify `unit::toLinearized`

### DIFF
--- a/include/units/core.h
+++ b/include/units/core.h
@@ -1816,9 +1816,8 @@ namespace units
 	template<class UnitTo, class UnitFrom, class = std::enable_if_t<detail::is_convertible_unit<UnitFrom, UnitTo>>>
 	constexpr UnitTo convert(const UnitFrom& from) noexcept
 	{
-		return UnitTo(
-			convert<typename UnitFrom::conversion_factor, typename UnitTo::conversion_factor,
-				typename UnitTo::underlying_type>(from.template toLinearized<typename UnitFrom::underlying_type>()),
+		return UnitTo(convert<typename UnitFrom::conversion_factor, typename UnitTo::conversion_factor,
+						  typename UnitTo::underlying_type>(from.toLinearized()),
 			std::true_type() /*store linear value*/);
 	}
 
@@ -2320,7 +2319,7 @@ namespace units
 		 * @returns		linearized value of unit which has a non-linear scale. For `unit` types with
 		 *				linear scales, this is equivalent to `value`.
 		 */
-		template<typename Ty, class = std::enable_if_t<std::is_arithmetic_v<Ty>>>
+		template<typename Ty = T, class = std::enable_if_t<std::is_arithmetic_v<Ty>>>
 		constexpr Ty toLinearized() const noexcept
 		{
 			return static_cast<Ty>(m_value);
@@ -3904,11 +3903,11 @@ namespace std
 		{
 			if constexpr (std::is_integral_v<U>)
 			{
-				return x.template toLinearized<T>();
+				return x.toLinearized();
 			}
 			else
 			{
-				return hash<T>()(x.template toLinearized<T>());
+				return hash<T>()(x.toLinearized());
 			}
 		}
 	};


### PR DESCRIPTION
By defaulting `units::toLinearized`'s return type to the unit's `underlying_type`, call sites that don't need something else get simpler.

What do you think about simplifying it further, so that it's not a template function? Changing `x.template toLinearized<Arithmetic>()` for `static_cast<Arithmetic>(x.toLinearized())` is, I believe, more clear on the intention and easier to read at call site.