### PR TITLE
Fix data transfer rate unit's dimension

### DIFF
--- a/include/units/core.h
+++ b/include/units/core.h
@@ -919,7 +919,7 @@ namespace units
 		using density            = dimension_divide<mass, volume>;         ///< Represents an SI derived unit of density
 		using concentration      = make_dimension<volume, std::ratio<-1>>; ///< Represents a unit of concentration
 		using data               = make_dimension<data_tag>;               ///< Represents a unit of data size
-		using data_transfer_rate = make_dimension<data, std::ratio<-1>>;   ///< Represents a unit of data transfer rate
+		using data_transfer_rate = dimension_divide<data, time>;           ///< Represents a unit of data transfer rate
 	}                                                                      // namespace dimension
 
 	//------------------------------

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -4101,6 +4101,29 @@ TEST_F(CaseStudies, rightTriangle)
 	EXPECT_EQ(5.0_m, c);
 }
 
+TEST_F(CaseStudies, dataReadSimulation)
+{
+	const megabyte_t<int> data_size             = 100_MB;
+	const megabytes_per_second_t<int> read_rate = 2_MBps;
+	byte_t<int> read_progress                   = 10_MB;
+
+	auto advance_simulation = [&](auto time) {
+		read_progress = units::min(read_progress + time * read_rate, data_size);
+	};
+
+	advance_simulation(10_s);
+	EXPECT_EQ(read_progress, 30_MB);
+
+	advance_simulation(25_s);
+	EXPECT_EQ(read_progress, 80_MB);
+
+	advance_simulation(500_ms);
+	EXPECT_EQ(read_progress, 81_MB);
+
+	advance_simulation(25_s);
+	EXPECT_EQ(read_progress, data_size);
+}
+
 TEST_F(CaseStudies, selfDefinedUnits)
 {
 	using liters_per_second  = decltype(1.0_L / 1.0_s);


### PR DESCRIPTION
I found it weird when I first read its declaration, as I'd expect it to be `dimension_divide<data, time>` and not `make_dimension<data, std::ratio<-1>>` like `frequency` is to `time`. Earlier, I finally tried to mix a data transfer unit with a time unit, and chaos ensued.