### PR TITLE
Setting Stefan-Botzman constant as a precalculated fixed value and a …

### DIFF
--- a/include/units.h
+++ b/include/units.h
@@ -4144,7 +4144,7 @@ namespace units
 		static constexpr const unit_t<compound_unit<energy::joules, inverse<temperature::kelvin>, inverse<substance::moles>>>						R(8.3144598);									///< Gas constant.
 		static constexpr const unit_t<compound_unit<energy::joules, inverse<temperature::kelvin>>>													k_B(R / N_A);									///< Boltzmann constant.
 		static constexpr const unit_t<compound_unit<charge::coulomb, inverse<substance::mol>>>														F(N_A * e);										///< Faraday constant.
-		static constexpr const unit_t<compound_unit<power::watts, inverse<area::square_meters>, inverse<squared<squared<temperature::kelvin>>>>>	sigma((2 * math::cpow<5>(pi) * math::cpow<4>(R)) / (15 * math::cpow<3>(h) * math::cpow<2>(c) * math::cpow<4>(N_A)));	///< Stefan-Boltzmann constant.
+		static constexpr const unit_t<compound_unit<power::watts, inverse<area::square_meters>, inverse<squared<squared<temperature::kelvin>>>>>	sigma(5.6703671313131313e-8);					///< Stefan-Boltzmann constant.
 		/** @} */
 	}
 #endif

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -46,3 +46,4 @@ if(GTAGS)
 endif(GTAGS)
 
 
+ADD_SUBDIRECTORY(floatTypeSupport)

--- a/unitTests/floatTypeSupport/CMakeLists.txt
+++ b/unitTests/floatTypeSupport/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Main concept of this test is a COMPILATION correctness test,
+# rather than functional check.
+
+PROJECT(unitLibTestFloat)
+
+SET(SOURCE_CODE 
+main.cpp
+)
+ADD_EXECUTABLE(${PROJECT_NAME} ${SOURCE_CODE})
+TARGET_LINK_LIBRARIES(${PROJECT_NAME} ${LIBRARIES})
+
+ADD_TEST(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/unitTests/floatTypeSupport/main.cpp
+++ b/unitTests/floatTypeSupport/main.cpp
@@ -1,0 +1,20 @@
+#include <iostream>
+#include <gtest/gtest.h>
+
+#define UNIT_LIB_DEFAULT_TYPE float
+#include <units.h>
+
+TEST(UnitsWithFloatType, is_truly_unit_4_bytes_long)
+{
+    using namespace units::literals;
+    using namespace units::length;
+
+    auto l = 10_m;
+    ASSERT_EQ(4, sizeof(l));
+}
+
+int main(int argc, char* argv[])
+{
+	::testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Even when #67 has been closed, here is a patch to improve how the library works with float as underlying unit type. Having single precision float as correctly supported type enables library to be usable for embedded systems, which is where I plan to use it.