### PR TITLE
Convert optimizations backport

### DIFF
--- a/include/units.h
+++ b/include/units.h
@@ -74,6 +74,7 @@
 //--------------------
 
 #include <chrono>
+#include <cstddef>
 #include <ratio>
 #include <type_traits>
 #include <cstdint>
@@ -1523,11 +1524,51 @@ namespace units
 			return value;
 		}
 
+		template<std::size_t Ratio_num, std::size_t Ratio_den>
+		struct normal_convert
+		{
+			template<typename T>
+			inline constexpr T operator()(const T& value) const noexcept
+			{
+				return value * Ratio_num / Ratio_den;
+			}
+		};
+
+		template<std::size_t Ratio_num>
+		struct normal_convert<Ratio_num, 1>
+		{
+			template<typename T>
+			inline constexpr T operator()(const T& value) const noexcept
+			{
+				return value * Ratio_num;
+			}
+		};
+
+		template<std::size_t Ratio_den>
+		struct normal_convert<1, Ratio_den>
+		{
+			template<typename T>
+			inline constexpr T operator()(const T& value) const noexcept
+			{
+				return value / Ratio_den;
+			}
+		};
+
+		template<>
+		struct normal_convert<1, 1>
+		{
+			template<typename T>
+			inline constexpr T operator()(const T& value) const noexcept
+			{
+				return value;
+			}
+		};
+
 		/// convert dispatch for units of different types w/ no translation and no PI
 		template<class Ratio, class PiRatio, class Translation, typename T>
 		static inline constexpr T convert(const T& value, std::false_type, std::false_type, std::false_type) noexcept
 		{
-			return ((value * Ratio::num) / Ratio::den);
+			return normal_convert<Ratio::num, Ratio::den>{}(value);
 		}
 
 		/// convert dispatch for units of different types w/ no translation, but has PI in numerator

--- a/include/units.h
+++ b/include/units.h
@@ -1647,7 +1647,7 @@ namespace units
 		using piRequired = std::integral_constant<bool, !(std::is_same<std::ratio<0>, PiRatio>::value)>;
 		using translationRequired = std::integral_constant<bool, !(std::is_same<std::ratio<0>, Translation>::value)>;
 
-		return units::detail::convert<Ratio, PiRatio, Translation, T>
+		return units::detail::convert<Ratio, PiRatio, Translation>
 			(value, isSame{}, piRequired{}, translationRequired{});
 	}
 

--- a/include/units.h
+++ b/include/units.h
@@ -1518,7 +1518,7 @@ namespace units
 		}
 
 		/// convert dispatch for units which are both the same
-		template<class Ratio, bool piRequired, bool translationRequired, typename T>
+		template<class Ratio, class PiRatio, class Translation, bool piRequired, bool translationRequired, typename T>
 		static inline constexpr T convert(const T& value, std::true_type, std::integral_constant<bool, piRequired>, std::integral_constant<bool, translationRequired>) noexcept
 		{
 			return value;

--- a/include/units.h
+++ b/include/units.h
@@ -1612,7 +1612,7 @@ namespace units
 		template<class Ratio, class PiRatio, class Translation, typename T>
 		static inline constexpr T convert(const T& value, std::false_type isSame, std::true_type piRequired, std::true_type) noexcept
 		{
-            return convert<Ratio, PiRatio, Translation>(value, isSame, piRequired, std::false_type()) + (static_cast<UNIT_LIB_DEFAULT_TYPE>(Translation::num) / Translation::den);
+			return convert<Ratio, PiRatio, Translation>(value, isSame, piRequired, std::false_type()) + (static_cast<UNIT_LIB_DEFAULT_TYPE>(Translation::num) / Translation::den);
 		}
 	}
 	/** @endcond */	// END DOXYGEN IGNORE

--- a/include/units.h
+++ b/include/units.h
@@ -1517,14 +1517,14 @@ namespace units
 		}
 
 		/// convert dispatch for units which are both the same
-		template<class UnitFrom, class UnitTo, class Ratio, bool piRequired, bool translationRequired, typename T>
+		template<class Ratio, bool piRequired, bool translationRequired, typename T>
 		static inline constexpr T convert(const T& value, std::true_type, std::integral_constant<bool, piRequired>, std::integral_constant<bool, translationRequired>) noexcept
 		{
 			return value;
 		}
 
 		/// convert dispatch for units of different types w/ no translation and no PI
-		template<class UnitFrom, class UnitTo, class Ratio, class PiRatio, class Translation, typename T>
+		template<class Ratio, class PiRatio, class Translation, typename T>
 		static inline constexpr T convert(const T& value, std::false_type, std::false_type, std::false_type) noexcept
 		{
 			return ((value * Ratio::num) / Ratio::den);
@@ -1532,7 +1532,7 @@ namespace units
 
 		/// convert dispatch for units of different types w/ no translation, but has PI in numerator
 		// constepxr with PI in numerator
-		template<class UnitFrom, class UnitTo, class Ratio, class PiRatio, class Translation, typename T>
+		template<class Ratio, class PiRatio, class Translation, typename T>
 		static inline constexpr
 		std::enable_if_t<(PiRatio::num / PiRatio::den >= 1 && PiRatio::num % PiRatio::den == 0), T>
 		convert(const T& value, std::false_type, std::true_type, std::false_type) noexcept
@@ -1542,7 +1542,7 @@ namespace units
 
 		/// convert dispatch for units of different types w/ no translation, but has PI in denominator
 		// constexpr with PI in denominator
-		template<class UnitFrom, class UnitTo, class Ratio, class PiRatio, class Translation, typename T>
+		template<class Ratio, class PiRatio, class Translation, typename T>
 		static inline constexpr
 		std::enable_if_t<(PiRatio::num / PiRatio::den <= -1 && PiRatio::num % PiRatio::den == 0), T>
  		convert(const T& value, std::false_type, std::true_type, std::false_type) noexcept
@@ -1552,7 +1552,7 @@ namespace units
 
 		/// convert dispatch for units of different types w/ no translation, but has PI in numerator
 		// Not constexpr - uses std::pow
-		template<class UnitFrom, class UnitTo, class Ratio, class PiRatio, class Translation, typename T>
+		template<class Ratio, class PiRatio, class Translation, typename T>
 		static inline // sorry, this can't be constexpr!
 		std::enable_if_t<(PiRatio::num / PiRatio::den < 1 && PiRatio::num / PiRatio::den > -1), T>
 		convert(const T& value, std::false_type, std::true_type, std::false_type) noexcept
@@ -1561,14 +1561,14 @@ namespace units
 		}
 
 		/// convert dispatch for units of different types with a translation, but no PI
-		template<class UnitFrom, class UnitTo, class Ratio, class PiRatio, class Translation, typename T>
+		template<class Ratio, class PiRatio, class Translation, typename T>
 		static inline constexpr T convert(const T& value, std::false_type, std::false_type, std::true_type) noexcept
 		{
 			return ((value * Ratio::num) / Ratio::den) + (static_cast<UNIT_LIB_DEFAULT_TYPE>(Translation::num) / Translation::den);
 		}
 
 		/// convert dispatch for units of different types with a translation AND PI
-		template<class UnitFrom, class UnitTo, class Ratio, class PiRatio, class Translation, typename T>
+		template<class Ratio, class PiRatio, class Translation, typename T>
 		static inline constexpr T convert(const T& value, const std::false_type, const std::true_type, const std::true_type) noexcept
 		{
 			return ((value * std::pow(constants::detail::PI_VAL, PiRatio::num / PiRatio::den) * Ratio::num) / Ratio::den) + (static_cast<UNIT_LIB_DEFAULT_TYPE>(Translation::num) / Translation::den);
@@ -1606,7 +1606,7 @@ namespace units
 		using piRequired = std::integral_constant<bool, !(std::is_same<std::ratio<0>, PiRatio>::value)>;
 		using translationRequired = std::integral_constant<bool, !(std::is_same<std::ratio<0>, Translation>::value)>;
 
-		return units::detail::convert<UnitFrom, UnitTo, Ratio, PiRatio, Translation, T>
+		return units::detail::convert<Ratio, PiRatio, Translation, T>
 			(value, isSame{}, piRequired{}, translationRequired{});
 	}
 

--- a/include/units.h
+++ b/include/units.h
@@ -1517,29 +1517,8 @@ namespace units
 		}
 
 		/// convert dispatch for units which are both the same
-		template<class UnitFrom, class UnitTo, class Ratio, class PiRatio, class Translation, typename T>
-		static inline constexpr T convert(const T& value, std::true_type, std::false_type, std::false_type) noexcept
-		{
-			return value;
-		}
-
-		/// convert dispatch for units which are both the same
-		template<class UnitFrom, class UnitTo, class Ratio, class PiRatio, class Translation, typename T>
-		static inline constexpr T convert(const T& value, std::true_type, std::false_type, std::true_type) noexcept
-		{
-			return value;
-		}
-
-		/// convert dispatch for units which are both the same
-		template<class UnitFrom, class UnitTo, class Ratio, class PiRatio, class Translation, typename T>
-		static inline constexpr T convert(const T& value, std::true_type, std::true_type, std::false_type) noexcept
-		{
-			return value;
-		}
-
-		/// convert dispatch for units which are both the same
-		template<class UnitFrom, class UnitTo, class Ratio, class PiRatio, class Translation, typename T>
-		static inline constexpr T convert(const T& value, std::true_type, std::true_type, std::true_type) noexcept
+		template<class UnitFrom, class UnitTo, class Ratio, bool piRequired, bool translationRequired, typename T>
+		static inline constexpr T convert(const T& value, std::true_type, std::integral_constant<bool, piRequired>, std::integral_constant<bool, translationRequired>) noexcept
 		{
 			return value;
 		}

--- a/include/units.h
+++ b/include/units.h
@@ -1610,9 +1610,9 @@ namespace units
 
 		/// convert dispatch for units of different types with a translation AND PI
 		template<class Ratio, class PiRatio, class Translation, typename T>
-		static inline constexpr T convert(const T& value, const std::false_type, const std::true_type, const std::true_type) noexcept
+		static inline constexpr T convert(const T& value, std::false_type isSame, std::true_type piRequired, std::true_type) noexcept
 		{
-			return ((value * std::pow(constants::detail::PI_VAL, PiRatio::num / PiRatio::den) * Ratio::num) / Ratio::den) + (static_cast<UNIT_LIB_DEFAULT_TYPE>(Translation::num) / Translation::den);
+            return convert<Ratio, PiRatio, Translation>(value, isSame, piRequired, std::false_type()) + (static_cast<UNIT_LIB_DEFAULT_TYPE>(Translation::num) / Translation::den);
 		}
 	}
 	/** @endcond */	// END DOXYGEN IGNORE

--- a/include/units.h
+++ b/include/units.h
@@ -1605,7 +1605,7 @@ namespace units
 		template<class Ratio, class PiRatio, class Translation, typename T>
 		static inline constexpr T convert(const T& value, std::false_type, std::false_type, std::true_type) noexcept
 		{
-			return ((value * Ratio::num) / Ratio::den) + (static_cast<UNIT_LIB_DEFAULT_TYPE>(Translation::num) / Translation::den);
+			return normal_convert<Ratio::num, Ratio::den>{}(value) + (static_cast<UNIT_LIB_DEFAULT_TYPE>(Translation::num) / Translation::den);
 		}
 
 		/// convert dispatch for units of different types with a translation AND PI

--- a/include/units.h
+++ b/include/units.h
@@ -1578,7 +1578,7 @@ namespace units
 		std::enable_if_t<(PiRatio::num / PiRatio::den >= 1 && PiRatio::num % PiRatio::den == 0), T>
 		convert(const T& value, std::false_type, std::true_type, std::false_type) noexcept
 		{
-			return ((value * pow(constants::detail::PI_VAL, PiRatio::num / PiRatio::den) * Ratio::num) / Ratio::den);
+			return normal_convert<Ratio::num, Ratio::den>{}(value) * pow(constants::detail::PI_VAL, PiRatio::num / PiRatio::den);
 		}
 
 		/// convert dispatch for units of different types w/ no translation, but has PI in denominator
@@ -1588,7 +1588,7 @@ namespace units
 		std::enable_if_t<(PiRatio::num / PiRatio::den <= -1 && PiRatio::num % PiRatio::den == 0), T>
  		convert(const T& value, std::false_type, std::true_type, std::false_type) noexcept
  		{
- 			return (value * Ratio::num) / (Ratio::den * pow(constants::detail::PI_VAL, -PiRatio::num / PiRatio::den));
+ 			return normal_convert<Ratio::num, Ratio::den>{}(value) / pow(constants::detail::PI_VAL, -PiRatio::num / PiRatio::den);
  		}
 
 		/// convert dispatch for units of different types w/ no translation, but has PI in numerator
@@ -1598,7 +1598,7 @@ namespace units
 		std::enable_if_t<(PiRatio::num / PiRatio::den < 1 && PiRatio::num / PiRatio::den > -1), T>
 		convert(const T& value, std::false_type, std::true_type, std::false_type) noexcept
 		{
-			return ((value * std::pow(constants::detail::PI_VAL, PiRatio::num / PiRatio::den)  * Ratio::num) / Ratio::den);
+			return normal_convert<Ratio::num, Ratio::den>{}(value) * std::pow(constants::detail::PI_VAL, PiRatio::num / PiRatio::den);
 		}
 
 		/// convert dispatch for units of different types with a translation, but no PI


### PR DESCRIPTION
I noticed that the constexpr Pi overloads (and branches for v3.x) don't assign the result of `pow` to a `constexpr` variable, which might result in the calls actually being performed at runtime for implementations less eager to do stuff at compile time.