### PR TITLE
Fix setting of permissive-

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ target_include_directories(${PROJECT_NAME}
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	# enable parallel build
 	set( ENV{CL} /MP )
-	target_compile_definitions(${PROJECT_NAME} INTERFACE "/permissive-")
+	target_compile_options(${PROJECT_NAME} INTERFACE /permissive-)
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 	# Increase warning levels
 	add_compile_options(-Wall -Wextra -pedantic)


### PR DESCRIPTION
The current `CMakeLists.txt` adds `"/permissive-"` as a `target_compile_definitions`. However it is a flag not a compile definition, see here https://docs.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=vs-2017