### PR TITLE
Make unarary ``operator+()`` and ``operator-()`` ``constexpr``

### DIFF
--- a/include/units.h
+++ b/include/units.h
@@ -2289,7 +2289,7 @@ namespace units
 
 	// unary addition: +T
 	template<class Units, typename T, template<typename> class NonLinearScale>
-	inline unit_t<Units, T, NonLinearScale> operator+(const unit_t<Units, T, NonLinearScale>& u) noexcept
+	constexpr inline unit_t<Units, T, NonLinearScale> operator+(const unit_t<Units, T, NonLinearScale>& u) noexcept
 	{
 		return u;
 	}
@@ -2313,7 +2313,7 @@ namespace units
 
 	// unary addition: -T
 	template<class Units, typename T, template<typename> class NonLinearScale>
-	inline unit_t<Units, T, NonLinearScale> operator-(const unit_t<Units, T, NonLinearScale>& u) noexcept
+	constexpr inline unit_t<Units, T, NonLinearScale> operator-(const unit_t<Units, T, NonLinearScale>& u) noexcept
 	{
 		return unit_t<Units, T, NonLinearScale>(-u());
 	}


### PR DESCRIPTION
These two functions can be safely marked ``constexpr``.

At present, if you try to write:
```
constexpr meter_t x = -1_m;
```
you get an error.

This PR fixes this.