### PR TITLE
Use `target_compile_options()` to add `/permissive-` flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ target_include_directories(${PROJECT_NAME}
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	# enable parallel build
 	set( ENV{CL} /MP )
-	target_compile_definitions(${PROJECT_NAME} INTERFACE "/permissive-")
+	target_compile_options(${PROJECT_NAME} INTERFACE "/permissive-")
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 	# Increase warning levels
 	add_compile_options(-Wall -Wextra -pedantic)


### PR DESCRIPTION
Previously used `target_compile_definitions()` added `-D/permissive-` flag instead.