### PR TITLE
revert: strong units

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ OPTION(BUILD_DOCS "Build the documentation" OFF)
 OPTION(DISABLE_IOSTREAM "Disables <iostream> (cout) support for embedded applications" OFF)
 
 SET(CMAKE_CXX_STANDARD_REQUIRED TRUE)
-SET(CMAKE_CXX_STANDARD 20)
+SET(CMAKE_CXX_STANDARD 17)
 
 # header-only library target. To use this project as a subdirectory,
 # add the following to your code:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ OPTION(BUILD_DOCS "Build the documentation" OFF)
 OPTION(DISABLE_IOSTREAM "Disables <iostream> (cout) support for embedded applications" OFF)
 
 SET(CMAKE_CXX_STANDARD_REQUIRED TRUE)
-SET(CMAKE_CXX_STANDARD 17)
+SET(CMAKE_CXX_STANDARD 20)
 
 # header-only library target. To use this project as a subdirectory,
 # add the following to your code:
@@ -18,9 +18,9 @@ SET(CMAKE_CXX_STANDARD 17)
 # target_link_libraries(${PROJECT_NAME} units)
 add_library(${PROJECT_NAME} INTERFACE)
 
-target_include_directories(${PROJECT_NAME} 
-	INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> 
-	$<INSTALL_INTERFACE:include> 
+target_include_directories(${PROJECT_NAME}
+	INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+	$<INSTALL_INTERFACE:include>
 )
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/include/units.h
+++ b/include/units.h
@@ -115,7 +115,7 @@ namespace units
 		inline constexpr const velocity::meters_per_second<double>																																				c(299792458.0);									///< Speed of light in vacuum.
 		inline constexpr const unit<compound_conversion_factor<cubed<length::meter_conversion_factor>, inverse<mass::kilogram_conversion_factor>, inverse<squared<time::second_conversion_factor>>>>			G(6.67408e-11);									///< Newtonian constant of gravitation.
 		inline constexpr const unit<compound_conversion_factor<energy::joule_conversion_factor, time::second_conversion_factor>>																				h(6.626070040e-34);								///< Planck constant.
-		inline constexpr const unit<compound_conversion_factor<force::newton_conversion_factor, inverse<squared<current::ampere_conversion_factor>>>>															mu0(pi * 4.0e-7 * force::newtons(1) / pow<2>(current::amperes(1)));	///< vacuum permeability.
+		inline constexpr const unit<compound_conversion_factor<force::newton_conversion_factor, inverse<squared<current::ampere_conversion_factor>>>>															mu0(pi * 4.0e-7 * force::newtons<>(1) / pow<2>(current::amperes<>(1)));	///< vacuum permeability.
 		inline constexpr const unit<compound_conversion_factor<capacitance::farad_conversion_factor, inverse<length::meter_conversion_factor>>>																	epsilon0(1.0 / (mu0 * pow<2>(c)));				///< vacuum permitivity.
 		inline constexpr const impedance::ohms<double>																																							Z0(mu0 * c);									///< characteristic impedance of vacuum.
 		inline constexpr const unit<compound_conversion_factor<force::newton_conversion_factor, area::square_meter_conversion_factor, inverse<squared<charge::coulomb_conversion_factor>>>>						k_e(1.0 / (4 * pi * epsilon0));					///< Coulomb's constant.

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -184,75 +184,8 @@ namespace units
  *				comprise the unit definition.
  */
 #define UNIT_ADD_SCALED_UNIT_DEFINITION(nameSingular, unitName, scale, /*definition*/...) \
-	template<class Underlying> \
-	class unitName : public ::units::unit<__VA_ARGS__, Underlying, scale> \
-	{ \
-		using _base = ::units::unit<__VA_ARGS__, Underlying, scale>; \
-\
-	public: \
-		constexpr unitName()                = default; \
-		constexpr unitName(const unitName&) = default; \
-		constexpr unitName(unitName&&)      = default; \
-		constexpr unitName& operator=(const unitName&) = default; \
-		constexpr unitName& operator=(unitName&&) = default; \
-\
-		template<class T, class... Args, \
-			::std::enable_if_t<::std::is_constructible_v<_base, T, Args...> && \
-					(sizeof...(Args) != 0 || !::std::is_convertible_v<T, _base>), \
-				int> = 0> \
-		explicit constexpr unitName(T&& val, Args&&... args) noexcept \
-		  : _base(::std::forward<T>(val), ::std::forward<Args>(args)...) \
-		{ \
-		} \
-\
-		template<class T, \
-			::std::enable_if_t<::std::is_constructible_v<_base, T>&& ::std::is_convertible_v<T, _base>, int> = 0> \
-		constexpr unitName(T&& val) noexcept : _base(::std::forward<T>(val)) \
-		{ \
-		} \
-\
-		template<class T, ::std::enable_if_t<::std::is_assignable_v<_base&, T>, int> = 0> \
-		constexpr unitName& operator=(T&& val) noexcept \
-		{ \
-			static_cast<_base&>(*this) = ::std::forward<T>(val); \
-			return *this; \
-		} \
-\
-		template<class Unit = unitName> \
-		constexpr const char* name() const noexcept \
-		{ \
-			return ::units::unit_name_v<Unit>; \
-		} \
-\
-		template<class Unit = unitName> \
-		constexpr const char* abbreviation() const noexcept \
-		{ \
-			return ::units::unit_abbreviation_v<Unit>; \
-		} \
-	}; \
-\
-	/* DEDUCTION GUIDES */ \
-	unitName()->unitName<UNIT_LIB_DEFAULT_TYPE>; \
-\
-	template<class Underlying, class... Args, ::std::enable_if_t<::std::is_arithmetic_v<Underlying>, int> = 0> \
-	unitName(const Underlying&, Args&&...)->unitName<Underlying>; \
-\
-	template<class Underlying> \
-	unitName(unitName<Underlying>)->unitName<Underlying>; \
-\
-	template<template<class> class StrongUnit, class Underlying, \
-		::std::enable_if_t<::std::is_arithmetic_v<Underlying>&& ::units::traits::detail::is_strong_unit_alias_v< \
-							   StrongUnit<Underlying>>, \
-			int> = 0> \
-	unitName(StrongUnit<Underlying>)->unitName<Underlying>; \
-\
-	template<class Cf, class Underlying, class Ns> \
-	unitName(unit<Cf, Underlying, Ns>)->unitName<Underlying>; \
-\
-	template<class Rep, class Period, \
-		::std::enable_if_t<::units::detail::is_time_conversion_factor<typename unitName<Rep>::conversion_factor>, \
-			int> = 0> \
-	unitName(::std::chrono::duration<Rep, Period>)->unitName<Rep>;
+	template<class Underlying = UNIT_LIB_DEFAULT_TYPE> \
+	using unitName = ::units::unit<__VA_ARGS__, Underlying, scale>;
 
 /**
  * @def			UNIT_ADD_IO(namespaceName,nameSingular, abbreviation)
@@ -308,127 +241,6 @@ namespace units
 	};
 
 /**
- * @def			UNIT_ADD_STRONG(namespaceName, nameSingular, scale)
- * @brief		Macro for generating the boiler-plate code for the strong type trait of the unit.
- * @details		The macro generates the specialization of the strong type trait of the unit.
- * @param		globalConversionFactor the unit's conversion factor prefixed with `::`, e.g. `::units::length::meter`
- * @param		globalUnitName the unit name prefixed with `::`, e.g. `::units::length::meter_t`
- * @param		scale the `NumericalScale` template template argument of the unit's `unit` base
- */
-#define UNIT_ADD_STRONG(globalConversionFactor, globalUnitName, scale) \
-	namespace traits \
-	{ \
-		template<class Underlying> \
-		struct strong<::units::unit<globalConversionFactor, Underlying, scale>> \
-		{ \
-			using type = globalUnitName<Underlying>; \
-		}; \
-	}
-
-/**
- * @def			UNIT_ADD_UNITS_SPECIALIZATIONS(namespaceName, nameSingular)
- * @brief		Macro for generating specializations of `units`'s templates for units. It should be used from the global
- * namespace.
- * @details		See `UNIT_ADD_NAME`, `UNIT_ADD_STRONG`
- * @param		namespaceName namespace in which the new units will be encapsulated.
- * @param		nameSingular singular version of the unit name, e.g. 'meter'
- * @param		namePlural - plural version of the unit name, e.g. 'meters'
- * @param		abbreviation - abbreviated unit name, e.g. 'm'
- * @param		scale the `NumericalScale` template template argument of the unit's `unit` base
- */
-#define UNIT_ADD_UNITS_SPECIALIZATIONS(namespaceName, nameSingular, namePlural, abbreviation, scale) \
-	namespace units \
-	{ \
-		UNIT_ADD_NAME(namespaceName, namePlural, abbreviation) \
-		UNIT_ADD_STRONG( \
-			::units::namespaceName::nameSingular##_conversion_factor, ::units::namespaceName::namePlural, scale) \
-	}
-
-/**
- * @def			UNIT_ADD_HASH(globalUnitName)
- * @brief		Macro for generating `std::hash` specializations for units.
- * @details		The macro generates `std::hash` specializations for units. It should be used from the global namespace.
- * @param		globalUnitName the unit name prefixed with `::`, e.g. `::units::length::meter_t`
- */
-#define UNIT_ADD_HASH(globalUnitName) \
-	namespace std \
-	{ \
-		template<class Underlying> \
-		struct hash<globalUnitName<Underlying>> \
-		  : private hash<::units::traits::unit_base_t<globalUnitName<Underlying>>> \
-		{ \
-			constexpr size_t operator()(const globalUnitName<Underlying>& x) const noexcept \
-			{ \
-				return hash<::units::traits::unit_base_t<globalUnitName<Underlying>>>()(x); \
-			} \
-		}; \
-	}
-
-/**
- * @def			UNIT_ADD_COMMON_TYPE(globalUnitName)
- * @brief		Macro for generating `std::common_type` specializations for units.
- * @details		The macro generates `std::common_type` specializations for units.
- *				It should be used from the global namespace.
- * @param		globalUnitName the unit name prefixed with `::`, e.g. `::units::length::meter_t`
- */
-#define UNIT_ADD_COMMON_TYPE(globalUnitName) \
-	namespace std \
-	{ \
-		template<typename Underlying, class ConversionFactor, class T, class NumericalScale> \
-		struct common_type<globalUnitName<Underlying>, ::units::unit<ConversionFactor, T, NumericalScale>> \
-		{ \
-			using type = \
-				::units::traits::strong_t<common_type_t<::units::traits::unit_base_t<globalUnitName<Underlying>>, \
-					::units::unit<ConversionFactor, T, NumericalScale>>>; \
-		}; \
-\
-		template<class ConversionFactor, class T, class NumericalScale, typename Underlying> \
-		struct common_type<::units::unit<ConversionFactor, T, NumericalScale>, globalUnitName<Underlying>> \
-		  : common_type<globalUnitName<Underlying>, ::units::unit<ConversionFactor, T, NumericalScale>> \
-		{ \
-		}; \
-\
-		template<typename Underlying1, typename Underlying2> \
-		struct common_type<globalUnitName<Underlying1>, globalUnitName<Underlying2>> \
-		{ \
-			using type = globalUnitName<common_type_t<Underlying1, Underlying2>>; \
-		}; \
-\
-		template<typename UnderlyingLhs, class StrongUnit> \
-		struct common_type<globalUnitName<UnderlyingLhs>, StrongUnit> \
-		  : common_type<globalUnitName<UnderlyingLhs>, \
-				::units::detail::detected_t<::units::traits::unit_base_t, StrongUnit>> \
-		{ \
-		}; \
-	}
-
-/**
- * @def			UNIT_ADD_STD_SPECIALIZATIONS(globalUnitName)
- * @brief		Macro for generating specializations of standard templates for units.
- *				It should be used from the global namespace.
- * @details		See `UNIT_ADD_HASH`, `UNIT_ADD_COMMON_TYPE`
- * @param		globalUnitName the unit name prefixed with `::`, e.g. `::units::length::meter_t`
- */
-#define UNIT_ADD_STD_SPECIALIZATIONS(globalUnitName) \
-	UNIT_ADD_HASH(globalUnitName) \
-	UNIT_ADD_COMMON_TYPE(globalUnitName)
-
-/**
- * @def			UNIT_ADD_SPECIALIZATIONS(namespaceName, nameSingular, abbreviation, scale)
- * @brief		Macro for generating specializations for units.
- *				It should be used from the global namespace.
- * @details		See UNIT_ADD_UNITS_SPECIALIZATIONS and UNIT_ADD_STD_HASH_SPECIALIZATIONS.
- * @param		namespaceName namespace in which the new units will be encapsulated.
- * @param		nameSingular singular version of the unit name, e.g. 'meter'
- * @param		namePlural - plural version of the unit name, e.g. 'meters'
- * @param		abbreviation - abbreviated unit name, e.g. 'm'
- * @param		scale the non linear scale template argument of the unit's base
- */
-#define UNIT_ADD_SPECIALIZATIONS(namespaceName, nameSingular, namePlural, abbreviation, scale) \
-	UNIT_ADD_UNITS_SPECIALIZATIONS(namespaceName, nameSingular, namePlural, abbreviation, scale) \
-	UNIT_ADD_STD_SPECIALIZATIONS(::units::namespaceName::namePlural)
-
-/**
  * @def			UNIT_ADD_LITERALS(namespaceName,nameSingular,abbreviation)
  * @brief		Macro for generating user-defined literals for units.
  * @details		The macro generates user-defined literals for units. A literal suffix is created
@@ -474,12 +286,10 @@ namespace units
 #define UNIT_ADD(namespaceName, nameSingular, namePlural, abbreviation, /*definition*/...) \
 	UNIT_ADD_UNIT_TAGS(namespaceName, nameSingular, namePlural, abbreviation, __VA_ARGS__) \
 	UNIT_ADD_UNIT_DEFINITION(namespaceName, nameSingular, namePlural) \
+    UNIT_ADD_NAME(namespaceName, namePlural, abbreviation) \
 	UNIT_ADD_IO(namespaceName, namePlural, abbreviation) \
-	UNIT_ADD_LITERALS(namespaceName, namePlural, abbreviation) \
-	} \
-	UNIT_ADD_SPECIALIZATIONS(namespaceName, nameSingular, namePlural, abbreviation, ::units::linear_scale) \
-	namespace units \
-	{
+	UNIT_ADD_LITERALS(namespaceName, namePlural, abbreviation)
+
 /**
  * @def			UNIT_ADD_DECIBEL(namespaceName, nameSingular, abbreviation)
  * @brief		Macro to create decibel container and literals for an existing unit type.
@@ -496,13 +306,8 @@ namespace units
 			abbreviation, abbreviation, ::units::decibel_scale, nameSingular##_conversion_factor) /** @} */ \
 	} \
 	UNIT_ADD_IO(namespaceName, abbreviation, abbreviation) \
-	UNIT_ADD_LITERALS(namespaceName, abbreviation, abbreviation) \
-	UNIT_ADD_STRONG(::units::namespaceName::nameSingular##_conversion_factor, ::units::namespaceName::abbreviation, \
-		::units::decibel_scale) \
-	} \
-	UNIT_ADD_STD_SPECIALIZATIONS(::units::namespaceName::abbreviation) \
-	namespace units \
-	{
+	UNIT_ADD_LITERALS(namespaceName, abbreviation, abbreviation)
+
 /**
  * @def			UNIT_ADD_DIMENSION_TRAIT(unitdimension)
  * @brief		Macro to create the `is_dimension_unit` type trait.
@@ -859,18 +664,14 @@ namespace units
 		template<class T>
 		inline constexpr bool is_conversion_factor_v = is_conversion_factor<T>::value;
 
-		// forward declaration
-		template<class T>
-		struct is_unit;
-
 		/**
 		 * @ingroup			TypeTraits
-		 * @brief			SFINAE-able trait that maps a `unit` or `conversion_factor` to its strengthened type.
-		 * @details			If `T` is a cv-unqualified `unit` or `conversion_factor`, the member `type` alias names the
+		 * @brief			SFINAE-able trait that maps a `conversion_factor` to its strengthened type.
+		 * @details			If `T` is a cv-unqualified `conversion_factor`, the member `type` alias names the
 		 *					strong type alias of `T`, if any, and `T` otherwise. Otherwise, there is no `type` member.
 		 *					This may be specialized only if `T` depends on a program-defined type.
 		 */
-		template<class T, class = std::enable_if<(is_conversion_factor_v<T> || is_unit<T>::value) && std::is_same_v<T, std::remove_cv_t<T>>>>
+		template<class T, class = std::enable_if<is_conversion_factor_v<T> && std::is_same_v<T, std::remove_cv_t<T>>>>
 		struct strong : T
 		{
 			typedef T type;
@@ -1254,10 +1055,6 @@ namespace units
 		 */
 		template<class U>
 		using dimension_of_t = typename units::detail::dimension_of_impl<U>::type;
-
-		/** @cond */ // DOXYGEN IGNORE
-		template<class T>
-		struct unit_base;
 	} // namespace traits
 
 	template<class ConversionFactor, typename T, class NumericalScale>
@@ -1265,43 +1062,29 @@ namespace units
 
 	namespace detail
 	{
-		enum class type
-		{
-			none,
-			conversion_factor,
-			unit
-		};
-
-		template<typename T, class Dim, type = type::none>
+		template<typename T, class Dim, bool IsConv = false>
 		struct has_dimension_of_impl : std::false_type
 		{
 		};
 
 		template<typename T, class Dim>
 		using has_dimension_of = typename has_dimension_of_impl<T, Dim,
-			(traits::is_conversion_factor_v<T> ? type::conversion_factor
-											   : (traits::is_unit<T>::value ? type::unit : type::none))>::type;
+			traits::is_conversion_factor_v<T>>::type;
 
 		template<typename Cf, class Dim>
-		struct has_dimension_of_impl<Cf, Dim, type::conversion_factor>
+		struct has_dimension_of_impl<Cf, Dim, true>
 		  : has_dimension_of<conversion_factor_base_t<Cf>, Dim>::type
 		{
 		};
 
 		template<typename C, typename Cf, typename P, typename T, class Dim>
-		struct has_dimension_of_impl<conversion_factor<C, Cf, P, T>, Dim, type::conversion_factor>
+		struct has_dimension_of_impl<conversion_factor<C, Cf, P, T>, Dim, true>
 		  : std::is_same<typename conversion_factor<C, Cf, P, T>::dimension_type, Dim>::type
 		{
 		};
 
-		template<typename Cf, class Dim>
-		struct has_dimension_of_impl<Cf, Dim, type::unit>
-		  : has_dimension_of<typename traits::unit_base<Cf>::type, Dim>::type
-		{
-		};
-
 		template<typename Cf, typename T, class Ns, class Dim>
-		struct has_dimension_of_impl<unit<Cf, T, Ns>, Dim, type::unit>
+		struct has_dimension_of_impl<unit<Cf, T, Ns>, Dim>
 		  : std::is_same<traits::dimension_of_t<Cf>, Dim>::type
 		{
 		};
@@ -1310,47 +1093,6 @@ namespace units
 
 	namespace traits
 	{
-		/** @cond */ // DOXYGEN IGNORE
-		namespace detail
-		{
-			template<class T, class = void>
-			struct is_strong_unit_alias_impl : std::false_type
-			{
-			};
-
-			template<class Unit>
-			struct is_strong_unit_alias_impl<Unit, std::void_t<typename traits::unit_base<Unit>::type>>
-			  : std::bool_constant<!std::is_same_v<std::remove_const_t<Unit>, typename traits::unit_base<Unit>::type>>
-			{
-			};
-
-			template<class T>
-			struct is_strong_unit_alias : is_strong_unit_alias_impl<T>
-			{
-			};
-
-			template<class T>
-			inline constexpr bool is_strong_unit_alias_v = is_strong_unit_alias<T>::value;
-
-			template<class Unit, class Underlying, bool IsStrongUnit>
-			struct replace_underlying_impl
-			{
-			};
-
-			template<template<class> class T, class U, class Underlying>
-			struct replace_underlying_impl<T<U>, Underlying, true>
-			{
-				using type = T<Underlying>;
-			};
-
-			template<class Cf, typename T, class Ns, class Underlying>
-			struct replace_underlying_impl<unit<Cf, T, Ns>, Underlying, false>
-			{
-				using type = unit<Cf, Underlying, Ns>;
-			};
-		}               // namespace detail
-		/** @endcond */ // END DOXYGEN IGNORE
-
 		/**
 		 * @ingroup		TypeTraits
 		 * @brief		SFINAE-able trait which replaces the underlying type of `Unit` with `Underlying`.
@@ -1361,8 +1103,13 @@ namespace units
 		 */
 		template<class Unit, class Underlying>
 		struct replace_underlying
-		  : detail::replace_underlying_impl<Unit, Underlying, detail::is_strong_unit_alias_v<Unit>>
 		{
+		};
+
+		template<class Cf, typename T, class Ns, class Underlying>
+		struct replace_underlying<unit<Cf, T, Ns>, Underlying>
+		{
+			using type = unit<Cf, Underlying, Ns>;
 		};
 
 		template<class Unit, class Underlying>
@@ -1911,6 +1658,13 @@ namespace units
 	//------------------------------
 
 	/** @cond */ // DOXYGEN IGNORE
+	namespace traits
+	{
+		// forward declaration
+		template<class T>
+		struct is_unit;
+	} // namespace traits
+
 	namespace detail
 	{
 		/**
@@ -1919,18 +1673,18 @@ namespace units
 		 *				overloaded on `float`, `double` and `long double`. Works for both arithmetic types and
 		 *				unit types.
 		 */
-		template<typename T, bool IsUnit = false>
+		template<typename T>
 		struct floating_point_promotion : std::conditional<std::is_floating_point_v<T>, T, double>
 		{
 		};
 
 		template<typename T>
-		using floating_point_promotion_t = typename floating_point_promotion<T, traits::is_unit<T>::value>::type;
+		using floating_point_promotion_t = typename floating_point_promotion<T>::type;
 
-		template<class Unit>
-		struct floating_point_promotion<Unit, true>
-		  : traits::replace_underlying<Unit, floating_point_promotion_t<typename Unit::underlying_type>>
+ 		template<class Cf, typename T, class Ns>
+		struct floating_point_promotion<unit<Cf, T, Ns>>
 		{
+			using type = unit<Cf, floating_point_promotion_t<T>, Ns>;
 		};
 	} // namespace detail
 
@@ -2263,41 +2017,6 @@ namespace units
 
 		template<class U1, class U2>
 		inline constexpr bool is_same_dimension_unit_v = is_same_dimension_unit<U1, U2>::value;
-
-		/** @cond */ // DOXYGEN IGNORE
-		namespace detail
-		{
-			template<class ConversionFactor, class T, class NumericalScale>
-			unit<ConversionFactor, T, NumericalScale> unit_base_t_impl(
-				const volatile unit<ConversionFactor, T, NumericalScale>*);
-
-			template<class T, bool IsUnit = false>
-			struct unit_base_impl
-			{
-			};
-
-			template<class T>
-			struct unit_base_impl<T, true>
-			{
-				using type = decltype(unit_base_t_impl(std::declval<T*>()));
-			};
-		}               // namespace detail
-		/** @endcond */ // END DOXYGEN IGNORE
-
-		/**
-		 * @ingroup		TypeTraits
-		 * @brief		SFINAE-able trait that names the `unit` base of `T`.
-		 * @details		If `is_unit_v<T>` is `true`, the member `type` alias names the cv-unqualified `unit`
-		 *				specialization that `T` is derived from. Otherwise, there is no `type` member. Note that
-		 *				`unit_base_t<unit<...>>` names `unit<...>`.
-		 */
-		template<class T>
-		struct unit_base : detail::unit_base_impl<T, is_unit<T>::value>
-		{
-		};
-
-		template<class T>
-		using unit_base_t = typename unit_base<T>::type;
 
 	} // namespace traits
 
@@ -2750,6 +2469,9 @@ namespace units
 		T linearized_value;
 	};
 
+	template<class Rep, class Period>
+	unit(std::chrono::duration<Rep, Period>)->unit<conversion_factor<Period, dimension::time>, Rep>;
+
 	//------------------------------
 	//	UNIT NON-MEMBER FUNCTIONS
 	//------------------------------
@@ -3138,16 +2860,11 @@ namespace units
 		};
 	} // namespace traits
 
-	UNIT_ADD_STRONG(::units::dimensionless_unit, ::units::dimensionless, ::units::linear_scale)
+	template<class Underlying>
+	using dimensionless = unit<dimensionless_unit, Underlying>;
 
 	UNIT_ADD_DIMENSION_TRAIT(dimensionless)
 
-} // namespace units
-
-UNIT_ADD_STD_SPECIALIZATIONS(::units::dimensionless)
-
-namespace units
-{
 	//------------------------------
 	//	LINEAR ARITHMETIC
 	//------------------------------
@@ -3235,9 +2952,9 @@ namespace units
 				traits::has_linear_scale_v<UnitTypeLhs, UnitTypeRhs>,
 			int> = 0>
 	constexpr auto operator*(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
-		-> traits::strong_t<unit<traits::strong_t<squared<typename units::traits::unit_traits<
+		-> unit<traits::strong_t<squared<typename units::traits::unit_traits<
 									 std::common_type_t<UnitTypeLhs, UnitTypeRhs>>::conversion_factor>>,
-			typename std::common_type_t<UnitTypeLhs, UnitTypeRhs>::underlying_type>>
+			typename std::common_type_t<UnitTypeLhs, UnitTypeRhs>::underlying_type>
 	{
 		using SquaredUnit = decltype(lhs * rhs);
 		using CommonUnit  = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
@@ -3330,10 +3047,10 @@ namespace units
 				traits::has_linear_scale_v<UnitTypeLhs, UnitTypeRhs> && !traits::is_dimensionless_unit_v<UnitTypeLhs> &&
 				!traits::is_dimensionless_unit_v<UnitTypeRhs>,
 			int> = 0>
-	constexpr auto operator/(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept -> traits::strong_t<unit<
+	constexpr auto operator/(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept -> unit<
 		traits::strong_t<compound_conversion_factor<typename units::traits::unit_traits<UnitTypeLhs>::conversion_factor,
 			inverse<typename units::traits::unit_traits<UnitTypeRhs>::conversion_factor>>>,
-		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>>
+		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>
 	{
 		using CompoundUnit     = decltype(lhs / rhs);
 		using CommonUnderlying = typename CompoundUnit::underlying_type;
@@ -3359,9 +3076,9 @@ namespace units
 		std::enable_if_t<traits::has_linear_scale_v<UnitTypeLhs, UnitTypeRhs> &&
 				traits::is_dimensionless_unit_v<UnitTypeLhs> && !traits::is_dimensionless_unit_v<UnitTypeRhs>,
 			int> = 0>
-	constexpr auto operator/(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept -> traits::strong_t<
+	constexpr auto operator/(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept ->
 		unit<traits::strong_t<inverse<typename units::traits::unit_traits<UnitTypeRhs>::conversion_factor>>,
-			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>>
+			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>
 	{
 		using InverseUnit      = decltype(lhs / rhs);
 		using CommonUnderlying = typename InverseUnit::underlying_type;
@@ -3573,10 +3290,10 @@ namespace units
 	 */
 	template<int power, class UnitType, std::enable_if_t<traits::has_linear_scale_v<UnitType>, int> = 0>
 	constexpr auto pow(const UnitType& value) noexcept
-		-> traits::strong_t<unit<traits::strong_t<typename units::detail::power_of_unit<power,
+		-> unit<traits::strong_t<typename units::detail::power_of_unit<power,
 									 typename units::traits::unit_traits<UnitType>::conversion_factor>::type>,
 			detail::floating_point_promotion_t<typename units::traits::unit_traits<UnitType>::underlying_type>,
-			linear_scale>>
+			linear_scale>
 	{
 		return decltype(units::pow<power>(value))(pow(value.value(), power));
 	}
@@ -3626,7 +3343,8 @@ namespace units
 	 * @sa			See unit for more information on unit type containers.
 	 */
 	UNIT_ADD_SCALED_UNIT_DEFINITION(dB, dB, ::units::decibel_scale, dimensionless_unit)
-	UNIT_ADD_STRONG(::units::dimensionless_unit, ::units::dB, ::units::decibel_scale)
+	template<class Underlying>
+	using dB = unit<dimensionless_unit, Underlying, decibel_scale>;
 #if !defined(UNIT_LIB_DISABLE_IOSTREAM)
 	template<class Underlying>
 	std::ostream& operator<<(std::ostream& os, const dB<Underlying>& obj)
@@ -3638,12 +3356,6 @@ namespace units
 	template<class Underlying>
 	using dBi_t = dB<Underlying>;
 
-} // namespace units
-
-UNIT_ADD_STD_SPECIALIZATIONS(::units::dB)
-
-namespace units
-{
 	//------------------------------
 	//	DECIBEL ARITHMETIC
 	//------------------------------
@@ -3654,9 +3366,9 @@ namespace units
 				traits::has_decibel_scale_v<UnitTypeLhs, UnitTypeRhs>,
 			int> = 0>
 	constexpr auto operator+(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
-		-> traits::strong_t<unit<traits::strong_t<squared<typename units::traits::unit_traits<
+		-> unit<traits::strong_t<squared<typename units::traits::unit_traits<
 									 std::common_type_t<UnitTypeLhs, UnitTypeRhs>>::conversion_factor>>,
-			typename std::common_type_t<UnitTypeLhs, UnitTypeRhs>::underlying_type, decibel_scale>>
+			typename std::common_type_t<UnitTypeLhs, UnitTypeRhs>::underlying_type, decibel_scale>
 	{
 		using SquaredUnit = decltype(lhs + rhs);
 		using CommonUnit  = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
@@ -3722,10 +3434,10 @@ namespace units
 		std::enable_if_t<traits::has_decibel_scale_v<UnitTypeLhs, UnitTypeRhs> &&
 				traits::is_dimensionless_unit_v<UnitTypeLhs> && !traits::is_dimensionless_unit_v<UnitTypeRhs>,
 			int> = 0>
-	constexpr auto operator-(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept -> traits::strong_t<
+	constexpr auto operator-(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept ->
 		unit<traits::strong_t<inverse<typename units::traits::unit_traits<UnitTypeRhs>::conversion_factor>>,
 			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>,
-			decibel_scale>>
+			decibel_scale>
 	{
 		using InverseUnit = decltype(lhs - rhs);
 		return InverseUnit(lhs.to_linearized() / rhs.to_linearized(), linearized_value);
@@ -3920,10 +3632,10 @@ namespace units
 	 *				unit type may have errors no larger than `1e-10`.
 	 */
 	template<class UnitType, std::enable_if_t<units::traits::has_linear_scale_v<UnitType>, int> = 0>
-	constexpr auto sqrt(const UnitType& value) noexcept -> traits::strong_t<
+	constexpr auto sqrt(const UnitType& value) noexcept ->
 		unit<traits::strong_t<square_root<typename units::traits::unit_traits<UnitType>::conversion_factor>>,
 			detail::floating_point_promotion_t<typename units::traits::unit_traits<UnitType>::underlying_type>,
-			linear_scale>>
+			linear_scale>
 	{
 		return decltype(units::sqrt(value))(sqrt(value.value()));
 	}

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -286,7 +286,7 @@ namespace units
 #define UNIT_ADD(namespaceName, nameSingular, namePlural, abbreviation, /*definition*/...) \
 	UNIT_ADD_UNIT_TAGS(namespaceName, nameSingular, namePlural, abbreviation, __VA_ARGS__) \
 	UNIT_ADD_UNIT_DEFINITION(namespaceName, nameSingular, namePlural) \
-    UNIT_ADD_NAME(namespaceName, namePlural, abbreviation) \
+	UNIT_ADD_NAME(namespaceName, namePlural, abbreviation) \
 	UNIT_ADD_IO(namespaceName, namePlural, abbreviation) \
 	UNIT_ADD_LITERALS(namespaceName, namePlural, abbreviation)
 
@@ -961,9 +961,9 @@ namespace units
 		using luminous_flux =
 			dimension_multiply<solid_angle, luminous_intensity>; ///< Represents an SI derived unit of luminous flux
 		using illuminance             = make_dimension<luminous_flux, std::ratio<1>, length,
-            std::ratio<-2>>; ///< Represents an SI derived unit of illuminance
+			std::ratio<-2>>; ///< Represents an SI derived unit of illuminance
 		using radioactivity           = make_dimension<length, std::ratio<2>, time,
-            std::ratio<-2>>; ///< Represents an SI derived unit of radioactivity
+			std::ratio<-2>>; ///< Represents an SI derived unit of radioactivity
 		using substance_mass          = dimension_divide<mass, substance>;
 		using substance_concentration = dimension_divide<substance, mass>;
 
@@ -1255,8 +1255,8 @@ namespace units
 			static_assert(traits::is_conversion_factor_v<Unit>, "Template parameter `Unit` must be a `unit` type.");
 			using Conversion = typename Unit::conversion_ratio;
 			using type       = conversion_factor<std::ratio_multiply<Conversion, Conversion>,
-                dimension_pow<traits::dimension_of_t<typename Unit::dimension_type>, std::ratio<2>>,
-                std::ratio_multiply<typename Unit::pi_exponent_ratio, std::ratio<2>>, typename Unit::translation_ratio>;
+				dimension_pow<traits::dimension_of_t<typename Unit::dimension_type>, std::ratio<2>>,
+				std::ratio_multiply<typename Unit::pi_exponent_ratio, std::ratio<2>>, typename Unit::translation_ratio>;
 		};
 	}               // namespace detail
 	/** @endcond */ // END DOXYGEN IGNORE
@@ -1476,8 +1476,8 @@ namespace units
 			static_assert(traits::is_conversion_factor_v<Unit>, "Template parameter `Unit` must be a `unit` type.");
 			using Conversion = typename Unit::conversion_ratio;
 			using type       = conversion_factor<ratio_sqrt<Conversion, Eps>,
-                dimension_root<traits::dimension_of_t<typename Unit::dimension_type>, std::ratio<2>>,
-                std::ratio_divide<typename Unit::pi_exponent_ratio, std::ratio<2>>, typename Unit::translation_ratio>;
+				dimension_root<traits::dimension_of_t<typename Unit::dimension_type>, std::ratio<2>>,
+				std::ratio_divide<typename Unit::pi_exponent_ratio, std::ratio<2>>, typename Unit::translation_ratio>;
 		};
 	}               // namespace detail
 	/** @endcond */ // END DOXYGEN IGNORE
@@ -1762,9 +1762,9 @@ namespace units
 	constexpr To convert(const From& value) noexcept
 	{
 		using Ratio       = std::ratio_divide<typename ConversionFactorFrom::conversion_ratio,
-            typename ConversionFactorTo::conversion_ratio>;
+			typename ConversionFactorTo::conversion_ratio>;
 		using PiRatio     = std::ratio_subtract<typename ConversionFactorFrom::pi_exponent_ratio,
-            typename ConversionFactorTo::pi_exponent_ratio>;
+			typename ConversionFactorTo::pi_exponent_ratio>;
 		using Translation = std::ratio_divide<std::ratio_subtract<typename ConversionFactorFrom::translation_ratio,
 												  typename ConversionFactorTo::translation_ratio>,
 			typename ConversionFactorTo::conversion_ratio>;
@@ -1773,7 +1773,7 @@ namespace units
 			using ResolvedUnitFrom = conversion_factor<typename ConversionFactorFrom::conversion_ratio,
 				typename ConversionFactorFrom::dimension_type>;
 			using ResolvedUnitTo   = conversion_factor<typename ConversionFactorTo::conversion_ratio,
-                typename ConversionFactorTo::dimension_type>;
+				typename ConversionFactorTo::dimension_type>;
 			return convert<ResolvedUnitFrom, ResolvedUnitTo, std::decay_t<decltype(value)>>(value);
 		};
 
@@ -1781,7 +1781,7 @@ namespace units
 			using ResolvedUnitFrom = conversion_factor<typename ConversionFactorFrom::conversion_ratio,
 				typename ConversionFactorFrom::dimension_type, typename ConversionFactorFrom::pi_exponent_ratio>;
 			using ResolvedUnitTo   = conversion_factor<typename ConversionFactorTo::conversion_ratio,
-                typename ConversionFactorTo::dimension_type, typename ConversionFactorTo::pi_exponent_ratio>;
+				typename ConversionFactorTo::dimension_type, typename ConversionFactorTo::pi_exponent_ratio>;
 			return convert<ResolvedUnitFrom, ResolvedUnitTo, std::decay_t<decltype(value)>>(value);
 		};
 

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -141,7 +141,7 @@ TEST_F(TypeTraits, is_conversion_factor)
 	EXPECT_FALSE(traits::is_conversion_factor_v<double>);
 	EXPECT_TRUE(traits::is_conversion_factor_v<meter_conversion_factor>);
 	EXPECT_TRUE(traits::is_conversion_factor_v<foot_conversion_factor>);
-	EXPECT_TRUE(traits::is_conversion_factor_v<degree_squared_conversion_factor>);
+//	EXPECT_TRUE(traits::is_conversion_factor_v<degree_squared_conversion_factor>);
 	EXPECT_TRUE(traits::is_conversion_factor_v<meters<double>>);
 }
 
@@ -151,29 +151,12 @@ TEST_F(TypeTraits, is_unit)
 	EXPECT_FALSE(traits::is_unit_v<double>);
 	EXPECT_FALSE(traits::is_unit_v<meter_conversion_factor>);
 	EXPECT_FALSE(traits::is_unit_v<foot_conversion_factor>);
-	EXPECT_FALSE(traits::is_unit_v<degree_squared_conversion_factor>);
+//	EXPECT_FALSE(traits::is_unit_v<degree_squared_conversion_factor>);
 	EXPECT_TRUE(traits::is_unit_v<meters<double>>);
-}
-
-TEST_F(TypeTraits, unit_base)
-{
-	EXPECT_TRUE((std::is_same_v<traits::unit_base_t<unit<dimensionless_unit, int>>, unit<dimensionless_unit, int>>));
-	EXPECT_TRUE((std::is_same_v<traits::unit_base_t<dimensionless<int>>, unit<dimensionless_unit, int>>));
-	EXPECT_TRUE((std::is_same_v<traits::unit_base_t<const volatile unit<dimensionless_unit, int>>,
-		unit<dimensionless_unit, int>>));
-	EXPECT_TRUE(
-		(std::is_same_v<traits::unit_base_t<const volatile dimensionless<int>>, unit<dimensionless_unit, int>>));
-	EXPECT_TRUE((std::is_same_v<traits::unit_base_t<meters<double>>, unit<meter_conversion_factor, double>>));
-	EXPECT_TRUE(
-		(std::is_same_v<traits::unit_base_t<const volatile meters<double>>, unit<meter_conversion_factor, double>>));
 }
 
 TEST_F(TypeTraits, replace_underlying)
 {
-	EXPECT_TRUE((std::is_same_v<traits::replace_underlying_t<unit<dimensionless_unit, int>, int>,
-		unit<dimensionless_unit, int>>));
-	EXPECT_TRUE((std::is_same_v<traits::replace_underlying_t<unit<dimensionless_unit, int>, double>,
-		unit<dimensionless_unit, double>>));
 	EXPECT_TRUE((std::is_same_v<traits::replace_underlying_t<dimensionless<int>, int>, dimensionless<int>>));
 	EXPECT_TRUE((std::is_same_v<traits::replace_underlying_t<dimensionless<int>, double>, dimensionless<double>>));
 }
@@ -699,18 +682,8 @@ TEST_F(STDTypeTraits, std_common_type)
 	static_assert(std::is_same_v<std::common_type_t<half_a_radian, third_a_radian>::underlying_type, double>);
 
 	static_assert(std::is_same_v<std::common_type_t<dimensionless<int>, dimensionless<int>>, dimensionless<int>>);
-	static_assert(std::is_same_v<std::common_type_t<dimensionless<int>, traits::unit_base_t<dimensionless<int>>>,
-		dimensionless<int>>);
-	static_assert(std::is_same_v<std::common_type_t<traits::unit_base_t<dimensionless<int>>, dimensionless<int>>,
-		dimensionless<int>>);
-	static_assert(std::is_same_v<
-		std::common_type_t<traits::unit_base_t<dimensionless<int>>, traits::unit_base_t<dimensionless<int>>>,
-		traits::unit_base_t<dimensionless<int>>>);
 	static_assert(std::is_same_v<std::common_type_t<dimensionless<int>, dimensionless<double>>, dimensionless<double>>);
 	static_assert(std::is_same_v<std::common_type_t<dimensionless<double>, dimensionless<int>>, dimensionless<double>>);
-	static_assert(std::is_same_v<
-		std::common_type_t<traits::unit_base_t<dimensionless<int>>, traits::unit_base_t<dimensionless<double>>>,
-		traits::unit_base_t<dimensionless<double>>>);
 
 	// static_assert(std::is_same_v<std::common_type_t<dimensionless<int>, int>, dimensionless<int>>);
 	// static_assert(std::is_same_v<std::common_type_t<int, dimensionless<int>>, dimensionless<int>>);
@@ -720,22 +693,6 @@ TEST_F(STDTypeTraits, std_common_type)
 	// static_assert(std::is_same_v<std::common_type_t<int, dimensionless<double>>, dimensionless<double>>);
 	// static_assert(std::is_same_v<std::common_type_t<dimensionless<double>, double>, dimensionless<double>>);
 	// static_assert(std::is_same_v<std::common_type_t<double, dimensionless<double>>, dimensionless<double>>);
-	// static_assert(std::is_same_v<std::common_type_t<traits::unit_base_t<dimensionless<int>>, int>,
-	// 	traits::unit_base_t<dimensionless<int>>>);
-	// static_assert(std::is_same_v<std::common_type_t<int, traits::unit_base_t<dimensionless<int>>>,
-	// 	traits::unit_base_t<dimensionless<int>>>);
-	// static_assert(std::is_same_v<std::common_type_t<traits::unit_base_t<dimensionless<int>>, double>,
-	// 	traits::unit_base_t<dimensionless<double>>>);
-	// static_assert(std::is_same_v<std::common_type_t<double, traits::unit_base_t<dimensionless<int>>>,
-	// 	traits::unit_base_t<dimensionless<double>>>);
-	// static_assert(std::is_same_v<std::common_type_t<traits::unit_base_t<dimensionless<double>>, int>,
-	// 	traits::unit_base_t<dimensionless<double>>>);
-	// static_assert(std::is_same_v<std::common_type_t<int, traits::unit_base_t<dimensionless<double>>>,
-	// 	traits::unit_base_t<dimensionless<double>>>);
-	// static_assert(std::is_same_v<std::common_type_t<traits::unit_base_t<dimensionless<double>>, double>,
-	// 	traits::unit_base_t<dimensionless<double>>>);
-	// static_assert(std::is_same_v<std::common_type_t<double, traits::unit_base_t<dimensionless<double>>>,
-	// 	traits::unit_base_t<dimensionless<double>>>);
 }
 
 TEST_F(STDSpecializations, hash)
@@ -752,7 +709,6 @@ TEST_F(STDSpecializations, hash)
 	EXPECT_EQ((std::hash<kilometers<int>>()(kilometers<int>(42))), 42);
 
 	EXPECT_EQ((std::hash<dimensionless<double>>()(3.14)), std::hash<double>()(3.14));
-	EXPECT_EQ((std::hash<unit<dimensionless_unit, double>>()(3.14)), std::hash<double>()(3.14));
 	EXPECT_EQ((std::hash<dimensionless<int>>()(42)), (std::hash<dimensionless<int>>()(42)));
 
 	EXPECT_EQ(std::hash<dBW<double>>()(2.0_dBW), std::hash<double>()(dBW(2.0).to_linearized()));
@@ -3022,7 +2978,7 @@ TEST_F(ConversionFactor, angular_velocity)
 	same = std::is_same_v<radians_per_second_conversion_factor,
 		traits::strong_t<conversion_factor<std::ratio<1>, dimension::angular_velocity>>>;
 	EXPECT_TRUE(same);
-  
+
 	same = traits::is_same_dimension_conversion_factor_v<revolutions_per_minute_conversion_factor, radians_per_second_conversion_factor>;
 	EXPECT_TRUE(same);
 
@@ -4038,7 +3994,7 @@ TEST_F(UnitMath, pow)
 
 	auto cube = pow<3>(value);
 	EXPECT_NEAR(1000.0, cube.value(), 5.0e-2);
-	isSame = std::is_same_v<decltype(cube), traits::strong_t<unit<traits::strong_t<cubed<meter_conversion_factor>>>>>;
+	isSame = std::is_same_v<decltype(cube), unit<traits::strong_t<cubed<meter_conversion_factor>>>>;
 	EXPECT_TRUE(isSame);
 
 	auto fourth = pow<4>(value);

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -711,7 +711,7 @@ TEST_F(STDSpecializations, hash)
 	EXPECT_EQ((std::hash<dimensionless<double>>()(3.14)), std::hash<double>()(3.14));
 	EXPECT_EQ((std::hash<dimensionless<int>>()(42)), (std::hash<dimensionless<int>>()(42)));
 
-	EXPECT_EQ(std::hash<dBW<double>>()(2.0_dBW), std::hash<double>()(dBW(2.0).to_linearized()));
+	EXPECT_EQ(std::hash<dBW<double>>()(2.0_dBW), std::hash<double>()(dBW<>(2.0).to_linearized()));
 }
 
 TEST_F(UnitManipulators, squared)
@@ -900,7 +900,7 @@ TEST_F(UnitType, constructionFromUnitType)
 	const dimensionless<double> g_dim(f_dim);
 	EXPECT_EQ(1, g_dim.value());
 }
-
+#if 0 && defined(__cpp_deduction_guides) && __cpp_deduction_guides >= 201907L
 TEST_F(UnitType, CTAD)
 {
 	// Default ctor
@@ -1020,7 +1020,7 @@ TEST_F(UnitType, CTAD)
 	const dimensionless m_dim(unit<conversion_factor<std::milli, dimensionless_unit>, double>(1.0));
 	static_assert(std::is_same_v<std::remove_const_t<decltype(m_dim)>, dimensionless<double>>);
 }
-
+#endif // defined(__cpp_deduction_guides) && __cpp_deduction_guides >= 201907L
 TEST_F(UnitType, assignmentFromArithmeticType)
 {
 	dimensionless<int> a_dim;
@@ -1305,134 +1305,55 @@ TEST_F(UnitType, unitTypeMixedRelational)
 
 TEST_F(UnitType, unitTypeArithmeticOperatorReturnType)
 {
-	using dimless      = dimensionless<int>;
-	using dimless_base = traits::unit_base_t<dimless>;
+	dimensionless<int> dim;
+	meters<int> m;
 
-	dimless dim;
-	dimless_base base;
+	static_assert(std::is_same_v<dimensionless<int>, decltype(+dim)>);
+	static_assert(std::is_same_v<meters<int>, decltype(+m)>);
 
-	using meter_conversion_factor = meters<int>;
-	using meter_base              = units::meters<int>;
+	static_assert(std::is_same_v<dimensionless<int>, decltype(-dim)>);
+	static_assert(std::is_same_v<meters<int>, decltype(-m)>);
 
-	meter_conversion_factor m;
-	meter_base b_m;
+	static_assert(std::is_same_v<dimensionless<int>, decltype(dim + 0)>);
+	static_assert(std::is_same_v<dimensionless<int>, decltype(0 + dim)>);
+	static_assert(std::is_same_v<dimensionless<int>, decltype(dim + dim)>);
 
-	using squared_meter = square_meters<int>;
-	using inverse_meter = unit<inverse<meter_conversion_factor>, int>;
+	static_assert(std::is_same_v<meters<int>, decltype(m + m)>);
 
-	static_assert(std::is_same_v<dimless, decltype(+dim)>);
-	static_assert(std::is_same_v<dimless_base, decltype(+base)>);
+	static_assert(std::is_same_v<dimensionless<int>, decltype(dim - 0)>);
+	static_assert(std::is_same_v<dimensionless<int>, decltype(0 - dim)>);
+	static_assert(std::is_same_v<dimensionless<int>, decltype(dim - dim)>);
 
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(+m)>);
-	static_assert(std::is_same_v<meter_base, decltype(+b_m)>);
+	static_assert(std::is_same_v<meters<int>, decltype(m - m)>);
 
-	static_assert(std::is_same_v<dimless, decltype(-dim)>);
-	static_assert(std::is_same_v<dimless_base, decltype(-base)>);
+	static_assert(std::is_same_v<dimensionless<int>, decltype(dim * 1)>);
+	static_assert(std::is_same_v<dimensionless<int>, decltype(1 * dim)>);
+	static_assert(std::is_same_v<dimensionless<int>, decltype(dim * dim)>);
 
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(-m)>);
-	static_assert(std::is_same_v<meter_base, decltype(-b_m)>);
+	static_assert(std::is_same_v<meters<int>, decltype(m * 1)>);
+	static_assert(std::is_same_v<meters<int>, decltype(1 * m)>);
+	static_assert(std::is_same_v<meters<int>, decltype(m * dim)>);
+	static_assert(std::is_same_v<meters<int>, decltype(dim * m)>);
 
-	static_assert(std::is_same_v<dimless, decltype(dim + 0)>);
-	static_assert(std::is_same_v<dimless, decltype(0 + dim)>);
-	static_assert(std::is_same_v<dimless, decltype(dim + dim)>);
-	static_assert(std::is_same_v<dimless, decltype(dim + base)>);
-	static_assert(std::is_same_v<dimless, decltype(base + dim)>);
-	static_assert(std::is_same_v<dimless_base, decltype(base + base)>);
-	static_assert(std::is_same_v<dimless_base, decltype(base + 0)>);
-	static_assert(std::is_same_v<dimless_base, decltype(0 + base)>);
+	static_assert(std::is_same_v<square_meters<int>, decltype(m * m)>);
 
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(m + m)>);
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(m + b_m)>);
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(b_m + m)>);
-	static_assert(std::is_same_v<meter_base, decltype(b_m + b_m)>);
+	static_assert(std::is_same_v<dimensionless<int>, decltype(dim / 1)>);
+	static_assert(std::is_same_v<dimensionless<int>, decltype(1 / dim)>);
+	static_assert(std::is_same_v<dimensionless<int>, decltype(dim / dim)>);
 
-	static_assert(std::is_same_v<dimless, decltype(dim - 0)>);
-	static_assert(std::is_same_v<dimless, decltype(0 - dim)>);
-	static_assert(std::is_same_v<dimless, decltype(dim - dim)>);
-	static_assert(std::is_same_v<dimless, decltype(dim - base)>);
-	static_assert(std::is_same_v<dimless, decltype(base - dim)>);
-	static_assert(std::is_same_v<dimless_base, decltype(base - base)>);
-	static_assert(std::is_same_v<dimless_base, decltype(base - 0)>);
-	static_assert(std::is_same_v<dimless_base, decltype(0 - base)>);
+	static_assert(std::is_same_v<meters<int>, decltype(m / 1)>);
+	static_assert(std::is_same_v<unit<inverse<meter_conversion_factor>, int>, decltype(1 / m)>);
+	static_assert(std::is_same_v<meters<int>, decltype(m / dim)>);
+	static_assert(std::is_same_v<unit<inverse<meter_conversion_factor>, int>, decltype(dim / m)>);
 
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(m - m)>);
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(m - b_m)>);
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(b_m - m)>);
-	static_assert(std::is_same_v<meter_base, decltype(b_m - b_m)>);
+	static_assert(std::is_same_v<dimensionless<int>, decltype(m / m)>);
 
-	static_assert(std::is_same_v<dimless, decltype(dim * 1)>);
-	static_assert(std::is_same_v<dimless, decltype(1 * dim)>);
-	static_assert(std::is_same_v<dimless, decltype(dim * dim)>);
-	static_assert(std::is_same_v<dimless, decltype(dim * base)>);
-	static_assert(std::is_same_v<dimless, decltype(base * dim)>);
-	static_assert(std::is_same_v<dimless, decltype(base * base)>);
-	static_assert(std::is_same_v<dimless_base, decltype(base * 1)>);
-	static_assert(std::is_same_v<dimless_base, decltype(1 * base)>);
+	static_assert(std::is_same_v<dimensionless<int>, decltype(dim % 1)>);
+	static_assert(std::is_same_v<dimensionless<int>, decltype(dim % dim)>);
 
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(m * 1)>);
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(1 * m)>);
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(m * dim)>);
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(dim * m)>);
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(m * base)>);
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(base * m)>);
-
-	static_assert(std::is_same_v<meter_base, decltype(b_m * 1)>);
-	static_assert(std::is_same_v<meter_base, decltype(1 * b_m)>);
-	static_assert(std::is_same_v<meter_base, decltype(b_m * dim)>);
-	static_assert(std::is_same_v<meter_base, decltype(dim * b_m)>);
-	static_assert(std::is_same_v<meter_base, decltype(b_m * base)>);
-	static_assert(std::is_same_v<meter_base, decltype(base * b_m)>);
-
-	static_assert(std::is_same_v<squared_meter, decltype(m * m)>);
-	static_assert(std::is_same_v<squared_meter, decltype(m * b_m)>);
-	static_assert(std::is_same_v<squared_meter, decltype(b_m * m)>);
-	static_assert(std::is_same_v<squared_meter, decltype(b_m * b_m)>);
-
-	static_assert(std::is_same_v<dimless, decltype(dim / 1)>);
-	static_assert(std::is_same_v<dimless_base, decltype(1 / dim)>);
-	static_assert(std::is_same_v<dimless, decltype(dim / dim)>);
-	static_assert(std::is_same_v<dimless, decltype(dim / base)>);
-	static_assert(std::is_same_v<dimless, decltype(base / dim)>);
-	static_assert(std::is_same_v<dimless, decltype(base / base)>);
-	static_assert(std::is_same_v<dimless_base, decltype(base / 1)>);
-	static_assert(std::is_same_v<dimless_base, decltype(1 / base)>);
-
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(m / 1)>);
-	static_assert(std::is_same_v<inverse_meter, decltype(1 / m)>);
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(m / dim)>);
-	static_assert(std::is_same_v<inverse_meter, decltype(dim / m)>);
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(m / base)>);
-	static_assert(std::is_same_v<inverse_meter, decltype(base / m)>);
-
-	static_assert(std::is_same_v<meter_base, decltype(b_m / 1)>);
-	static_assert(std::is_same_v<inverse_meter, decltype(1 / b_m)>);
-	static_assert(std::is_same_v<meter_base, decltype(b_m / dim)>);
-	static_assert(std::is_same_v<inverse_meter, decltype(dim / b_m)>);
-	static_assert(std::is_same_v<meter_base, decltype(b_m / base)>);
-	static_assert(std::is_same_v<inverse_meter, decltype(base / b_m)>);
-
-	static_assert(std::is_same_v<dimless, decltype(m / m)>);
-	static_assert(std::is_same_v<dimless, decltype(m / b_m)>);
-	static_assert(std::is_same_v<dimless, decltype(b_m / m)>);
-	static_assert(std::is_same_v<dimless, decltype(b_m / b_m)>);
-
-	static_assert(std::is_same_v<dimless, decltype(dim % 1)>);
-	static_assert(std::is_same_v<dimless, decltype(dim % dim)>);
-	static_assert(std::is_same_v<dimless, decltype(dim % base)>);
-	static_assert(std::is_same_v<dimless_base, decltype(base % dim)>);
-	static_assert(std::is_same_v<dimless_base, decltype(base % 1)>);
-	static_assert(std::is_same_v<dimless_base, decltype(base % base)>);
-
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(m % 1)>);
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(m % dim)>);
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(m % base)>);
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(m % m)>);
-	static_assert(std::is_same_v<meter_conversion_factor, decltype(m % b_m)>);
-	static_assert(std::is_same_v<meter_base, decltype(b_m % 1)>);
-	static_assert(std::is_same_v<meter_base, decltype(b_m % dim)>);
-	static_assert(std::is_same_v<meter_base, decltype(b_m % base)>);
-	static_assert(std::is_same_v<meter_base, decltype(b_m % m)>);
-	static_assert(std::is_same_v<meter_base, decltype(b_m % b_m)>);
+	static_assert(std::is_same_v<meters<int>, decltype(m % 1)>);
+	static_assert(std::is_same_v<meters<int>, decltype(m % dim)>);
+	static_assert(std::is_same_v<meters<int>, decltype(m % m)>);
 }
 
 TEST_F(UnitType, unitTypeAddition)
@@ -4155,11 +4076,11 @@ TEST_F(Constexpr, arithmetic)
 	[[maybe_unused]] constexpr auto result1(1.0_m - 1.0_m);
 	[[maybe_unused]] constexpr auto result2(1.0_m * 1.0_m);
 	[[maybe_unused]] constexpr auto result3(1.0_m / 1.0_m);
-	[[maybe_unused]] constexpr auto result4(meters(1) + meters(1));
-	[[maybe_unused]] constexpr auto result5(meters(1) - meters(1));
-	[[maybe_unused]] constexpr auto result6(meters(1) * meters(1));
-	[[maybe_unused]] constexpr auto result7(meters(1) / meters(1));
-	[[maybe_unused]] constexpr auto result8(pow<2>(meters(2)));
+	[[maybe_unused]] constexpr auto result4(meters<int>(1) + meters<int>(1));
+	[[maybe_unused]] constexpr auto result5(meters<int>(1) - meters<int>(1));
+	[[maybe_unused]] constexpr auto result6(meters<int>(1) * meters<int>(1));
+	[[maybe_unused]] constexpr auto result7(meters<int>(1) / meters<int>(1));
+	[[maybe_unused]] constexpr auto result8(pow<2>(meters<int>(2)));
 	constexpr auto result9  = pow<3>(2.0_m);
 	constexpr auto result10 = 2.0_m * 2.0_m;
 
@@ -4167,10 +4088,10 @@ TEST_F(Constexpr, arithmetic)
 	EXPECT_TRUE(noexcept(1.0_m - 1.0_m));
 	EXPECT_TRUE(noexcept(1.0_m * 1.0_m));
 	EXPECT_TRUE(noexcept(1.0_m / 1.0_m));
-	EXPECT_TRUE(noexcept(meters(1) + meters(1)));
-	EXPECT_TRUE(noexcept(meters(1) - meters(1)));
-	EXPECT_TRUE(noexcept(meters(1) * meters(1)));
-	EXPECT_TRUE(noexcept(meters(1) / meters(1)));
+	EXPECT_TRUE(noexcept(meters<int>(1) + meters<int>(1)));
+	EXPECT_TRUE(noexcept(meters<int>(1) - meters<int>(1)));
+	EXPECT_TRUE(noexcept(meters<int>(1) * meters<int>(1)));
+	EXPECT_TRUE(noexcept(meters<int>(1) / meters<int>(1)));
 	EXPECT_TRUE(noexcept(pow<2>(meters<double>(2))));
 	EXPECT_TRUE(noexcept(pow<3>(2.0_m)));
 	EXPECT_TRUE(noexcept(2.0_m * 2.0_m));
@@ -4191,7 +4112,7 @@ TEST_F(Constexpr, assignment)
 {
 	auto testConstexpr = []() constexpr noexcept
 	{
-		meters m{42.};
+		meters<double> m{42.};
 		+m;
 		-m;
 		++m;
@@ -4246,23 +4167,23 @@ TEST_F(Constexpr, stdArray)
 
 TEST_F(CaseStudies, radarRangeEquation)
 {
-	watts P_t;           // transmit power
-	dimensionless G;     // gain
-	meters lambda;       // wavelength
-	square_meters sigma; // radar cross section
-	meters R;            // range
-	kelvin T_s;          // system noise temp
-	hertz B_n;           // bandwidth
-	dimensionless L;     // loss
+	watts<> P_t;           // transmit power
+	dimensionless<> G;     // gain
+	meters<> lambda;       // wavelength
+	square_meters<> sigma; // radar cross section
+	meters<> R;            // range
+	kelvin<> T_s;          // system noise temp
+	hertz<> B_n;           // bandwidth
+	dimensionless<> L;     // loss
 
-	P_t    = megawatts(1.4);
-	G      = dB(33.0);
-	lambda = constants::c / megahertz(2800.0);
-	sigma  = square_meters(1.0);
-	R      = meters(111000.0);
-	T_s    = kelvin(950.0);
-	B_n    = megahertz(1.67);
-	L      = dB(8.0);
+	P_t    = megawatts<>(1.4);
+	G      = dB<>(33.0);
+	lambda = constants::c / megahertz<>(2800.0);
+	sigma  = square_meters<>(1.0);
+	R      = meters<>(111000.0);
+	T_s    = kelvin<>(950.0);
+	B_n    = megahertz<>(1.67);
+	L      = dB<>(8.0);
 
 	dimensionless<double> SNR = (P_t * pow<2>(G) * pow<2>(lambda) * sigma) /
 		(pow<3>(4 * constants::pi) * pow<4>(R) * constants::k_B * T_s * B_n * L);
@@ -4273,6 +4194,7 @@ TEST_F(CaseStudies, radarRangeEquation)
 TEST_F(CaseStudies, rightTriangle)
 {
 	constexpr auto a = 3.0_m;
+
 	constexpr auto b = 4.0_m;
 	constexpr auto c = sqrt(pow<2>(a) + pow<2>(b));
 	EXPECT_EQ(5.0_m, c);

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -141,7 +141,7 @@ TEST_F(TypeTraits, is_conversion_factor)
 	EXPECT_FALSE(traits::is_conversion_factor_v<double>);
 	EXPECT_TRUE(traits::is_conversion_factor_v<meter_conversion_factor>);
 	EXPECT_TRUE(traits::is_conversion_factor_v<foot_conversion_factor>);
-//	EXPECT_TRUE(traits::is_conversion_factor_v<degree_squared_conversion_factor>);
+	EXPECT_TRUE(traits::is_conversion_factor_v<degree_squared_conversion_factor>);
 	EXPECT_TRUE(traits::is_conversion_factor_v<meters<double>>);
 }
 
@@ -151,7 +151,7 @@ TEST_F(TypeTraits, is_unit)
 	EXPECT_FALSE(traits::is_unit_v<double>);
 	EXPECT_FALSE(traits::is_unit_v<meter_conversion_factor>);
 	EXPECT_FALSE(traits::is_unit_v<foot_conversion_factor>);
-//	EXPECT_FALSE(traits::is_unit_v<degree_squared_conversion_factor>);
+	EXPECT_FALSE(traits::is_unit_v<degree_squared_conversion_factor>);
 	EXPECT_TRUE(traits::is_unit_v<meters<double>>);
 }
 

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -4194,7 +4194,6 @@ TEST_F(CaseStudies, radarRangeEquation)
 TEST_F(CaseStudies, rightTriangle)
 {
 	constexpr auto a = 3.0_m;
-
 	constexpr auto b = 4.0_m;
 	constexpr auto c = sqrt(pow<2>(a) + pow<2>(b));
 	EXPECT_EQ(5.0_m, c);


### PR DESCRIPTION
resolves #219.

Refs: 1634c7864d782e9ef960e73a45a376a4b728ca30

This ICEs on GCC 10+ due to [GCC 95486](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95486). So it may be incomplete.