### PR TITLE
Fix "ENABLE_PREDEFINED_CONSTANTS_UNITS" not used (#264)

### DIFF
--- a/include/units.h
+++ b/include/units.h
@@ -4154,7 +4154,7 @@ namespace units
 	 * @brief		namespace for physical constants like PI and Avogadro's Number.
 	 * @sa			See unit_t for more information on unit type containers.
 	 */
-#if !defined(DISABLE_PREDEFINED_UNITS)
+#if !defined(DISABLE_PREDEFINED_UNITS) || defined(ENABLE_PREDEFINED_CONSTANTS_UNITS)
 	namespace constants
 	{
 		/**


### PR DESCRIPTION
Hi!

Recently I compiled `units` with `DISABLE_PREDEFINED_UNITS=ON` but could not access `contants::PI` despite `ENABLE_PREDEFINED_CONSTANTS_UNITS=ON`.

It seems this problem has been reported in #264. Could the fix be that simple?