### PR TITLE
Fix UNITS_<VAR> def and <var> use mismatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,13 +23,13 @@ target_include_directories(${PROJECT_NAME}
 )
 
 # Remove IOStream from the library (useful for embdedded development)
-if(DISABLE_IOSTREAM)
+if(UNITS_DISABLE_IOSTREAM)
 	target_compile_definitions(${PROJECT_NAME} INTERFACE -DUNIT_LIB_DISABLE_IOSTREAM)
-endif(DISABLE_IOSTREAM)
+endif(UNITS_DISABLE_IOSTREAM)
 
 # unit tests
 include(CTest)
-if(BUILD_TESTING AND BUILD_TESTS)
+if(BUILD_TESTING AND UNITS_BUILD_TESTS)
 	enable_testing()
 	find_package(Threads)
 	add_subdirectory(3rdParty/googletest-1.10.0)
@@ -37,7 +37,7 @@ if(BUILD_TESTING AND BUILD_TESTS)
 endif()
 
 # add a target to generate API documentation with Doxygen
-if(BUILD_DOCS)
+if(UNITS_BUILD_DOCS)
 	find_package(Doxygen)
 	if(DOXYGEN_FOUND)
 		configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docs/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)


### PR DESCRIPTION
A few variables prefixed with UNITS_ are defined to control various
build options, but prefix-less versions are checked in the rest of the
file when determining their values. This makes the options effectively
useless.

This commit unifies definition and use so the options actually affect
the build.