### PR TITLE
Fix compile error under GCC-12

### DIFF
--- a/include/units/core.h
+++ b/include/units/core.h
@@ -1805,7 +1805,7 @@ namespace units
 					normal_convert(static_cast<CommonUnderlying>(value) / static_cast<CommonUnderlying>(pow(detail::PI_VAL, -PiRatio::num / PiRatio::den))));
 			}
 			// non-constexpr pi in numerator. This case (only) isn't actually constexpr.
-			else if constexpr (PiRatio::num / PiRatio::den < 1 && PiRatio::num / PiRatio::den > -1)
+			else if constexpr ((PiRatio::num / PiRatio::den) < 1 && (PiRatio::num / PiRatio::den) > -1)
 			{
 				return static_cast<To>(normal_convert(
 					static_cast<CommonUnderlying>(value) * static_cast<CommonUnderlying>(std::pow(detail::PI_VAL, PiRatio::num / PiRatio::den))));


### PR DESCRIPTION
Fix ambiguous parse error in the following expression:
  if constexpr (PiRatio::num / PiRatio::den < 1 && PiRatio::num / PiRatio::den > -1)

GCC-12 apparently interprets `PiRatio::den < 1 && PiRatio::num / PiRatio::den >` as a template expression, which it shouldn't. Help disambiguating this expression by putting parentheses around the division.

Closes #306