### PR TITLE
MSVC-specific Empty Baseclass Optimization activation.

### DIFF
--- a/include/units/core.h
+++ b/include/units/core.h
@@ -2134,8 +2134,15 @@ namespace units
 	 *				- \ref concentrationUnits "concentration units"
 	 *				- \ref constantUnits "constant units"
 	 */
+#ifdef _WIN32
+// Microsoft compiler requires explicit activation of empty base class optimization
+// so that sizeof(unit<..., double, ...>) == sizeof(double)
+#define MSVC_EBO __declspec(empty_bases)
+#else
+#define MSVC_EBO
+#endif
 	template<class ConversionFactor, typename T = UNIT_LIB_DEFAULT_TYPE, class NumericalScale = linear_scale>
-	class unit : public ConversionFactor, NumericalScale, units::detail::_unit
+	class MSVC_EBO unit : public ConversionFactor, NumericalScale, units::detail::_unit
 	{
 		static_assert(traits::is_conversion_factor_v<ConversionFactor>,
 			"Template parameter `ConversionFactor` must be a conversion factor. Check that you aren't using an unit "

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -103,9 +103,15 @@ namespace
 	};
 } // namespace
 
+TEST_F(TypeTraits, sizeOf) {
+    static_assert(sizeof(dimensionless<double>) == sizeof(double));
+    static_assert(sizeof(meters<double>) == sizeof(double));
+    static_assert(sizeof(degrees_squared<double>) == sizeof(double));
+}
+
 TEST_F(TypeTraits, isRatio)
 {
-	EXPECT_TRUE(traits::is_ratio_v<std::ratio<1>>);
+    EXPECT_TRUE(traits::is_ratio_v<std::ratio<1>>);
 	EXPECT_FALSE(traits::is_ratio_v<double>);
 }
 


### PR DESCRIPTION
Ensures sizof(unit type) is the same as sizeof(underlying_type), which was not the case on Windows on the v3.x branch.
Without that fix I observed sizeof(meters<float>) to be 8  as each units base class contributes at least one byte on top of the 4 bytes of a float.

According to [this answer](https://stackoverflow.com/a/55530422/4249338), that fix is valid since Visual Studio 2017 Update 2, which seems acceptable to me in term of backward compatibility for the new branch? 

Extended test coverage accordingly.