### PR TITLE
Bump CMake Minimum Version Range

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.2...3.5 FATAL_ERROR)
 
 PROJECT(units LANGUAGES CXX)
 set(units_VERSION 2.3.1)


### PR DESCRIPTION
## Changes
Increase the CMake minimum required version to include the range from 3.2 to 3.5.

## Description
CMake version 3.27 introduces a [deprecation warning for versions < 3.5](https://cmake.org/cmake/help/latest/release/3.27.html#id18). This PR's changes resolve these deprecation warnings.

## Testing
* `UnitContainer/to_string_locale` fails on arrival (not fixed).
* All other tests unchanged and pass.
* Build process appears by unchanged.
