### PR TITLE
Using intmax_t instead of size_t fixes narrowing conversion on 32bit

### DIFF
--- a/include/units.h
+++ b/include/units.h
@@ -1524,7 +1524,7 @@ namespace units
 			return value;
 		}
 
-		template<std::size_t Ratio_num, std::size_t Ratio_den>
+		template<std::intmax_t  Ratio_num, std::intmax_t Ratio_den>
 		struct normal_convert
 		{
 			template<typename T>
@@ -1534,7 +1534,7 @@ namespace units
 			}
 		};
 
-		template<std::size_t Ratio_num>
+		template<std::intmax_t  Ratio_num>
 		struct normal_convert<Ratio_num, 1>
 		{
 			template<typename T>
@@ -1544,7 +1544,7 @@ namespace units
 			}
 		};
 
-		template<std::size_t Ratio_den>
+		template<std::intmax_t  Ratio_den>
 		struct normal_convert<1, Ratio_den>
 		{
 			template<typename T>


### PR DESCRIPTION
The update fixes https://github.com/nholthaus/units/issues/308.