### PR TITLE
Add #undef PI

### DIFF
--- a/include/units.h
+++ b/include/units.h
@@ -4162,6 +4162,7 @@ namespace units
 		 * @anchor constantContainers
 		 * @{
 		 */
+		#undef PI
 		using PI = unit<std::ratio<1>, dimensionless::scalar, std::ratio<1>>;
 
 		static constexpr const unit_t<PI>																											pi(1);											///< Ratio of a circle's circumference to its diameter.


### PR DESCRIPTION
Some other libraries define PI, which creates a conflict. This will implicitly resolve this problem. (It can be resolved explicitly, by adding this line of code before include, but that's extremely annoying)