### PR TITLE
Updated CMake policy version to resolve deprecation warning.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.2...3.5 FATAL_ERROR)
 
 PROJECT(units LANGUAGES CXX)
 set(units_VERSION 2.3.1)


### PR DESCRIPTION
From <https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html>:

> Changed in version 3.27: Compatibility with versions of CMake older than 3.5 is deprecated. Calls to cmake_minimum_required(VERSION) or cmake_policy(VERSION) that do not specify at least 3.5 as their policy version (optionally via ...<max>) will produce a deprecation warning in CMake 3.27 and above.