### PR TITLE
fix (backport): define mil as 1/1000 of an inch and not 1000 inches

### DIFF
--- a/include/units.h
+++ b/include/units.h
@@ -3398,7 +3398,7 @@ namespace units
 	UNIT_ADD_WITH_METRIC_PREFIXES(length, meter, meters, m, unit<std::ratio<1>, units::category::length_unit>)
 	UNIT_ADD(length, foot, feet, ft, unit<std::ratio<381, 1250>, meters>)
 	UNIT_ADD(length, inch, inches, in, unit<std::ratio<1, 12>, feet>)
-	UNIT_ADD(length, mil, mils, mil, unit<std::ratio<1000>, inches>)
+	UNIT_ADD(length, mil, mils, mil, unit<std::ratio<1, 1000>, inches>)
 	UNIT_ADD(length, mile,   miles,    mi,    unit<std::ratio<5280>, feet>)
 	UNIT_ADD(length, nauticalMile, nauticalMiles, nmi, unit<std::ratio<1852>, meters>)
 	UNIT_ADD(length, astronicalUnit, astronicalUnits, au, unit<std::ratio<149597870700>, meters>)

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -1660,7 +1660,7 @@ TEST_F(UnitConversion, length)
 	test = convert<meters, chains>(1.0);
 	EXPECT_NEAR(0.0497097, test, 5.0e-7);
 	test = convert<inches, mils>(1.0);
-	EXPECT_NEAR(0.001, test, 5.0e-7);
+	EXPECT_NEAR(1000.0, test, 5.0e-5);
 
 }
 


### PR DESCRIPTION
Closes #346
Backports #321 