### PR TITLE
Fix std extensions still using `operator()`

### DIFF
--- a/include/units/core.h
+++ b/include/units/core.h
@@ -2195,9 +2195,9 @@ namespace units
 					 *
 					 *				The value of an `unit` can only be set on construction, or changed by assignment
 					 *				from another `unit` type. If necessary, the underlying value can be accessed
-					 *				using `operator()`: @code
+					 *				using `raw()`: @code
 					 *				meter_t m(5.0);
-					 *				double val = m(); // val == 5.0	@endcode.
+					 *				double val = m.raw(); // val == 5.0	@endcode.
 					 * @tparam		ConversionFactor `conversion_factor` of the represented unit (e.g. meters)
 					 * @tparam		T underlying type of the storage. Defaults to `UNIT_LIB_DEFAULT_TYPE`.
 					 * @tparam		NumericalScale optional scale class for the units. Defaults to linear (i.e. does
@@ -4646,19 +4646,25 @@ namespace std
 	template<units::ConversionFactorType ConversionFactor, units::ArithmeticType T, units::NumericalScaleType<T> NonLinearScale>
 	constexpr bool isnan(const units::unit<ConversionFactor, T, NonLinearScale>& x)
 	{
-		return std::isnan(x());
+		return std::isnan(x.raw());
 	}
 
 	template<units::ConversionFactorType ConversionFactor, units::ArithmeticType T, units::NumericalScaleType<T> NonLinearScale>
 	constexpr bool isinf(const units::unit<ConversionFactor, T, NonLinearScale>& x)
 	{
-		return std::isinf(x());
+		return std::isinf(x.raw());
+	}
+
+	template<units::ConversionFactorType ConversionFactor, units::ArithmeticType T, units::NumericalScaleType<T> NonLinearScale>
+	constexpr bool isfinite(const units::unit<ConversionFactor, T, NonLinearScale>& x)
+	{
+		return std::isfinite(x.raw());
 	}
 
 	template<units::ConversionFactorType ConversionFactor, units::ArithmeticType T, units::NumericalScaleType<T> NonLinearScale>
 	constexpr bool signbit(const units::unit<ConversionFactor, T, NonLinearScale>& x)
 	{
-		return std::signbit(x());
+		return std::signbit(x.raw());
 	}
 } // namespace std
 

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -5061,6 +5061,38 @@ TEST_F(UnitMath, isunordered)
 	EXPECT_FALSE(units::isunordered(zero, zero));
 }
 
+TEST_F(UnitMath, signbit)
+{
+	meters<> zero(0.0);
+	meters<> pos(1.0);
+	meters<> neg(-1.0);
+	meters<> negZero(-0.0);
+
+	EXPECT_FALSE(std::signbit(zero));
+	EXPECT_FALSE(std::signbit(pos));
+	EXPECT_TRUE(std::signbit(neg));
+	EXPECT_TRUE(std::signbit(negZero));
+}
+
+TEST_F(UnitMath, stdExtensions)
+{
+	meters<> zero(0.0);
+	meters<> nan(NAN);
+	meters<> inf(INFINITY);
+
+	EXPECT_TRUE(std::isnan(nan));
+	EXPECT_FALSE(std::isnan(inf));
+	EXPECT_FALSE(std::isnan(zero));
+
+	EXPECT_TRUE(std::isinf(inf));
+	EXPECT_FALSE(std::isinf(nan));
+	EXPECT_FALSE(std::isinf(zero));
+
+	EXPECT_TRUE(std::isfinite(zero));
+	EXPECT_FALSE(std::isfinite(nan));
+	EXPECT_FALSE(std::isfinite(inf));
+}
+
 // Constexpr
 TEST_F(Constexpr, construction)
 {

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -10,7 +10,11 @@
 #include <chrono>
 #include <complex>
 #include <gtest/gtest.h>
+#include <iomanip>
+#include <iostream>
+#include <locale>
 #include <ratio>
+#include <sstream>
 #include <string>
 #include <type_traits>
 #include <units.h>
@@ -3031,6 +3035,10 @@ TEST_F(UnitType, to_string_locale)
 #if defined(_MSC_VER)
 	setlocale(LC_ALL, "de-DE");
 	os1.imbue(std::locale("de-DE"));
+#elif defined(__APPLE__)
+	// BSD libc (macOS) only recognizes the canonical `.UTF-8` spelling, not glibc's `de_DE.utf8` alias.
+	EXPECT_STREQ("de_DE.UTF-8", setlocale(LC_ALL, "de_DE.UTF-8")) << "For this test to work, you need a german locale installed.";
+	os1.imbue(std::locale("de_DE.UTF-8"));
 #else
 	EXPECT_STREQ("de_DE.utf8", setlocale(LC_ALL, "de_DE.utf8")) << "For this test to work, you need a german locale installed: `sudo locale-gen de_DE.UTF-8`";
 	os1.imbue(std::locale("de_DE.utf8"));
@@ -3054,6 +3062,10 @@ TEST_F(UnitType, to_string_locale)
 #if defined(_MSC_VER)
 	setlocale(LC_ALL, "en-US");
 	os2.imbue(std::locale("en-US"));
+#elif defined(__APPLE__)
+	// BSD libc (macOS) only recognizes the canonical `.UTF-8` spelling, not glibc's `en_US.utf8` alias.
+	EXPECT_STREQ("en_US.UTF-8", setlocale(LC_ALL, "en_US.UTF-8")) << "For this test to work, you need a USA locale installed.";
+	os2.imbue(std::locale("en_US.UTF-8"));
 #else
 	EXPECT_STREQ("en_US.utf8", setlocale(LC_ALL, "en_US.utf8")) << "For this test to work, you need a USA locale installed: `sudo locale-gen en_US.UTF-8`";
 	os2.imbue(std::locale("en_US.utf8"));


### PR DESCRIPTION
`std::isnan()`, `std::isinf()` and `std:: signbit()` were still using the legacy `operator()` and `std::isfinite()` was missing. I also fixed the unit tests so that they can run on macOS.

Thanks for the awesome library!