### PR TITLE
v3.4.0: readable diagnostics (class-based named units) + #357 fix + natvis + error-msg CI harness

### DIFF
--- a/.github/workflows/clang-19.yaml
+++ b/.github/workflows/clang-19.yaml
@@ -45,3 +45,7 @@ jobs:
       - name: Run Tests
         working-directory: build
         run: ctest --output-on-failure
+
+      - name: Error-message tests
+        run: |
+          python3 test/errorMessages/run.py --cc clang++-19 --std c++23 --include include

--- a/.github/workflows/gcc-13.yaml
+++ b/.github/workflows/gcc-13.yaml
@@ -44,3 +44,7 @@ jobs:
       - name: Run Tests
         working-directory: build
         run: ctest --output-on-failure
+
+      - name: Error-message tests
+        run: |
+          python3 test/errorMessages/run.py --cc g++-13 --std c++23 --include include

--- a/.github/workflows/msvc-2022.yaml
+++ b/.github/workflows/msvc-2022.yaml
@@ -15,14 +15,27 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      # Set up the MSVC command-line environment FIRST (puts cl.exe on PATH). The "Visual Studio 17 2022"
+      # generator's own VS discovery has been unreliable on recent windows-latest images ("could not find any
+      # instance of Visual Studio"); configuring with Ninja against the dev-cmd-provided cl is robust and also
+      # provides cl for the error-message harness below.
+      - name: Set up MSVC command-line environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
       - name: Configure CMake
         run: |
-          cmake -B build -G "Visual Studio 17 2022" -A x64
+          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=cl
 
       - name: Build
         run: |
-          cmake --build build --config Release
+          cmake --build build
 
       - name: Run Tests
         working-directory: build
-        run: ctest -C Release --output-on-failure
+        run: ctest --output-on-failure
+
+      - name: Error-message tests
+        run: |
+          python test/errorMessages/run.py --cc cl --std c++23 --include include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,15 @@ target_include_directories(${PROJECT_NAME}
 # Require C++23 for consumers (header-only propagation)
 target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_23)
 
+# Ship the MSVC debugger visualizer (natvis) so a consumer's Visual Studio shows a unit as "3 m" instead of an
+# opaque object. Attaching it to the INTERFACE target propagates it to anything that links `units`, and MSVC
+# auto-loads a .natvis carried on a target. No-op for non-MSVC generators.
+if(MSVC)
+	target_sources(${PROJECT_NAME} INTERFACE
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/natvis/units.natvis>
+		$<INSTALL_INTERFACE:natvis/units.natvis>)
+endif()
+
 # Remove IOStream from the library (useful for embedded development)
 if(UNITS_DISABLE_IOSTREAM)
 	target_compile_definitions(${PROJECT_NAME} INTERFACE UNIT_LIB_DISABLE_IOSTREAM)
@@ -76,6 +85,12 @@ write_basic_package_version_file(
 # Install headers
 install(DIRECTORY include/
 		DESTINATION include
+)
+
+# Install the MSVC debugger visualizer so the installed package's $<INSTALL_INTERFACE:natvis/units.natvis>
+# resolves and Visual Studio picks it up for consumers of the installed units package.
+install(FILES natvis/units.natvis
+		DESTINATION natvis
 )
 
 # Exported targets -> unitsTargets.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16...4.99 FATAL_ERROR)
 
-PROJECT(units VERSION 3.1.2 LANGUAGES CXX)
+PROJECT(units VERSION 3.4.0 LANGUAGES CXX)
 
 # check if this is the main project
 set(MAIN_PROJECT OFF)

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -2195,9 +2195,9 @@ namespace units
 					 *
 					 *				The value of an `unit` can only be set on construction, or changed by assignment
 					 *				from another `unit` type. If necessary, the underlying value can be accessed
-					 *				using `operator()`: @code
+					 *				using `raw()`: @code
 					 *				meter_t m(5.0);
-					 *				double val = m(); // val == 5.0	@endcode.
+					 *				double val = m.raw(); // val == 5.0	@endcode.
 					 * @tparam		ConversionFactor `conversion_factor` of the represented unit (e.g. meters)
 					 * @tparam		T underlying type of the storage. Defaults to `UNIT_LIB_DEFAULT_TYPE`.
 					 * @tparam		NumericalScale optional scale class for the units. Defaults to linear (i.e. does
@@ -4646,19 +4646,25 @@ namespace std
 	template<units::ConversionFactorType ConversionFactor, units::ArithmeticType T, units::NumericalScaleType<T> NonLinearScale>
 	constexpr bool isnan(const units::unit<ConversionFactor, T, NonLinearScale>& x)
 	{
-		return std::isnan(x());
+		return std::isnan(x.raw());
 	}
 
 	template<units::ConversionFactorType ConversionFactor, units::ArithmeticType T, units::NumericalScaleType<T> NonLinearScale>
 	constexpr bool isinf(const units::unit<ConversionFactor, T, NonLinearScale>& x)
 	{
-		return std::isinf(x());
+		return std::isinf(x.raw());
+	}
+
+	template<units::ConversionFactorType ConversionFactor, units::ArithmeticType T, units::NumericalScaleType<T> NonLinearScale>
+	constexpr bool isfinite(const units::unit<ConversionFactor, T, NonLinearScale>& x)
+	{
+		return std::isfinite(x.raw());
 	}
 
 	template<units::ConversionFactorType ConversionFactor, units::ArithmeticType T, units::NumericalScaleType<T> NonLinearScale>
 	constexpr bool signbit(const units::unit<ConversionFactor, T, NonLinearScale>& x)
 	{
-		return std::signbit(x());
+		return std::signbit(x.raw());
 	}
 } // namespace std
 

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -79,6 +79,8 @@
 namespace units::detail
 {
 	template<typename T>
+		requires std::is_arithmetic_v<T>    // numbers only: a named unit's associated namespace is units::detail, so an
+											// unconstrained overload here would be an ADL candidate for to_string(someUnit)
 	std::string to_string(const T& t)
 	{
 		std::string str{std::to_string(t)};
@@ -166,16 +168,12 @@ namespace units
 		{                                                                                                                                                                                              \
 		}; /** @} */                                                                                                                                                                                   \
 	}                                                                                                                                                                                                  \
-	namespace traits                                                                                                                                                                                   \
+	namespace detail                                                                                                                                                                                   \
 	{                                                                                                                                                                                                  \
-		template<>                                                                                                                                                                                     \
-		struct strong<__VA_ARGS__>                                                                                                                                                                     \
-		{                                                                                                                                                                                              \
-			using type = ::units::namespaceName::namePlural##_;                                                                                                                                        \
-		};                                                                                                                                                                                             \
-                                                                                                                                                                                                       \
-		template<class ConversionFactor>                                                                                                                                                               \
-		using strong_t = typename strong<ConversionFactor>::type;                                                                                                                                      \
+		/** ADL registration of the strong type for this conversion factor (see detail::strong_name, #357). */         \
+		/** Exact-`__VA_ARGS__*` parameter — a strictly better match than the variadic fallback — so `strong_t` */     \
+		/** resolves to the named type once THIS header is included, order-independently. Declared, never defined. */   \
+		::units::namespaceName::namePlural##_ strong_name(__VA_ARGS__*);                                                                                                                                \
 	}
 
 /**
@@ -211,8 +209,63 @@ namespace units
  *				comprise the unit definition.
  */
 #define UNIT_ADD_SCALED_UNIT_DEFINITION(unitName, scale, /*conversionFactor*/...)                                                                                                                      \
+	/** A named unit is a CLASS deriving from its `unit<...>` (not an alias) so a diagnostic prints the friendly */    \
+	/** name (`meters<double>`) instead of `unit<strong, Underlying, scale>` cruft, keeping the `unitName<>` spelling. */\
 	template<class Underlying = UNIT_LIB_DEFAULT_TYPE>                                                                                                                                                 \
-	using unitName = ::units::unit<traits::strong_t<__VA_ARGS__>, Underlying, scale>;
+	struct unitName : ::units::unit<traits::strong_t<__VA_ARGS__>, Underlying, scale>                                                                                                                  \
+	{                                                                                                                                                                                                  \
+		using base = ::units::unit<traits::strong_t<__VA_ARGS__>, Underlying, scale>;                                                                                                                  \
+		using base::base;                                                                                                                                                                              \
+		/* Keep the named class TRIVIAL (a load-bearing property of the unit type — memcpy-able, zero overhead): */    \
+		/* explicitly default the special members. Declaring the converting ctor below would otherwise suppress the */ \
+		/* trivial default ctor, and inheriting ctors leaves the special members implicit; defaulting them restores */  \
+		/* std::is_trivial. */                                                                                          \
+		unitName() = default;                                                                                                                                                                          \
+		unitName(const unitName&) = default;                                                                                                                                                           \
+		unitName(unitName&&) = default;                                                                                                                                                                 \
+		unitName& operator=(const unitName&) = default;                                                                                                                                                 \
+		unitName& operator=(unitName&&) = default;                                                                                                                                                      \
+		constexpr unitName(const base& other) noexcept : base(other) {}                                                                                                                               \
+		/* Forward a scalar assignment to the base's operator= so the dimensionless '= 0.30' path (which the derived */ \
+		/* class would otherwise route through the raw-value converting ctor, off by the CF ratio) is used. Templated */\
+		/* + constrained to arithmetic so it never competes with unit-to-unit assignment (that stays the base's job). */\
+		template<class Rhs>                                                                                                                                                                            \
+			requires ::std::is_arithmetic_v<Rhs>                                                                                                                                                       \
+		constexpr unitName& operator=(const Rhs& rhs) noexcept                                                                                                                                          \
+		{                                                                                                                                                                                              \
+			base::operator=(rhs);                                                                                                                                                                      \
+			return *this;                                                                                                                                                                              \
+		}                                                                                                                                                                                              \
+		/** Re-create this named unit with a different underlying type, so traits (replace_underlying, common_type) */ \
+		/** that swap the storage type PRESERVE the friendly name instead of decaying to the plain `unit<...>`. */     \
+		template<class NewUnderlying>                                                                                                                                                                  \
+		using rebind = unitName<NewUnderlying>;                                                                                                                                                        \
+	};                                                                                                                                                                                                 \
+	/** Deduction guide so the BARE name works (no <>): `unitName x(5.0)` / `constexpr unitName c(3e8)` deduces */    \
+	/** `unitName<double>`. As an ALIAS template (pre-refactor) a bare name resolved via the default arg; as a CLASS */\
+	/** template CTAD is required, and some compilers (e.g. GCC 13) will not deduce it from an arithmetic argument */  \
+	/** without this guide. Constrained to arithmetic so it never competes with the base/converting constructors. */  \
+	template<class Arg>                                                                                                                                                                                \
+		requires ::std::is_arithmetic_v<Arg>                                                                                                                                                           \
+	unitName(Arg) -> unitName<Arg>;                                                                                                                                                                    \
+	/** Nullary guide so bare default-construction `unitName{}` / `unitName()` deduces `unitName<default>` — again a */\
+	/** CLASS template needs this where the old alias resolved via its default arg; GCC 13 requires it explicitly. */ \
+	unitName() -> unitName<UNIT_LIB_DEFAULT_TYPE>;                                                                                                                                                      \
+	/** And from another same-dimension UNIT (bare): `unitName x(otherUnit)` deduces the underlying the converting */  \
+	/** constructor would produce — the SOURCE underlying when losslessly convertible to this named unit, else its */  \
+	/** floating-point promotion (so e.g. `radians r(degrees{1})` deduces radians<double>, since degrees->radians is */\
+	/** not integer-lossless). GCC 13 will not deduce this implicitly (GCC 15 will), so the guide is required; */      \
+	/** constrained to unit types so it never competes with the arithmetic/nullary guides. */                          \
+	template<class OtherUnit>                                                                                                                                                                          \
+		requires(::units::traits::is_unit<OtherUnit>::value &&                                                                                                                                         \
+				 ::units::traits::is_same_dimension_unit_v<OtherUnit,                                                                                                                                    \
+					 ::units::unit<traits::strong_t<__VA_ARGS__>, typename ::units::traits::unit_traits<OtherUnit>::underlying_type, scale>>)                                                            \
+	unitName(const OtherUnit&) -> unitName<::units::detail::deduced_named_underlying_t<OtherUnit, traits::strong_t<__VA_ARGS__>, scale>>;\
+	/** And from a std::chrono::duration (bare, for time units): `nanoseconds n(chrono::nanoseconds(10))` deduces */  \
+	/** the default underlying; the chrono converting constructor does the Rep/Period conversion. GCC 13 needs the */ \
+	/** explicit guide. */                                                                                            \
+	template<class Rep, class Period>                                                                                                                                                                  \
+	unitName(const ::std::chrono::duration<Rep, Period>&) -> unitName<UNIT_LIB_DEFAULT_TYPE>;                          \
 /**
  * @def		UNIT_ADD_NAME(namespaceName,namePlural,abbreviation)
  * @brief		Macro for generating constexpr names/abbreviations for units.
@@ -235,6 +288,25 @@ namespace units
 	{                                                                                                                                                                                                  \
 		static constexpr const char* value = #abbrev;                                                                                                                                                  \
 	};
+
+/**
+ * @def			UNIT_REGISTER_NAMED_CLASS(namespaceName, namePlural)
+ * @brief		Register the CF-struct -> NAMED-class ADL map so an arithmetic RESULT is reported as the friendly type.
+ * @details		A result unit<strong, U, scale> is rewrapped into `namePlural<U>` via detail::named_class_of (results
+ *				stay as friendly as inputs). Registered at `units` scope AFTER the class is defined (so no forward
+ *				reference) and only for LINEAR named units — decibel-scale units are excluded because several dB names
+ *				share one linear conversion_factor, which would make the reverse map ambiguous. Declared, never defined.
+ */
+#define UNIT_REGISTER_NAMED_CLASS(namespaceName, namePlural)                                                                                                                                            \
+	namespace detail                                                                                                                                                                                   \
+	{                                                                                                                                                                                                  \
+		/* Keyed on BOTH the conversion_factor AND the numerical scale: the linear and decibel forms of a unit share */ \
+		/* one conversion_factor (watts_ for both watts and dBW) and differ only by scale, so scale must disambiguate */\
+		/* the reverse map (else watts vs dBW collide). Declared, never defined (decltype-only). */                     \
+		::units::namespaceName::namePlural<UNIT_LIB_DEFAULT_TYPE> named_class_of(                                                                                                                       \
+			typename ::units::namespaceName::namePlural<>::conversion_factor*,                                                                                                                          \
+			typename ::units::namespaceName::namePlural<>::numerical_scale_type*);                                                                                                                      \
+	}
 
 /**
  * @def			UNIT_ADD_LITERALS(namespaceName,namePlural,abbreviation)
@@ -289,6 +361,7 @@ namespace units
 	UNIT_ADD_STRONG_CONVERSION_FACTOR(namespaceName, namePlural, __VA_ARGS__)                                                                                                                          \
 	UNIT_ADD_UNIT_DEFINITION(namespaceName, namePlural, __VA_ARGS__)                                                                                                                                   \
 	UNIT_ADD_NAME(namespaceName, namePlural, abbreviation)                                                                                                                                             \
+	UNIT_REGISTER_NAMED_CLASS(namespaceName, namePlural)                                                                                                                                               \
 	UNIT_ADD_LITERALS(namespaceName, namePlural, abbreviation)                                                                                                                                         \
 	UNIT_ADD_CONSTANT(namespaceName, namePlural, abbreviation)
 
@@ -307,6 +380,7 @@ namespace units
 		/** @name Unit Containers */ /** @{ */ UNIT_ADD_SCALED_UNIT_DEFINITION(abbreviation, ::units::decibel_scale, typename ::units::namespaceName::namePlural<>::conversion_factor) /** @} */       \
 	}                                                                                                                                                                                                  \
 	UNIT_ADD_NAME(namespaceName, abbreviation, abbreviation)                                                                                                                                           \
+	UNIT_REGISTER_NAMED_CLASS(namespaceName, abbreviation)                                                                                                                                             \
 	UNIT_ADD_LITERALS(namespaceName, abbreviation, abbreviation)
 
 /**
@@ -663,6 +737,24 @@ namespace units
 		struct _unit
 		{
 		};
+
+		/**
+		 * @brief		ADL customization point that maps a `conversion_factor` to its friendly strong type.
+		 * @details		This is the anchor `traits::strong` resolves through. A dimension header registers a named
+		 *				strong type by declaring a better-matching overload of `strong_name` (see the
+		 *				`UNIT_ADD_STRONG_CONVERSION_FACTOR` macro), discoverable by ADL because a `conversion_factor`'s
+		 *				associated namespace is `units`. This fallback is the WORST match (variadic `...`), so it is
+		 *				chosen only when no dimension header has registered a named type — in which case the strong
+		 *				type is the `conversion_factor` itself. Only ever used unevaluated (in `decltype`); never
+		 *				defined. Being an overload set rather than an explicit specialization, a later-included header
+		 *				merely contributes a stronger candidate — it can never be "declared after instantiation" (#357).
+		 *
+		 *				The fallback deduces the `conversion_factor` from its pointer argument, followed by a trailing
+		 *				ellipsis so that any exact-`CF*` registration overload (a non-template, non-variadic parameter)
+		 *				is a strictly better match and wins whenever its dimension header is visible.
+		 */
+		template<class ConversionFactor>
+		ConversionFactor strong_name(ConversionFactor*, ...);
 	} // namespace detail
 
 	namespace traits
@@ -800,13 +892,25 @@ namespace units
 		 * @brief			SFINAE-able trait that maps a `conversion_factor` to its strengthened type.
 		 * @details			If `T` is a cv-unqualified `conversion_factor`, the member `type` alias names the
 		 *					strong type alias of `T`, if any, and `T` otherwise. Otherwise, there is no `type` member.
-		 *					This may be specialized only if `T` depends on a program-defined type.
+		 *
+		 *					The strong type of a `conversion_factor` is registered by its dimension header (e.g.
+		 *					`units/frequency.h` registers `hertz` for `1/time`). Resolution is an ADL customization
+		 *					point (`units::detail::strong_name`), NOT an explicit specialization of `strong`: a named
+		 *					type is discovered by overload resolution over the `conversion_factor`'s associated
+		 *					namespace at the point `strong_t<T>` is instantiated. This deliberately avoids the
+		 *					"explicit specialization after implicit instantiation" ordering trap (#357) — forming an
+		 *					expression that reduces to a not-yet-included dimension no longer bakes in a decision a
+		 *					later header would contradict; the later header simply contributes a better overload.
 		 */
 		template<ConversionFactorType T>
 			requires std::is_same_v<T, std::remove_cv_t<T>>
-		struct strong : T
+		struct strong
 		{
-			typedef T type;
+			// UNQUALIFIED call so ADL on T* is performed: T is a conversion_factor whose associated namespaces are
+			// `units` and (via its base detail::_conversion_factor) `units::detail`, so every dimension header's
+			// strong_name registration in units::detail is found, along with the identity fallback. A qualified call
+			// (::units::detail::strong_name) would SUPPRESS ADL and see only the fallback — the whole point is ADL.
+			using type = decltype(strong_name(static_cast<T*>(nullptr)));
 		};
 
 		template<class T>
@@ -2148,6 +2252,13 @@ namespace units
 
 	namespace detail
 	{
+		// Forward declaration so unit's name()/abbreviation() members (defined below, in the unit class) can name
+		// detail::rewrap_to_named_t; the full definition follows after the unit class is complete (it depends on it).
+		template<class U, class = void>
+		struct rewrap_to_named;
+		template<class U>
+		using rewrap_to_named_t = typename rewrap_to_named<U>::type;
+
 		/**
 		 * @brief		SFINAE helper to test if an arithmetic conversion is lossless.
 		 */
@@ -2172,6 +2283,31 @@ namespace units
 			std::disjunction<std::is_floating_point<typename UnitTo::underlying_type>,
 				std::conjunction<std::negation<std::is_floating_point<typename UnitFrom::underlying_type>>,
 					is_non_truncated_convertible_unit<typename UnitFrom::conversion_factor, typename UnitTo::conversion_factor>>>>;
+
+		// The underlying type a NAMED unit's from-unit deduction guide should produce when constructed from `Source`:
+		// the source's own underlying when losslessly convertible into the target (StrongCf, Scale), else its
+		// floating-point promotion (so e.g. radians(degrees{1}) deduces radians<double>). A SFINAE-friendly class
+		// template (NOT a var-template init), so the guide's return type never eagerly instantiates
+		// is_losslessly_convertible_unit for a non-unit / non-same-dimension Source — the primary is chosen and the
+		// heavy check only runs in the partial specialization, which is constrained to a same-dimension unit source.
+		template<class Source, class StrongCf, class Scale, class = void>
+		struct deduced_named_underlying
+		{
+			using type = typename traits::unit_traits<Source>::underlying_type;
+		};
+		template<class Source, class StrongCf, class Scale>
+		struct deduced_named_underlying<Source, StrongCf, Scale,
+			std::enable_if_t<traits::is_unit_v<Source> &&
+				traits::is_same_dimension_unit_v<Source, unit<StrongCf, typename traits::unit_traits<Source>::underlying_type, Scale>>>>
+		{
+		private:
+			using Src = typename traits::unit_traits<Source>::underlying_type;
+
+		public:
+			using type = std::conditional_t<is_losslessly_convertible_unit<Source, unit<StrongCf, Src, Scale>>, Src, floating_point_promotion_t<Src>>;
+		};
+		template<class Source, class StrongCf, class Scale>
+		using deduced_named_underlying_t = typename deduced_named_underlying<Source, StrongCf, Scale>::type;
 
 		template<RatioType Ratio>
 		using time_conversion_factor = conversion_factor<Ratio, dimension::time>;
@@ -2579,7 +2715,9 @@ namespace units
 		template<UnitType Unit = unit>
 		[[nodiscard]] constexpr const char* name() const noexcept
 		{
-			return unit_name_v<Unit>;
+			// unit_name is specialized on the NAMED class, not this unit<...> base; resolve the named form first so a
+			// named unit (feet) reports "feet" instead of null. Identity for a plain unit<...>.
+			return unit_name_v<detail::rewrap_to_named_t<Unit>>;
 		}
 
 		/**
@@ -2588,7 +2726,9 @@ namespace units
 		template<UnitType Unit = unit>
 		[[nodiscard]] constexpr const char* abbreviation() const noexcept
 		{
-			return unit_abbreviation_v<Unit>;
+			// unit_abbreviation is specialized on the NAMED class, not this unit<...> base; resolve the named form
+			// first so a named unit (feet) reports "ft" instead of null. Identity for a plain unit<...>.
+			return unit_abbreviation_v<detail::rewrap_to_named_t<Unit>>;
 		}
 
 		template<ConversionFactorType Cf, ArithmeticType Ty, NumericalScaleType<Ty> Ns>
@@ -2598,6 +2738,108 @@ namespace units
 		/// of `units` as NTTP types.
 		T _linearized_value;
 	};
+
+	namespace detail
+	{
+		/**
+		 * @brief		Maps any unit type to the canonical `unit<Cf, Underlying, Scale>` it represents.
+		 * @details		A NAMED unit (e.g. `length::meters<double>`) is a class deriving from its `unit<...>` so a
+		 *				diagnostic prints the friendly name; but the exact-pattern trait specializations
+		 *				(`replace_underlying`, `floating_point_promotion`, `std::common_type`) match `unit<Cf,T,Ns>`
+		 *				literally, not a derived class. `unit_base_t` reconstructs that canonical base from the type's
+		 *				own (inherited) member typedefs, so those traits can unwrap first and work for named and plain
+		 *				units alike. Identity when `T` already IS a `unit<...>`.
+		 */
+		template<class T>
+		using unit_base_t = unit<typename T::conversion_factor, typename T::underlying_type, typename T::numerical_scale_type>;
+
+		// True iff T is a unit-derived class that is NOT itself the canonical unit<...> (i.e. a NAMED unit). Guarded:
+		// unit_base_t<T> (which reads T::conversion_factor) is only well-formed for a unit, so gate on is_unit FIRST
+		// via a helper struct — a plain arithmetic T (e.g. double) has no conversion_factor and must yield false, not
+		// a hard error.
+		template<class T, bool = traits::is_unit<T>::value>
+		struct is_named_unit_impl : std::false_type
+		{
+		};
+		template<class T>
+		struct is_named_unit_impl<T, true> : std::bool_constant<!std::is_same_v<T, unit_base_t<T>>>
+		{
+		};
+		template<class T>
+		inline constexpr bool is_named_unit_v = is_named_unit_impl<T>::value;
+
+		// Re-wrap a computed base result `unit<Cf, U, Ns>` into a NAMED unit when a candidate operand `Named` is a
+		// named unit of the SAME conversion_factor: the friendly name is preserved through the trait (so
+		// common_type<meters<int>, meters<double>> is meters<double>, not unit<meters_, double, linear_scale>). When no
+		// candidate matches (mixed names, or a plain-unit operand), the base result stands. `Base` is the plain unit<>.
+		template<class Base, class Named, class = void>
+		struct rewrap_named
+		{
+			using type = Base;
+		};
+		template<class Base, class Named>
+		struct rewrap_named<Base, Named,
+			std::enable_if_t<is_named_unit_v<Named> && std::is_same_v<typename Base::conversion_factor, typename Named::conversion_factor>>>
+		{
+			using type = typename Named::template rebind<typename Base::underlying_type>;
+		};
+		template<class Base, class Named>
+		using rewrap_named_t = typename rewrap_named<Base, Named>::type;
+
+		// Identity fallback for the CF-struct -> named-class ADL map (the exact registrations are emitted per named
+		// unit by UNIT_REGISTER_NAMED_CLASS). Worst match (trailing ellipsis); returns void to signal "no named class
+		// for this CF". decltype-only, never defined. A real registration's exact strong-CF* parameter beats this.
+		template<class ConversionFactor, class Scale>
+		void named_class_of(ConversionFactor*, Scale*, ...);
+
+		// Map a plain unit<Cf, U, Ns> to its NAMED class when one is registered for Cf, else identity. Used by the
+		// arithmetic operators so a computed result (e.g. unit<square_meters_, int, linear_scale>) is REPORTED as the
+		// friendly named type (square_meters<int>). Rebinds the registered class to U so the underlying flows through.
+		// SFINAE-guarded: only a unit whose Cf has a registration is rewrapped; everything else is identity.
+		// (The primary template + the rewrap_to_named_t alias are forward-declared before the unit class so unit's
+		// name()/abbreviation() members can name them; here we DEFINE the primary and the specialization.)
+		template<class U, class>
+		struct rewrap_to_named
+		{
+			using type = U;
+		};
+		template<class U>
+		struct rewrap_to_named<U,
+			std::enable_if_t<traits::is_unit<U>::value &&
+				!std::is_void_v<decltype(named_class_of(static_cast<typename U::conversion_factor*>(nullptr),
+					static_cast<typename U::numerical_scale_type*>(nullptr)))>>>
+		{
+			using type = typename decltype(named_class_of(static_cast<typename U::conversion_factor*>(nullptr),
+				static_cast<typename U::numerical_scale_type*>(nullptr)))::template rebind<typename U::underlying_type>;
+		};
+	} // namespace detail
+
+	namespace traits
+	{
+		// A NAMED unit (a class deriving from unit<...>) unwraps to its base for these exact-pattern traits, so
+		// replace_underlying / floating_point_promotion behave for named units exactly as for the plain unit<...>.
+		// The plain-unit<...> specializations are declared earlier; these constrained ones fire only for a named unit.
+		template<class Unit, class Underlying>
+			requires ::units::detail::is_named_unit_v<Unit>
+		struct replace_underlying<Unit, Underlying>
+		{
+			// PRESERVE the named type: rebind it to the new underlying (meters<int> -> meters<double>), rather than
+			// decaying to the plain unit<...> base. Keeps trait results as friendly as the inputs.
+			using type = typename Unit::template rebind<Underlying>;
+		};
+	} // namespace traits
+
+	namespace detail
+	{
+		template<class Unit>
+			requires is_named_unit_v<Unit>
+		struct floating_point_promotion<Unit>
+		{
+			// Promote the UNDERLYING type but PRESERVE the friendly named type: rebind the named unit to the promoted
+			// underlying (meters<int> -> meters<double>), so ceil/floor/round/hypot report the named result, not unit<>.
+			using type = typename Unit::template rebind<typename floating_point_promotion<unit_base_t<Unit>>::type::underlying_type>;
+		};
+	} // namespace detail
 
 	//------------------------------
 	//	UNIT NON-MEMBER FUNCTIONS
@@ -2656,10 +2898,15 @@ namespace units
 		using BaseUnit         = unit<BaseConversion, T, NumericalScale>;
 		using PromotedBaseUnit = unit<BaseConversion, detail::floating_point_promotion_t<T>, NumericalScale>;
 
+		// The abbreviation trait is specialized on the NAMED class, not the plain unit<...> base this overload
+		// deduces; resolve the named form first and query THAT so a named unit (meters_per_second -> "mps") prints
+		// its abbreviation instead of the dimension form.
+		using NamedForm = detail::rewrap_to_named_t<unit<ConversionFactor, T, NumericalScale>>;
+
 		std::locale loc;
-		if constexpr (unit_abbreviation_v<unit<ConversionFactor, T, NumericalScale>>)
+		if constexpr (unit_abbreviation_v<NamedForm>)
 		{
-			os << obj.raw() << " " << obj.abbreviation();
+			os << obj.raw() << " " << unit_abbreviation<NamedForm>::value;
 		}
 		else
 		{
@@ -2686,10 +2933,15 @@ namespace units
 		using BaseUnit         = unit<BaseConversion, T, NumericalScale>;
 		using PromotedBaseUnit = unit<BaseConversion, detail::floating_point_promotion_t<T>, NumericalScale>;
 
-		if constexpr (unit_abbreviation_v<unit<ConversionFactor, T, NumericalScale>>)
+		// The abbreviation trait (unit_name/unit_abbreviation) is specialized on the NAMED class, not the plain
+		// unit<...> base this overload deduces, so resolve the named form first and query THAT — a named unit
+		// (feet<double>) then still prints its abbreviation ("ft") instead of falling to the dimension path.
+		using NamedForm = detail::rewrap_to_named_t<unit<ConversionFactor, T, NumericalScale>>;
+
+		if constexpr (unit_abbreviation_v<NamedForm>)
 		{
 			std::string s = detail::to_string(obj.raw());
-			s.append(" ").append(obj.abbreviation());
+			s.append(" ").append(unit_abbreviation<NamedForm>::value);
 			return s;
 		}
 		else
@@ -2754,6 +3006,51 @@ namespace std
 		using type = units::unit<UnitConversionT, T, NonLinearScale>;
 	};
 
+	// A NAMED unit is a class deriving from unit<...>; the exact-pattern specializations above do not match it. When
+	// either operand is a named unit, compute the common type of the canonical unit<...> BASES, then RE-WRAP the result
+	// into the named type when an operand shares its conversion_factor — so common_type<meters<int>, meters<double>> is
+	// meters<double>, not the plain unit<...> (the friendly name survives through the trait). Constrained to "both are
+	// units AND at least one is named" so it never overlaps the exact-unit<...> cases above.
+	template<class Lhs, class Rhs>
+		requires(units::traits::is_unit<Lhs>::value && units::traits::is_unit<Rhs>::value &&
+				 (units::detail::is_named_unit_v<Lhs> || units::detail::is_named_unit_v<Rhs>) &&
+				 // ONLY when the plain-base common type EXISTS (same dimension). For different dimensions the bases have
+				 // no common type, so this specialization must be SFINAE-EMPTY too (no `type`) — matching the plain
+				 // unit<...> behavior. Without this, computing `base` below is a hard error on stricter compilers
+				 // (clang) where g++ tolerated the absent member.
+				 requires { typename common_type<units::detail::unit_base_t<Lhs>, units::detail::unit_base_t<Rhs>>::type; })
+	struct common_type<Lhs, Rhs>
+	{
+	private:
+		using base = common_type_t<units::detail::unit_base_t<Lhs>, units::detail::unit_base_t<Rhs>>;
+		// prefer to re-wrap into Lhs's name; if that doesn't share the CF, try Rhs's.
+		using viaLhs = units::detail::rewrap_named_t<base, Lhs>;
+
+	public:
+		using type = units::detail::rewrap_named_t<viaLhs, Rhs>;
+	};
+
+	// A NAMED DIMENSIONLESS unit (e.g. percent) mixed with a plain arithmetic scalar: the exact-unit<...>-vs-scalar
+	// specializations below do not match the named class, so unwrap the named operand to its base and re-wrap the
+	// result to keep the friendly name. dimensionless units stay fully interchangeable with int/double. Gated on
+	// is_dimensionless_unit (mirroring the plain unit<...>-vs-scalar specializations): a DIMENSIONED named unit + a
+	// scalar must NOT match — it falls through to the primary std::common_type and is SFINAE-empty (no `type`), the
+	// same SFINAE-friendly behavior the plain form has (never a hard error).
+	template<class Named, class Scalar>
+		requires(units::detail::is_named_unit_v<Named> && std::is_arithmetic_v<Scalar> &&
+				 units::traits::is_dimensionless_unit<typename units::detail::unit_base_t<Named>::conversion_factor>::value)
+	struct common_type<Named, Scalar>
+	{
+		using type = units::detail::rewrap_named_t<common_type_t<units::detail::unit_base_t<Named>, Scalar>, Named>;
+	};
+	template<class Scalar, class Named>
+		requires(units::detail::is_named_unit_v<Named> && std::is_arithmetic_v<Scalar> &&
+				 units::traits::is_dimensionless_unit<typename units::detail::unit_base_t<Named>::conversion_factor>::value)
+	struct common_type<Scalar, Named>
+	{
+		using type = units::detail::rewrap_named_t<common_type_t<Scalar, units::detail::unit_base_t<Named>>, Named>;
+	};
+
 	template<class Ratio, class T, class NumericalScale, class Rep, class Period>
 	struct common_type<units::unit<units::detail::time_conversion_factor<Ratio>, T, NumericalScale>, chrono::duration<Rep, Period>>
 	  : std::common_type<units::unit<units::detail::time_conversion_factor<Ratio>, T, NumericalScale>, decltype(units::unit{chrono::duration<Rep, Period>{}})>
@@ -2767,15 +3064,17 @@ namespace std
 	};
 
 	template<class ConversionFactor, class Tx, class NumericalScale, class Ty>
+		requires std::is_arithmetic_v<Ty>    // constrain so a unit `Ty` never matches (that is a unit+unit case above)
 	struct common_type<Ty, units::unit<ConversionFactor, Tx, NumericalScale>>
-	  : std::enable_if<std::is_arithmetic_v<Ty> && units::traits::is_dimensionless_unit<units::unit<ConversionFactor, Tx, NumericalScale>>::value,
+	  : std::enable_if<units::traits::is_dimensionless_unit<units::unit<ConversionFactor, Tx, NumericalScale>>::value,
 			units::unit<units::conversion_factor<std::ratio<1>, units::dimension::dimensionless>, common_type_t<Tx, Ty>, NumericalScale>>
 	{
 	};
 
 	template<class ConversionFactor, class Tx, class NumericalScale, class Ty>
+		requires std::is_arithmetic_v<Ty>    // constrain so a unit `Ty` never matches (that is a unit+unit case above)
 	struct common_type<units::unit<ConversionFactor, Tx, NumericalScale>, Ty>
-	  : std::enable_if<std::is_arithmetic_v<Ty> && units::traits::is_dimensionless_unit<units::unit<ConversionFactor, Tx, NumericalScale>>::value,
+	  : std::enable_if<units::traits::is_dimensionless_unit<units::unit<ConversionFactor, Tx, NumericalScale>>::value,
 			units::unit<units::conversion_factor<std::ratio<1>, units::dimension::dimensionless>, common_type_t<Tx, Ty>, NumericalScale>>
 	{
 	};
@@ -2916,12 +3215,20 @@ namespace units
 
 	using dimensionless_ = conversion_factor<std::ratio<1>, dimension::dimensionless>;
 
-	template<>
-	struct traits::strong<units::detail::conversion_factor_base_t<dimensionless_>>
+	namespace detail
 	{
-		using type = conversion_factor<std::ratio<1>, dimension::dimensionless>;
-	}; // namespace traits
-	UNIT_ADD_SCALED_UNIT_DEFINITION(dimensionless, ::units::linear_scale, conversion_factor<std::ratio<1>, dimension::dimensionless>)
+		// ADL registration of the dimensionless strong type (see detail::strong_name, #357). The base-form CF maps
+		// back to the canonical dimensionless conversion_factor. Declared, never defined (used only in decltype).
+		conversion_factor<std::ratio<1>, dimension::dimensionless> strong_name(
+			units::detail::conversion_factor_base_t<dimensionless_>*);
+	}
+	// The PURE dimensionless unit (ratio 1) stays a plain alias to unit<...>, NOT a named class: it must remain
+	// totally interchangeable with the built-in arithmetic types (int/double) and identity-equal to its unit<...>
+	// base (so common_type<dimensionless<int>, int> is the plain unit and dimensionless<int> IS unit<dimensionless_,
+	// int>). A distinct class would break that interchangeability. Named ratio-dimensionless units (percent/ppm/...)
+	// are still classes — they carry a meaningful name.
+	template<class Underlying = UNIT_LIB_DEFAULT_TYPE>
+	using dimensionless = unit<traits::strong_t<conversion_factor<std::ratio<1>, dimension::dimensionless>>, Underlying, linear_scale>;
 
 	UNIT_ADD_DIMENSION_TRAIT(dimensionless)
 
@@ -3463,8 +3770,8 @@ namespace units
 	template<UnitType UnitTypeLhs, UnitType UnitTypeRhs>
 		requires(same_dimension<UnitTypeLhs, UnitTypeRhs> && traits::has_linear_scale_v<UnitTypeLhs, UnitTypeRhs>)
 	constexpr auto operator*(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
-		-> unit<traits::strong_t<squared<typename traits::unit_traits<std::common_type_t<UnitTypeLhs, UnitTypeRhs>>::conversion_factor>>,
-			typename std::common_type_t<UnitTypeLhs, UnitTypeRhs>::underlying_type>
+		-> detail::rewrap_to_named_t<unit<traits::strong_t<squared<typename traits::unit_traits<std::common_type_t<UnitTypeLhs, UnitTypeRhs>>::conversion_factor>>,
+			typename std::common_type_t<UnitTypeLhs, UnitTypeRhs>::underlying_type>>
 	{
 		using SquaredUnit = decltype(lhs * rhs);
 		using CommonUnit  = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
@@ -3476,8 +3783,8 @@ namespace units
 	template<DimensionedUnitType UnitTypeLhs, DimensionedUnitType UnitTypeRhs>
 		requires(!same_dimension<UnitTypeLhs, UnitTypeRhs> && traits::has_linear_scale_v<UnitTypeLhs, UnitTypeRhs>)
 	constexpr auto operator*(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
-		-> unit<traits::strong_t<compound_conversion_factor<typename traits::unit_traits<UnitTypeLhs>::conversion_factor, typename traits::unit_traits<UnitTypeRhs>::conversion_factor>>,
-			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>
+		-> detail::rewrap_to_named_t<unit<traits::strong_t<compound_conversion_factor<typename traits::unit_traits<UnitTypeLhs>::conversion_factor, typename traits::unit_traits<UnitTypeRhs>::conversion_factor>>,
+			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>>
 	{
 		using CompoundUnit     = decltype(lhs * rhs);
 		using CommonUnderlying = typename CompoundUnit::underlying_type;
@@ -3607,8 +3914,8 @@ namespace units
 	template<DimensionedUnitType UnitTypeLhs, DimensionedUnitType UnitTypeRhs>
 		requires(!same_dimension<UnitTypeLhs, UnitTypeRhs> && traits::has_linear_scale_v<UnitTypeLhs, UnitTypeRhs>)
 	constexpr auto operator/(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
-		-> unit<traits::strong_t<compound_conversion_factor<typename traits::unit_traits<UnitTypeLhs>::conversion_factor, inverse<typename traits::unit_traits<UnitTypeRhs>::conversion_factor>>>,
-			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>
+		-> detail::rewrap_to_named_t<unit<traits::strong_t<compound_conversion_factor<typename traits::unit_traits<UnitTypeLhs>::conversion_factor, inverse<typename traits::unit_traits<UnitTypeRhs>::conversion_factor>>>,
+			std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>>
 	{
 		using CompoundUnit     = decltype(lhs / rhs);
 		using CommonUnderlying = typename CompoundUnit::underlying_type;
@@ -3649,8 +3956,8 @@ namespace units
 	/// Produces inverse<ratio-dimensionless> (compound) and uses raw() for rhs.
 	template<OrdinaryDimensionlessUnitType UnitTypeLhs, RatioDimensionlessUnitType UnitTypeRhs>
 		requires(traits::has_linear_scale_v<UnitTypeLhs, UnitTypeRhs>)
-	constexpr auto operator/(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept -> unit<traits::strong_t<inverse<typename traits::unit_traits<UnitTypeRhs>::conversion_factor>>,
-		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>
+	constexpr auto operator/(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept -> detail::rewrap_to_named_t<unit<traits::strong_t<inverse<typename traits::unit_traits<UnitTypeRhs>::conversion_factor>>,
+		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>>
 	{
 		using Out              = decltype(lhs / rhs);
 		using CommonUnderlying = typename Out::underlying_type;
@@ -3662,8 +3969,8 @@ namespace units
 	/// Division of a dimensionless unit by a unit type with a linear scale
 	template<OrdinaryDimensionlessUnitType UnitTypeLhs, DimensionedUnitType UnitTypeRhs>
 		requires(traits::has_linear_scale_v<UnitTypeLhs, UnitTypeRhs> && traits::is_dimensionless_unit_v<UnitTypeLhs>)
-	constexpr auto operator/(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept -> unit<traits::strong_t<inverse<typename traits::unit_traits<UnitTypeRhs>::conversion_factor>>,
-		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>
+	constexpr auto operator/(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept -> detail::rewrap_to_named_t<unit<traits::strong_t<inverse<typename traits::unit_traits<UnitTypeRhs>::conversion_factor>>,
+		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>>>
 	{
 		using CommonUnit       = decltype(lhs / rhs);
 		using CommonUnderlying = typename CommonUnit::underlying_type;
@@ -3709,7 +4016,7 @@ namespace units
 	template<UnitType UnitTypeRhs, ArithmeticType T>
 		requires(traits::has_linear_scale_v<UnitTypeRhs> && !RatioDimensionlessUnitType<UnitTypeRhs>)
 	constexpr auto operator/(T lhs, const UnitTypeRhs& rhs) noexcept
-		-> unit<traits::strong_t<inverse<typename traits::unit_traits<UnitTypeRhs>::conversion_factor>>, std::common_type_t<T, typename UnitTypeRhs::underlying_type>>
+		-> detail::rewrap_to_named_t<unit<traits::strong_t<inverse<typename traits::unit_traits<UnitTypeRhs>::conversion_factor>>, std::common_type_t<T, typename UnitTypeRhs::underlying_type>>>
 	{
 		using InverseUnit      = decltype(lhs / rhs);
 		using UnitConversion   = typename traits::unit_traits<UnitTypeRhs>::conversion_factor;
@@ -3970,8 +4277,8 @@ namespace units
 	 */
 	template<int power, UnitType UnitType>
 		requires(traits::has_linear_scale_v<UnitType>)
-	constexpr auto pow(const UnitType& value) noexcept -> unit<traits::strong_t<typename units::detail::power_of_unit<power, typename units::traits::unit_traits<UnitType>::conversion_factor>::type>,
-		detail::floating_point_promotion_t<typename units::traits::unit_traits<UnitType>::underlying_type>, linear_scale>
+	constexpr auto pow(const UnitType& value) noexcept -> detail::rewrap_to_named_t<unit<traits::strong_t<typename units::detail::power_of_unit<power, typename units::traits::unit_traits<UnitType>::conversion_factor>::type>,
+		detail::floating_point_promotion_t<typename units::traits::unit_traits<UnitType>::underlying_type>, linear_scale>>
 	{
 		return decltype(units::pow<power>(value))(pow<power>(value.raw()));
 	}
@@ -4021,8 +4328,6 @@ namespace units
 	 * @sa			See unit for more information on unit type containers.
 	 */
 	UNIT_ADD_SCALED_UNIT_DEFINITION(decibels, ::units::decibel_scale, dimensionless_)
-	template<class Underlying>
-	using decibels = unit<dimensionless_, Underlying, decibel_scale>;
 #if !defined(UNIT_LIB_DISABLE_IOSTREAM)
 	template<class Underlying>
 	std::ostream& operator<<(std::ostream& os, const decibels<Underlying>& obj)
@@ -4042,8 +4347,8 @@ namespace units
 	template<UnitType UnitTypeLhs, UnitType UnitTypeRhs>
 		requires(same_dimension<UnitTypeLhs, UnitTypeRhs> && traits::has_decibel_scale_v<UnitTypeLhs, UnitTypeRhs>)
 	constexpr auto operator+(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
-		-> unit<traits::strong_t<squared<typename traits::unit_traits<std::common_type_t<UnitTypeLhs, UnitTypeRhs>>::conversion_factor>>,
-			typename std::common_type_t<UnitTypeLhs, UnitTypeRhs>::underlying_type, decibel_scale>
+		-> detail::rewrap_to_named_t<unit<traits::strong_t<squared<typename traits::unit_traits<std::common_type_t<UnitTypeLhs, UnitTypeRhs>>::conversion_factor>>,
+			typename std::common_type_t<UnitTypeLhs, UnitTypeRhs>::underlying_type, decibel_scale>>
 	{
 		using SquaredUnit = decltype(lhs + rhs);
 		using CommonUnit  = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
@@ -4095,8 +4400,8 @@ namespace units
 	/// Subtraction between unit types with a decibel_scale and dimensionless dB units
 	template<DimensionlessUnitType UnitTypeLhs, DimensionedUnitType UnitTypeRhs>
 		requires(traits::has_decibel_scale_v<UnitTypeLhs, UnitTypeRhs>)
-	constexpr auto operator-(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept -> unit<traits::strong_t<inverse<typename traits::unit_traits<UnitTypeRhs>::conversion_factor>>,
-		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>, decibel_scale>
+	constexpr auto operator-(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept -> detail::rewrap_to_named_t<unit<traits::strong_t<inverse<typename traits::unit_traits<UnitTypeRhs>::conversion_factor>>,
+		std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>, decibel_scale>>
 	{
 		using InverseUnit = decltype(lhs - rhs);
 		return InverseUnit(lhs.to_linearized() / rhs.to_linearized(), linearized_value);
@@ -4275,7 +4580,7 @@ namespace units
 	template<UnitType UnitType>
 		requires(traits::has_linear_scale_v<UnitType>)
 	constexpr auto sqrt(const UnitType& value) noexcept
-		-> unit<traits::strong_t<square_root<typename traits::unit_traits<UnitType>::conversion_factor>>, detail::floating_point_promotion_t<typename traits::unit_traits<UnitType>::underlying_type>>
+		-> detail::rewrap_to_named_t<unit<traits::strong_t<square_root<typename traits::unit_traits<UnitType>::conversion_factor>>, detail::floating_point_promotion_t<typename traits::unit_traits<UnitType>::underlying_type>>>
 	{
 		return decltype(units::sqrt(value))(sqrt(value.raw()));
 	}
@@ -4580,6 +4885,15 @@ struct std::hash<units::unit<ConversionFactor, T, NumericalScale>>
 	}
 };
 
+// A NAMED unit is a class deriving from unit<...>; the exact-pattern specialization above does not match it, so its
+// std::hash falls to the deleted primary. Inherit the base unit's hash (it operates on the linearized value, which the
+// named unit has via its base) so a named unit is hashable exactly like the plain unit<...> it represents.
+template<class Named>
+	requires units::detail::is_named_unit_v<Named>
+struct std::hash<Named> : std::hash<units::detail::unit_base_t<Named>>
+{
+};
+
 //----------------------------------------------------------------------------------------------------------------------
 //  NUMERIC LIMITS
 //----------------------------------------------------------------------------------------------------------------------
@@ -4643,26 +4957,58 @@ namespace std
 		static constexpr bool has_signaling_NaN = std::numeric_limits<T>::has_signaling_NaN;
 	};
 
-	template<units::ConversionFactorType ConversionFactor, units::ArithmeticType T, units::NumericalScaleType<T> NonLinearScale>
-	constexpr bool isnan(const units::unit<ConversionFactor, T, NonLinearScale>& x)
+	// A NAMED unit is a class deriving from unit<...>; the exact-pattern specialization above does not match it.
+	// Return the NAMED type from each limit (the named unit converts from its base), so both the VALUE and the
+	// reported TYPE match the named unit — generic code that asks for numeric_limits<meters<double>>::max() gets a
+	// meters<double> back, not the plain unit<...> base.
+	template<class Named>
+		requires units::detail::is_named_unit_v<Named>
+	struct numeric_limits<Named> : numeric_limits<units::detail::unit_base_t<Named>>
+	{
+	private:
+		using Base = numeric_limits<units::detail::unit_base_t<Named>>;
+
+	public:
+		// Inherit every flag/member from the base (has_infinity, is_signed, digits, ...); only SHADOW the
+		// value-returning statics to return the NAMED type (the named unit converts from its base), so both the value
+		// and the reported type match the named unit.
+		static constexpr Named min() { return Named(Base::min()); }
+		static constexpr Named max() { return Named(Base::max()); }
+		static constexpr Named lowest() { return Named(Base::lowest()); }
+		static constexpr Named epsilon() { return Named(Base::epsilon()); }
+		static constexpr Named round_error() { return Named(Base::round_error()); }
+		static constexpr Named denorm_min() { return Named(Base::denorm_min()); }
+		static constexpr Named infinity() { return Named(Base::infinity()); }
+		static constexpr Named quiet_NaN() { return Named(Base::quiet_NaN()); }
+		static constexpr Named signaling_NaN() { return Named(Base::signaling_NaN()); }
+	};
+
+	// These overloads accept ANY unit — including a NAMED unit, which is a class DERIVING from units::unit<...>.
+	// Constraining on the units::UnitType concept (rather than an exact `unit<Cf,T,Ns>&` parameter) makes a named
+	// unit an EXACT match, so it wins over <cmath>'s own generic isnan/isinf/... templates. With the exact-type
+	// parameter, a named (derived) unit only bound via a derived->base conversion — a WORSE match than <cmath>'s
+	// template — so on some standard libraries (MSVC) the generic <cmath> overload was selected and forwarded the
+	// unit to fpclassify(), which has no unit overload (error C2665). raw() yields the arithmetic magnitude.
+	template<units::UnitType U>
+	constexpr bool isnan(U x)
 	{
 		return std::isnan(x.raw());
 	}
 
-	template<units::ConversionFactorType ConversionFactor, units::ArithmeticType T, units::NumericalScaleType<T> NonLinearScale>
-	constexpr bool isinf(const units::unit<ConversionFactor, T, NonLinearScale>& x)
+	template<units::UnitType U>
+	constexpr bool isinf(U x)
 	{
 		return std::isinf(x.raw());
 	}
 
-	template<units::ConversionFactorType ConversionFactor, units::ArithmeticType T, units::NumericalScaleType<T> NonLinearScale>
-	constexpr bool isfinite(const units::unit<ConversionFactor, T, NonLinearScale>& x)
+	template<units::UnitType U>
+	constexpr bool isfinite(U x)
 	{
 		return std::isfinite(x.raw());
 	}
 
-	template<units::ConversionFactorType ConversionFactor, units::ArithmeticType T, units::NumericalScaleType<T> NonLinearScale>
-	constexpr bool signbit(const units::unit<ConversionFactor, T, NonLinearScale>& x)
+	template<units::UnitType U>
+	constexpr bool signbit(U x)
 	{
 		return std::signbit(x.raw());
 	}

--- a/natvis/units.natvis
+++ b/natvis/units.natvis
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    ****************************************************************************
+    **
+    ** Natvis debugger visualizer for the nholthaus `units` library (v3.x).
+    **
+    ** Makes every `units::unit<...>` show its magnitude AND its unit inline in
+    ** the MSVC debugger (Watch / Locals / DataTips) instead of an opaque object
+    ** whose base classes you must expand to read. e.g. a 3-second value shows as:
+    **        3 s
+    **
+    ** GENERAL BY DESIGN — nothing is hardcoded per unit. Every rule is a
+    ** wildcard template match, so a single rule set covers every unit type
+    ** (length, time, frequency, compound, dimensionless, decibel, ...) with no
+    ** unit name enumerated anywhere.
+    **
+    ** ADAPTED FOR THIS REPO (differs from the older units.h v3 natvis):
+    **   - the class is `units::unit<Cf, T, Scale>` (NOT `units::unit_t<...>`);
+    **   - the magnitude is stored in `T _linearized_value` (NOT `m_value`);
+    **   - NAMED units (e.g. `units::length::meters<double>`) are CLASSES that
+    **     DERIVE from `units::unit<...>`. Natvis <Type> rules are inheritable by
+    **     default, so the `units::unit<*...>` rules below also visualize a named
+    **     unit through its base — `meters<double>` still shows as `3 m`.
+    **
+    ** UNIT LABEL — two tiers, best-effort:
+    **   1) `unit::abbreviation()` is a `constexpr const char*` member returning
+    **      the true abbreviation ("s", "m", "Hz", "mps"). It is a FUNCTION, not
+    **      stored data, so reading it needs debugger function-evaluation. We bind
+    **      it via an Optional <Intrinsic>; when the debugger can evaluate it we
+    **      show the clean abbreviation:  3 s.
+    **   2) Function-eval is not always available (optimized builds, minidumps, or
+    **      a unit whose unit_abbreviation<> specialization was never
+    **      instantiated). When the intrinsic yields nothing we FALL BACK to `$T1`
+    **      — the conversion-factor tag's type name — which is always available and
+    **      still readable. So the label degrades gracefully, never blank.
+    **
+    ** If a future units version renames `_linearized_value` or `abbreviation()`,
+    ** update the anchors below.
+    **
+    ****************************************************************************
+-->
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+
+    <!-- units::unit, all three template arities so the rule binds whether or not
+         the optional T / NumericalScale args are spelled out in the
+         instantiation. Inheritable by default, so a NAMED unit (a class deriving
+         from unit<...>) is visualized through these rules too.
+         `abbrev` = the true abbreviation via func-eval (Optional: absent if the
+         debugger can't evaluate it); `$T1` = the conversion-factor tag type name
+         (fallback); `_linearized_value` = the stored magnitude. -->
+    <Type Name="units::unit&lt;*&gt;">
+        <Intrinsic Name="abbrev" Expression="abbreviation()" Optional="true"/>
+        <DisplayString Optional="true" Condition="abbrev() != 0">{_linearized_value} {abbrev(),sb}</DisplayString>
+        <DisplayString>{_linearized_value} [$T1]</DisplayString>
+        <Expand>
+            <Item Name="[value]">_linearized_value</Item>
+            <Item Name="[abbrev]" Optional="true">abbreviation(),sb</Item>
+        </Expand>
+    </Type>
+    <Type Name="units::unit&lt;*,*&gt;">
+        <Intrinsic Name="abbrev" Expression="abbreviation()" Optional="true"/>
+        <DisplayString Optional="true" Condition="abbrev() != 0">{_linearized_value} {abbrev(),sb}</DisplayString>
+        <DisplayString>{_linearized_value} [$T1]</DisplayString>
+        <Expand>
+            <Item Name="[value]">_linearized_value</Item>
+            <Item Name="[abbrev]" Optional="true">abbreviation(),sb</Item>
+        </Expand>
+    </Type>
+    <Type Name="units::unit&lt;*,*,*&gt;">
+        <Intrinsic Name="abbrev" Expression="abbreviation()" Optional="true"/>
+        <DisplayString Optional="true" Condition="abbrev() != 0">{_linearized_value} {abbrev(),sb}</DisplayString>
+        <DisplayString>{_linearized_value} [$T1]</DisplayString>
+        <Expand>
+            <Item Name="[value]">_linearized_value</Item>
+            <Item Name="[abbrev]" Optional="true">abbreviation(),sb</Item>
+        </Expand>
+    </Type>
+
+    <!-- NOTE: unlike the older units.h v3, this repo's `linear_scale` / `decibel_scale` are STATELESS policy
+         types (only static linearize()/scale(); no data member). The magnitude lives solely on
+         `units::unit::_linearized_value`, covered by the rules above — so there are no scale-base rules here
+         (a raw scale object carries no value to display). For a decibel unit, _linearized_value is the LINEARIZED
+         (power) value; the unit reports 10*log10(value) as dB, which a natvis expression cannot compute, so the dB
+         unit shows its linear magnitude + abbreviation (e.g. `dBW`) via the unit<*> rules. -->
+
+</AutoVisualizer>

--- a/test/errorMessages/cases/357_ordering.cpp
+++ b/test/errorMessages/cases/357_ordering.cpp
@@ -1,0 +1,15 @@
+// Case: nholthaus/units #357 — forming an expression that simplifies to a dimension
+// (velocity/length -> 1/time == frequency's dimension) BEFORE including that dimension's
+// header must NOT cause an "explicit specialization after instantiation" error.
+//
+// EXPECT: compiles clean (exit 0). A regression here is the #357 bug.
+#include <units/velocity.h>
+#include <units/length.h>
+using namespace units::literals;
+auto x = 1.0_mps / 1.0_m; // dimension time^-1, == frequency's dimension, before frequency.h is seen
+#include <units/frequency.h>
+int main()
+{
+	(void)x;
+	return 0;
+}

--- a/test/errorMessages/cases/generated_add_frequency_angle.cpp
+++ b/test/errorMessages/cases/generated_add_frequency_angle.cpp
@@ -1,0 +1,12 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: hertz<double>
+// expect-match: radians<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/frequency.h>
+#include <units/angle.h>
+using namespace units;
+using namespace units::literals;
+auto bad = units::frequency::hertz<double>(1.0) + units::angle::radians<double>(1.0);
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_add_length_time.cpp
+++ b/test/errorMessages/cases/generated_add_length_time.cpp
@@ -1,0 +1,12 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: meters<double>
+// expect-match: seconds<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/length.h>
+#include <units/time.h>
+using namespace units;
+using namespace units::literals;
+auto bad = 1.0_m + 1.0_s;
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_add_mass_length.cpp
+++ b/test/errorMessages/cases/generated_add_mass_length.cpp
@@ -1,0 +1,12 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: kilograms<double>
+// expect-match: meters<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/mass.h>
+#include <units/length.h>
+using namespace units;
+using namespace units::literals;
+auto bad = 1.0_kg + 1.0_m;
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_angle_to_length.cpp
+++ b/test/errorMessages/cases/generated_angle_to_length.cpp
@@ -1,0 +1,12 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: radians<double>
+// expect-match: meters<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/angle.h>
+#include <units/length.h>
+using namespace units;
+using namespace units::literals;
+units::length::meters<double> x = units::angle::radians<double>(1.0);
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_area_to_length.cpp
+++ b/test/errorMessages/cases/generated_area_to_length.cpp
@@ -1,0 +1,12 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: square_meters<double>
+// expect-match: meters<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/area.h>
+#include <units/length.h>
+using namespace units;
+using namespace units::literals;
+units::length::meters<double> x = units::area::square_meters<double>(4.0);
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_charge_to_current.cpp
+++ b/test/errorMessages/cases/generated_charge_to_current.cpp
@@ -1,0 +1,12 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: coulombs<double>
+// expect-match: amperes<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/charge.h>
+#include <units/current.h>
+using namespace units;
+using namespace units::literals;
+units::current::amperes<double> x = units::charge::coulombs<double>(1.0);
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_data_to_time.cpp
+++ b/test/errorMessages/cases/generated_data_to_time.cpp
@@ -1,0 +1,12 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: bytes<double>
+// expect-match: seconds<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/data.h>
+#include <units/time.h>
+using namespace units;
+using namespace units::literals;
+units::time::seconds<double> x = units::data::bytes<double>(8.0);
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_div_energy_time_to_length.cpp
+++ b/test/errorMessages/cases/generated_div_energy_time_to_length.cpp
@@ -1,0 +1,14 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: watts<double>
+// expect-match: meters<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/energy.h>
+#include <units/time.h>
+#include <units/power.h>
+#include <units/length.h>
+using namespace units;
+using namespace units::literals;
+units::length::meters<double> x = units::energy::joules<double>(6.0) / 2.0_s;
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_div_length_time_to_mass.cpp
+++ b/test/errorMessages/cases/generated_div_length_time_to_mass.cpp
@@ -1,0 +1,14 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: meters_per_second<double>
+// expect-match: kilograms<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/length.h>
+#include <units/time.h>
+#include <units/velocity.h>
+#include <units/mass.h>
+using namespace units;
+using namespace units::literals;
+units::mass::kilograms<double> x = 10.0_m / 2.0_s;
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_energy_to_power.cpp
+++ b/test/errorMessages/cases/generated_energy_to_power.cpp
@@ -1,0 +1,12 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: joules<double>
+// expect-match: watts<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/energy.h>
+#include <units/power.h>
+using namespace units;
+using namespace units::literals;
+units::power::watts<double> x = units::energy::joules<double>(3.0);
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_frequency_to_time.cpp
+++ b/test/errorMessages/cases/generated_frequency_to_time.cpp
@@ -1,0 +1,12 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: hertz<double>
+// expect-match: seconds<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/frequency.h>
+#include <units/time.h>
+using namespace units;
+using namespace units::literals;
+units::time::seconds<double> x = units::frequency::hertz<double>(2.0);
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_length_to_time.cpp
+++ b/test/errorMessages/cases/generated_length_to_time.cpp
@@ -1,0 +1,12 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: meters<double>
+// expect-match: seconds<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/length.h>
+#include <units/time.h>
+using namespace units;
+using namespace units::literals;
+units::time::seconds<double> x = 1.0_m;
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_mass_to_force.cpp
+++ b/test/errorMessages/cases/generated_mass_to_force.cpp
@@ -1,0 +1,12 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: kilograms<double>
+// expect-match: newtons<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/mass.h>
+#include <units/force.h>
+using namespace units;
+using namespace units::literals;
+units::force::newtons<double> x = 1.0_kg;
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_mul_length_length_to_time.cpp
+++ b/test/errorMessages/cases/generated_mul_length_length_to_time.cpp
@@ -1,0 +1,13 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: square_meters<double>
+// expect-match: seconds<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/length.h>
+#include <units/time.h>
+#include <units/area.h>
+using namespace units;
+using namespace units::literals;
+units::time::seconds<double> x = 2.0_m * 2.0_m;
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_order_area_over_length.cpp
+++ b/test/errorMessages/cases/generated_order_area_over_length.cpp
@@ -1,0 +1,11 @@
+// GENERATED (generate_cases.py). #357-class ordering: an expression reducing to the 'length' dimension is
+// formed BEFORE that dimension's header is included — must still compile (no explicit-specialization-after-
+// instantiation).
+// expect: pass
+#include <units/area.h>
+#include <units/length.h>
+using namespace units;
+using namespace units::literals;
+auto x = units::area::square_meters<double>(4.0) / 1.0_m;
+#include <units/length.h>
+int main() { (void)sizeof(x); return 0; }

--- a/test/errorMessages/cases/generated_order_energy_over_time.cpp
+++ b/test/errorMessages/cases/generated_order_energy_over_time.cpp
@@ -1,0 +1,11 @@
+// GENERATED (generate_cases.py). #357-class ordering: an expression reducing to the 'power' dimension is
+// formed BEFORE that dimension's header is included — must still compile (no explicit-specialization-after-
+// instantiation).
+// expect: pass
+#include <units/energy.h>
+#include <units/time.h>
+using namespace units;
+using namespace units::literals;
+auto x = units::energy::joules<double>(6.0) / 1.0_s;
+#include <units/power.h>
+int main() { (void)sizeof(x); return 0; }

--- a/test/errorMessages/cases/generated_order_length_over_time.cpp
+++ b/test/errorMessages/cases/generated_order_length_over_time.cpp
@@ -1,0 +1,11 @@
+// GENERATED (generate_cases.py). #357-class ordering: an expression reducing to the 'velocity' dimension is
+// formed BEFORE that dimension's header is included — must still compile (no explicit-specialization-after-
+// instantiation).
+// expect: pass
+#include <units/length.h>
+#include <units/time.h>
+using namespace units;
+using namespace units::literals;
+auto x = 1.0_m / 1.0_s;
+#include <units/velocity.h>
+int main() { (void)sizeof(x); return 0; }

--- a/test/errorMessages/cases/generated_order_length_times_length.cpp
+++ b/test/errorMessages/cases/generated_order_length_times_length.cpp
@@ -1,0 +1,10 @@
+// GENERATED (generate_cases.py). #357-class ordering: an expression reducing to the 'area' dimension is
+// formed BEFORE that dimension's header is included — must still compile (no explicit-specialization-after-
+// instantiation).
+// expect: pass
+#include <units/length.h>
+using namespace units;
+using namespace units::literals;
+auto x = 1.0_m * 1.0_m;
+#include <units/area.h>
+int main() { (void)sizeof(x); return 0; }

--- a/test/errorMessages/cases/generated_order_mass_times_accel.cpp
+++ b/test/errorMessages/cases/generated_order_mass_times_accel.cpp
@@ -1,0 +1,11 @@
+// GENERATED (generate_cases.py). #357-class ordering: an expression reducing to the 'force' dimension is
+// formed BEFORE that dimension's header is included — must still compile (no explicit-specialization-after-
+// instantiation).
+// expect: pass
+#include <units/mass.h>
+#include <units/acceleration.h>
+using namespace units;
+using namespace units::literals;
+auto x = 1.0_kg * units::acceleration::meters_per_second_squared<double>(1.0);
+#include <units/force.h>
+int main() { (void)sizeof(x); return 0; }

--- a/test/errorMessages/cases/generated_order_velocity_over_length.cpp
+++ b/test/errorMessages/cases/generated_order_velocity_over_length.cpp
@@ -1,0 +1,11 @@
+// GENERATED (generate_cases.py). #357-class ordering: an expression reducing to the 'frequency' dimension is
+// formed BEFORE that dimension's header is included — must still compile (no explicit-specialization-after-
+// instantiation).
+// expect: pass
+#include <units/velocity.h>
+#include <units/length.h>
+using namespace units;
+using namespace units::literals;
+auto x = 1.0_mps / 1.0_m;
+#include <units/frequency.h>
+int main() { (void)sizeof(x); return 0; }

--- a/test/errorMessages/cases/generated_pressure_to_force.cpp
+++ b/test/errorMessages/cases/generated_pressure_to_force.cpp
@@ -1,0 +1,12 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: pascals<double>
+// expect-match: newtons<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/pressure.h>
+#include <units/force.h>
+using namespace units;
+using namespace units::literals;
+units::force::newtons<double> x = units::pressure::pascals<double>(5.0);
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_sub_velocity_area.cpp
+++ b/test/errorMessages/cases/generated_sub_velocity_area.cpp
@@ -1,0 +1,12 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: meters_per_second<double>
+// expect-match: square_meters<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/velocity.h>
+#include <units/area.h>
+using namespace units;
+using namespace units::literals;
+auto bad = 1.0_mps - units::area::square_meters<double>(1.0);
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_temperature_to_time.cpp
+++ b/test/errorMessages/cases/generated_temperature_to_time.cpp
@@ -1,0 +1,12 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: kelvin<double>
+// expect-match: seconds<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/temperature.h>
+#include <units/time.h>
+using namespace units;
+using namespace units::literals;
+units::time::seconds<double> x = units::temperature::kelvin<double>(300.0);
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_velocity_to_length.cpp
+++ b/test/errorMessages/cases/generated_velocity_to_length.cpp
@@ -1,0 +1,12 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: meters_per_second<double>
+// expect-match: meters<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/velocity.h>
+#include <units/length.h>
+using namespace units;
+using namespace units::literals;
+units::length::meters<double> x = 1.0_mps;
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_volume_to_area.cpp
+++ b/test/errorMessages/cases/generated_volume_to_area.cpp
@@ -1,0 +1,12 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: cubic_meters<double>
+// expect-match: square_meters<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/volume.h>
+#include <units/area.h>
+using namespace units;
+using namespace units::literals;
+units::area::square_meters<double> x = units::volume::cubic_meters<double>(1.0);
+int main() { return 0; }

--- a/test/errorMessages/cases/readable_add_incompatible.cpp
+++ b/test/errorMessages/cases/readable_add_incompatible.cpp
@@ -1,0 +1,14 @@
+// Case: adding incompatible units (length + time) must FAIL readably, naming the strong types.
+//
+// expect: fail
+// expect-match: meters
+// expect-match: seconds
+#include <units/length.h>
+#include <units/time.h>
+using namespace units::literals;
+auto bad = 1.0_m + 1.0_s; // ill-formed: cannot add length and time
+int main()
+{
+	(void)bad;
+	return 0;
+}

--- a/test/errorMessages/cases/readable_bad_conversion.cpp
+++ b/test/errorMessages/cases/readable_bad_conversion.cpp
@@ -1,0 +1,20 @@
+// Case: a deliberate bad conversion (length -> frequency) must FAIL with a READABLE message
+// that names the strong types `meters_` and `hertz_`, NOT the raw conversion_factor<...> soup.
+// This is exactly what traits::strong<> exists to protect; any strong<> refactor must keep it.
+//
+// EXPECT: compile FAILS, and the error text contains "meters_" and "hertz_"
+//         (the readability assertion; see the harness's expect: block below).
+//
+// expect: fail
+// expect-match: meters
+// expect-match: hertz
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/length.h>
+#include <units/frequency.h>
+using namespace units::literals;
+units::frequency::hertz<double> f = 1.0_m; // ill-formed on purpose
+int main()
+{
+	(void)f;
+	return 0;
+}

--- a/test/errorMessages/cases/readable_compound_assign.cpp
+++ b/test/errorMessages/cases/readable_compound_assign.cpp
@@ -1,0 +1,17 @@
+// Case: assigning a compound (derived) result to the wrong named unit must FAIL readably.
+// velocity = length / time; assigning it to acceleration_ names both strong types.
+//
+// expect: fail
+// expect-match: meters_per_second
+// expect-match: acceleration
+#include <units/length.h>
+#include <units/time.h>
+#include <units/velocity.h>
+#include <units/acceleration.h>
+using namespace units::literals;
+units::acceleration::meters_per_second_squared<double> a = 1.0_m / 1.0_s; // ill-formed: velocity -> acceleration
+int main()
+{
+	(void)a;
+	return 0;
+}

--- a/test/errorMessages/generate_cases.py
+++ b/test/errorMessages/generate_cases.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Generate the error-message harness case corpus for nholthaus/units.
+
+Each generated cases/*.cpp carries in-file directives the runner (run.py) grades:
+  // expect: pass|fail
+  // expect-match: <substr>     the diagnostic MUST contain this (readable named type present)
+  // forbid-match: <substr>     the diagnostic must NOT contain this (no conversion_factor soup)
+
+The corpus proves two things across the unit zoo:
+  1. #357-class include-ordering never regresses (an expression reducing to a not-yet-included
+     dimension still compiles);
+  2. a deliberate ill-formed use names the FRIENDLY unit type (meters<double>, hertz<double>,
+     square_meters<int>, ...) and never the raw conversion_factor<...> template soup.
+
+Hand-written cases (357_ordering.cpp, readable_*.cpp) are left in place; this only (re)writes the
+generated_*.cpp files, so re-running is idempotent and won't clobber the curated ones.
+"""
+import pathlib
+
+HERE = pathlib.Path(__file__).resolve().parent
+CASES = HERE / "cases"
+SOUP = "conversion_factor<std::ratio<1>, units::dimension_t"  # the thing readability must never show
+
+# (name, headers, using, body-lines, expect, [expect-match...], [forbid-match...])
+BAD_CONVERSIONS = [
+    # deliberate cross-dimension assignment -> must name BOTH friendly types, never soup
+    ("length_to_time", ["length", "time"], "units::time::seconds<double> x = 1.0_m;",
+     ["meters<double>", "seconds<double>"]),
+    ("velocity_to_length", ["velocity", "length"], "units::length::meters<double> x = 1.0_mps;",
+     ["meters_per_second<double>", "meters<double>"]),
+    ("mass_to_force", ["mass", "force"], "units::force::newtons<double> x = 1.0_kg;",
+     ["kilograms<double>", "newtons<double>"]),
+    ("area_to_length", ["area", "length"], "units::length::meters<double> x = units::area::square_meters<double>(4.0);",
+     ["square_meters<double>", "meters<double>"]),
+    ("frequency_to_time", ["frequency", "time"], "units::time::seconds<double> x = units::frequency::hertz<double>(2.0);",
+     ["hertz<double>", "seconds<double>"]),
+    ("angle_to_length", ["angle", "length"], "units::length::meters<double> x = units::angle::radians<double>(1.0);",
+     ["radians<double>", "meters<double>"]),
+    ("energy_to_power", ["energy", "power"], "units::power::watts<double> x = units::energy::joules<double>(3.0);",
+     ["joules<double>", "watts<double>"]),
+    ("pressure_to_force", ["pressure", "force"], "units::force::newtons<double> x = units::pressure::pascals<double>(5.0);",
+     ["pascals<double>", "newtons<double>"]),
+    ("temperature_to_time", ["temperature", "time"], "units::time::seconds<double> x = units::temperature::kelvin<double>(300.0);",
+     ["kelvin<double>", "seconds<double>"]),
+    ("charge_to_current", ["charge", "current"], "units::current::amperes<double> x = units::charge::coulombs<double>(1.0);",
+     ["coulombs<double>", "amperes<double>"]),
+    ("volume_to_area", ["volume", "area"], "units::area::square_meters<double> x = units::volume::cubic_meters<double>(1.0);",
+     ["cubic_meters<double>", "square_meters<double>"]),
+    ("data_to_time", ["data", "time"], "units::time::seconds<double> x = units::data::bytes<double>(8.0);",
+     ["bytes<double>", "seconds<double>"]),
+]
+
+ADD_INCOMPATIBLE = [
+    ("add_length_time", ["length", "time"], "auto bad = 1.0_m + 1.0_s;", ["meters<double>", "seconds<double>"]),
+    ("add_mass_length", ["mass", "length"], "auto bad = 1.0_kg + 1.0_m;", ["kilograms<double>", "meters<double>"]),
+    ("sub_velocity_area", ["velocity", "area"], "auto bad = 1.0_mps - units::area::square_meters<double>(1.0);",
+     ["meters_per_second<double>", "square_meters<double>"]),
+    ("add_frequency_angle", ["frequency", "angle"], "auto bad = units::frequency::hertz<double>(1.0) + units::angle::radians<double>(1.0);",
+     ["hertz<double>", "radians<double>"]),
+]
+
+# derived-result cases: forming the product/quotient must name the DERIVED friendly type when assigned wrong
+DERIVED_RESULT = [
+    ("mul_length_length_to_time", ["length", "time", "area"],
+     "units::time::seconds<double> x = 2.0_m * 2.0_m;", ["square_meters<double>", "seconds<double>"]),
+    ("div_length_time_to_mass", ["length", "time", "velocity", "mass"],
+     "units::mass::kilograms<double> x = 10.0_m / 2.0_s;", ["meters_per_second<double>", "kilograms<double>"]),
+    ("div_energy_time_to_length", ["energy", "time", "power", "length"],
+     "units::length::meters<double> x = units::energy::joules<double>(6.0) / 2.0_s;", ["watts<double>", "meters<double>"]),
+]
+
+# #357-class ordering: an expression reducing to a dimension whose header is included LAST must still compile.
+ORDERING_OK = [
+    ("order_velocity_over_length", ["velocity", "length"], "auto x = 1.0_mps / 1.0_m;", "frequency"),
+    ("order_length_over_time", ["length", "time"], "auto x = 1.0_m / 1.0_s;", "velocity"),
+    ("order_area_over_length", ["area", "length"], "auto x = units::area::square_meters<double>(4.0) / 1.0_m;", "length"),
+    ("order_length_times_length", ["length"], "auto x = 1.0_m * 1.0_m;", "area"),
+    ("order_energy_over_time", ["energy", "time"], "auto x = units::energy::joules<double>(6.0) / 1.0_s;", "power"),
+    ("order_mass_times_accel", ["mass", "acceleration"],
+     "auto x = 1.0_kg * units::acceleration::meters_per_second_squared<double>(1.0);", "force"),
+]
+
+def header_includes(hdrs):
+    return "\n".join(f"#include <units/{h}.h>" for h in hdrs)
+
+def write(name, text):
+    (CASES / f"generated_{name}.cpp").write_text(text)
+
+def gen_bad_conversion(name, hdrs, body, matches):
+    directives = ["// expect: fail"] + [f"// expect-match: {m}" for m in matches] + [f"// forbid-match: {SOUP}"]
+    txt = f"""// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+{chr(10).join(directives)}
+{header_includes(hdrs)}
+using namespace units;
+using namespace units::literals;
+{body}
+int main() {{ return 0; }}
+"""
+    write(name, txt)
+
+def gen_ordering(name, hdrs, body, last_dim):
+    # include the reduced dimension's header LAST, after the expression is formed, to exercise #357.
+    txt = f"""// GENERATED (generate_cases.py). #357-class ordering: an expression reducing to the '{last_dim}' dimension is
+// formed BEFORE that dimension's header is included — must still compile (no explicit-specialization-after-
+// instantiation).
+// expect: pass
+{header_includes(hdrs)}
+using namespace units;
+using namespace units::literals;
+{body}
+#include <units/{last_dim}.h>
+int main() {{ (void)sizeof(x); return 0; }}
+"""
+    write(name, txt)
+
+def main():
+    # clear old generated files so removals don't linger
+    for f in CASES.glob("generated_*.cpp"):
+        f.unlink()
+    for c in BAD_CONVERSIONS:
+        gen_bad_conversion(c[0], c[1], c[2], c[3])
+    for c in ADD_INCOMPATIBLE:
+        gen_bad_conversion(c[0], c[1], c[2], c[3])
+    for c in DERIVED_RESULT:
+        gen_bad_conversion(c[0], c[1], c[2], c[3])
+    for c in ORDERING_OK:
+        gen_ordering(c[0], c[1], c[2], c[3])
+    total = len(BAD_CONVERSIONS) + len(ADD_INCOMPATIBLE) + len(DERIVED_RESULT) + len(ORDERING_OK)
+    print(f"generated {total} cases (+ 4 curated hand-written) = {total + 4} total")
+
+if __name__ == "__main__":
+    main()

--- a/test/errorMessages/run.py
+++ b/test/errorMessages/run.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+Template error-message harness for nholthaus/units.
+
+For each case in cases/*.cpp it:
+  - compiles with -fsyntax-only and records exit code + wall time,
+  - honours in-file directives:
+      // expect: fail            (default: pass)  -- whether the compile SHOULD fail
+      // expect-match: <substr>  the error/output MUST contain <substr>   (readability assertion)
+      // forbid-match: <substr>  the error/output must NOT contain <substr> (anti-soup assertion)
+  - records a trimmed error excerpt.
+
+Readability is graded by the expect-match/forbid-match directives: they assert the diagnostic
+names the friendly `strong` types (meters_, hertz_, ...) and never the raw conversion_factor soup.
+
+Usage:
+  run.py --cc g++ --std c++23 --include ../../include [--json out.json] [--label baseline]
+Compare two runs:
+  run.py --compare baseline.json proto.json
+"""
+import argparse, json, re, subprocess, sys, time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+def parse_directives(text):
+    d = {"expect_fail": False, "expect_match": [], "forbid_match": []}
+    for line in text.splitlines():
+        m = re.search(r'//\s*expect:\s*(\w+)', line)
+        if m:
+            d["expect_fail"] = (m.group(1).lower() == "fail")
+        m = re.search(r'//\s*expect-match:\s*(.+?)\s*$', line)
+        if m:
+            d["expect_match"].append(m.group(1))
+        m = re.search(r'//\s*forbid-match:\s*(.+?)\s*$', line)
+        if m:
+            d["forbid_match"].append(m.group(1))
+    return d
+
+def is_msvc(cc):
+    return Path(cc).stem.lower() == "cl"
+
+def compile_cmd(cc, std, include, path):
+    # Syntax-only compile that PRODUCES the diagnostic but no object file, across compilers.
+    if is_msvc(cc):
+        # /Zs = syntax check only; /EHsc for standard C++; /permissive- for conformance; /diagnostics:classic
+        # keeps the message form stable. /std:c++latest when std is c++23 (older MSVC lacks /std:c++23).
+        stdflag = "/std:c++latest" if std in ("c++23", "c++2b") else f"/std:{std}"
+        return [cc, "/nologo", "/Zs", "/EHsc", "/permissive-", stdflag, f"/I{include}", str(path)]
+    return [cc, f"-std={std}", "-I", include, "-fsyntax-only", str(path)]
+
+def normalize(diag):
+    # Make token matching COMPILER-INDEPENDENT: the exact diagnostic text differs by compiler (MSVC prefixes
+    # class/struct/enum and writes 'units::length::meters<double>' with different spacing than g++/clang). Strip the
+    # elaborated-type keywords and collapse all whitespace so an expect-match like 'meters<double>' or the bare
+    # 'meters' matches on g++, clang, AND MSVC alike.
+    d = re.sub(r'\b(class|struct|enum|typename)\s+', '', diag)
+    d = re.sub(r'\s+', ' ', d)
+    return d
+
+def run_case(path, cc, std, include):
+    text = path.read_text()
+    d = parse_directives(text)
+    cmd = compile_cmd(cc, std, include, path)
+    t0 = time.perf_counter()
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
+    dt = time.perf_counter() - t0
+    out = proc.stderr + proc.stdout
+    compiled = (proc.returncode == 0)
+    norm = normalize(out)
+
+    problems = []
+    if d["expect_fail"] and compiled:
+        problems.append("expected compile FAILURE but it compiled")
+    if not d["expect_fail"] and not compiled:
+        problems.append("expected compile SUCCESS but it FAILED")
+    # Match against the whitespace/keyword-normalized diagnostic so tokens are compiler-portable.
+    for sub in d["expect_match"]:
+        if normalize(sub) not in norm:
+            problems.append(f"missing readable token: {sub!r}")
+    for sub in d["forbid_match"]:
+        if normalize(sub) in norm:
+            problems.append(f"contains forbidden soup: {sub!r}")
+
+    # first error line, for the report
+    err_excerpt = ""
+    for line in out.splitlines():
+        if "error:" in line:
+            err_excerpt = line.strip()
+            break
+
+    return {
+        "case": path.name,
+        "compiled": compiled,
+        "expect_fail": d["expect_fail"],
+        "seconds": round(dt, 3),
+        "ok": len(problems) == 0,
+        "problems": problems,
+        "error_excerpt": err_excerpt[:300],
+    }
+
+def do_run(args):
+    cases = sorted((HERE / "cases").glob("*.cpp"))
+    results = [run_case(c, args.cc, args.std, args.include) for c in cases]
+    total_time = round(sum(r["seconds"] for r in results), 3)
+    passed = sum(1 for r in results if r["ok"])
+    report = {"label": args.label, "cc": args.cc, "std": args.std,
+              "total_seconds": total_time, "passed": passed, "count": len(results),
+              "results": results}
+    print(f"\n=== error-message harness [{args.label}] :: {args.cc} {args.std} ===")
+    for r in results:
+        mark = "PASS" if r["ok"] else "FAIL"
+        print(f"  [{mark}] {r['case']:<32} {r['seconds']:>6.3f}s  "
+              f"{'(compiled)' if r['compiled'] else '(rejected)'}")
+        for p in r["problems"]:
+            print(f"          - {p}")
+        if not r["ok"] and r["error_excerpt"]:
+            print(f"          err: {r['error_excerpt']}")
+    print(f"  ---- {passed}/{len(results)} cases OK, total {total_time}s ----")
+    if args.json:
+        Path(args.json).write_text(json.dumps(report, indent=2))
+        print(f"  wrote {args.json}")
+    return 0 if passed == len(results) else 1
+
+def do_compare(a_path, b_path):
+    a = json.loads(Path(a_path).read_text())
+    b = json.loads(Path(b_path).read_text())
+    ab = {r["case"]: r for r in a["results"]}
+    bb = {r["case"]: r for r in b["results"]}
+    print(f"\n=== compare  A=[{a['label']}]  vs  B=[{b['label']}] ===")
+    print(f"  total time: A={a['total_seconds']}s  B={b['total_seconds']}s  "
+          f"(Δ {round(b['total_seconds']-a['total_seconds'],3):+}s)")
+    for case in sorted(set(ab) | set(bb)):
+        ra, rb = ab.get(case), bb.get(case)
+        if not ra or not rb:
+            print(f"  {case}: only in {'A' if ra else 'B'}"); continue
+        dt = round(rb["seconds"] - ra["seconds"], 3)
+        flags = []
+        if ra["ok"] != rb["ok"]:
+            flags.append(f"OK {ra['ok']}->{rb['ok']}")
+        if ra["compiled"] != rb["compiled"]:
+            flags.append(f"compiled {ra['compiled']}->{rb['compiled']}")
+        note = ("  <<< " + ", ".join(flags)) if flags else ""
+        print(f"  {case:<32} A={ra['seconds']:>6.3f}s B={rb['seconds']:>6.3f}s  Δ{dt:+}s{note}")
+    return 0
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cc", default="g++")
+    ap.add_argument("--std", default="c++23")
+    ap.add_argument("--include", default=str(HERE.parent.parent / "include"))
+    ap.add_argument("--json")
+    ap.add_argument("--label", default="run")
+    ap.add_argument("--compare", nargs=2, metavar=("A.json", "B.json"))
+    args = ap.parse_args()
+    if args.compare:
+        sys.exit(do_compare(*args.compare))
+    sys.exit(do_run(args))
+
+if __name__ == "__main__":
+    main()

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -24,6 +24,11 @@ using namespace units::literals;
 
 namespace
 {
+	// Detector op for the SFINAE-safety guards: is std::common_type_t<A, B> well-formed? Used with the library's
+	// detection idiom (detail::is_detected_v) to assert common_type is SFINAE-empty (not a hard error) where expected.
+	template<class A, class B>
+	using common_type_of = std::common_type_t<A, B>;
+
 	class TypeTraits : public ::testing::Test
 	{
 	};
@@ -689,6 +694,35 @@ TEST_F(STDSpecializations, hash)
 	EXPECT_EQ((std::hash<dimensionless<int>>()(42)), (std::hash<dimensionless<int>>()(42)));
 
 	EXPECT_EQ(std::hash<dBW<double>>()(2.0_dBW), std::hash<double>()(dBW<>(2.0).to_linearized()));
+}
+
+// General coverage (not tied to a specific change): units must work END-TO-END as STL associative-container
+// keys — an ordered container exercises operator<, an unordered one exercises std::hash + operator== together.
+// The hash test above only calls std::hash directly; this proves the real use case, and that a scaled key
+// (kilometers vs meters) compares/hashes by magnitude, not by stored representation.
+TEST_F(STDSpecializations, unitsAsContainerKeys)
+{
+	// std::map — ordered by value via operator<.
+	std::map<meters<double>, std::string> m;
+	m[meters<double>(1.0)] = "one";
+	m[meters<double>(2.0)] = "two";
+	m[kilometers<double>(0.003)] = "three-m"; // 3 m, distinct key from 1 m / 2 m
+	EXPECT_EQ(m.size(), 3u);
+	EXPECT_EQ(m[meters<double>(1.0)], "one");
+	EXPECT_EQ(m.begin()->second, "one"); // smallest key first
+
+	// std::unordered_map — needs both std::hash<meters<double>> AND operator==.
+	std::unordered_map<meters<double>, int> um;
+	um[meters<double>(5.0)] = 50;
+	EXPECT_EQ(um.at(meters<double>(5.0)), 50);
+	// a scaled-but-equal key resolves to the SAME bucket (kilometers<double>(0.005) == 5 m). Look it up after
+	// converting to the map's key type, since a heterogeneous [] would insert a different key type.
+	EXPECT_EQ(um.at(meters<double>(kilometers<double>(0.005))), 50);
+
+	// std::set — membership by value.
+	std::set<seconds<double>> s{seconds<double>(1.0), seconds<double>(2.0), seconds<double>(1.0)};
+	EXPECT_EQ(s.size(), 2u); // the duplicate 1 s collapses
+	EXPECT_TRUE(s.count(seconds<double>(2.0)) == 1);
 }
 
 TEST_F(UnitManipulators, squared)
@@ -1487,6 +1521,58 @@ TEST_F(UnitType, unitTypeArithmeticOperatorReturnType)
 	static_assert(std::is_same_v<meters<int>, decltype(length % dim)>);
 	static_assert(std::is_same_v<meters<int>, decltype(length % pcnt)>);
 	static_assert(std::is_same_v<meters<int>, decltype(length % length)>);
+}
+
+// Regression guards for the class-based named-unit refactor: diagnostics/traits must report the FRIENDLY named
+// type, and the trait/std specializations must see through the derived named class (not decay to the plain unit<...>
+// base or hard-error). These lock in the behavior the coverage audit flagged as correct-but-untested.
+TEST_F(UnitType, namedUnitReportedTypeIsPreserved)
+{
+	// (1) arithmetic RESULTS report the named type, not the equivalent-but-unnamed unit<strong_t<...>>.
+	static_assert(std::is_same_v<decltype(meters<double>(2) * meters<double>(2)), square_meters<double>>);
+	static_assert(std::is_same_v<decltype(meters<double>(10) / seconds<double>(2)), meters_per_second<double>>);
+	static_assert(std::is_same_v<decltype(1.0 / seconds<double>(1)), hertz<double>>);       // inverse -> named
+	static_assert(std::is_same_v<decltype(pow<3>(meters<double>(1))), cubic_meters<double>>);
+
+	// (2) unit-math functions PRESERVE the named type on a dimensioned named input (audit: value-tested only before).
+	static_assert(std::is_same_v<decltype(floor(meters<double>(1.5))), meters<double>>);
+	static_assert(std::is_same_v<decltype(round(meters<double>(1.5))), meters<double>>);
+	static_assert(std::is_same_v<decltype(trunc(meters<double>(1.5))), meters<double>>);
+	static_assert(std::is_same_v<decltype(hypot(meters<double>(3), meters<double>(4))), meters<double>>);
+
+	// (3) traits see through the derived named class.
+	static_assert(std::is_same_v<traits::replace_underlying_t<meters<int>, double>, meters<double>>);
+	static_assert(std::is_same_v<std::common_type_t<meters<int>, meters<double>>, meters<double>>);
+
+	// (4) C1: std::numeric_limits<Named> returns the NAMED type (value AND type), not the plain base.
+	static_assert(std::is_same_v<decltype(std::numeric_limits<meters<double>>::max()), meters<double>>);
+	static_assert(std::is_same_v<decltype(std::numeric_limits<meters<double>>::lowest()), meters<double>>);
+	EXPECT_EQ(std::numeric_limits<meters<double>>::max().to_linearized(), std::numeric_limits<double>::max());
+
+	// (5) C2: common_type<dimensioned-named, scalar> is SFINAE-EMPTY (no `type`), exactly like the plain unit<...>
+	//     form — never a hard error. A dimensionless-named + scalar still HAS a common type (interchangeable).
+	static_assert(!detail::is_detected_v<common_type_of, meters<double>, double>, "dimensioned named + scalar: no common type (SFINAE-safe)");
+	static_assert(!detail::is_detected_v<common_type_of, unit<conversion_factor<std::ratio<1>, dimension::length>, double>, double>, "plain dimensioned + scalar: also none (parity)");
+	static_assert(detail::is_detected_v<common_type_of, percent<double>, double>, "dimensionless named + scalar: has a common type");
+
+	// (6) abbreviation()/name() members resolve on the named form (incl. a COMPOUND named unit, per audit).
+	EXPECT_STREQ("m", meters<double>(1).abbreviation());
+	EXPECT_STREQ("meters", meters<double>(1).name());
+	EXPECT_STREQ("mps", meters_per_second<double>(1).abbreviation());
+
+	// (7) the remaining unit-math functions PRESERVE the named type on a named input (audit: value-only before).
+	static_assert(std::is_same_v<decltype(min(meters<double>(1), meters<double>(2))), meters<double>>);
+	static_assert(std::is_same_v<decltype(max(meters<double>(1), meters<double>(2))), meters<double>>);
+	static_assert(std::is_same_v<decltype(fmod(meters<double>(5), meters<double>(2))), meters<double>>);
+	static_assert(std::is_same_v<decltype(copysign(meters<double>(3), -1.0)), meters<double>>);
+	static_assert(std::is_same_v<decltype(fabs(meters<double>(-3))), meters<double>>);
+	static_assert(std::is_same_v<decltype(abs(meters<double>(-3))), meters<double>>);
+	static_assert(std::is_same_v<decltype(sqrt(square_meters<double>(4))), meters<double>>);
+
+	// (8) a NON-registered derived CF stays the plain unit<...> (identity rewrap): dividing two unlike named units
+	//     whose quotient has no named class must NOT invent a name. meters/kilograms has no named unit.
+	static_assert(!detail::is_named_unit_v<decltype(meters<double>(1) / kilograms<double>(1))>,
+		"a derived CF with no registered named class stays the plain unit<...>");
 }
 
 TEST_F(UnitType, unitTypeAddition)
@@ -4879,7 +4965,9 @@ TEST_F(UnitMath, pow)
 
 	auto cube = pow<3>(value);
 	EXPECT_NEAR(1000.0, cube.value(), 5.0e-2);
-	static_assert(std::is_same_v<decltype(cube), unit<traits::strong_t<cubed<meters<double>>>>>);
+	// Named-result parity with pow<2> -> square_meters above: pow<3> of a length reports the named volume unit
+	// (cubic_meters<double>), the friendly type, rather than the equivalent-but-unnamed unit<strong_t<cubed<...>>>.
+	static_assert(std::is_same_v<decltype(cube), cubic_meters<double>>);
 
 	auto fourth = pow<4>(value);
 	EXPECT_NEAR(10000.0, fourth.value(), 5.0e-2);

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -10,7 +10,11 @@
 #include <chrono>
 #include <complex>
 #include <gtest/gtest.h>
+#include <iomanip>
+#include <iostream>
+#include <locale>
 #include <ratio>
+#include <sstream>
 #include <string>
 #include <type_traits>
 #include <units.h>
@@ -3031,6 +3035,10 @@ TEST_F(UnitType, to_string_locale)
 #if defined(_MSC_VER)
 	setlocale(LC_ALL, "de-DE");
 	os1.imbue(std::locale("de-DE"));
+#elif defined(__APPLE__)
+	// BSD libc (macOS) only recognizes the canonical `.UTF-8` spelling, not glibc's `de_DE.utf8` alias.
+	EXPECT_STREQ("de_DE.UTF-8", setlocale(LC_ALL, "de_DE.UTF-8")) << "For this test to work, you need a german locale installed.";
+	os1.imbue(std::locale("de_DE.UTF-8"));
 #else
 	EXPECT_STREQ("de_DE.utf8", setlocale(LC_ALL, "de_DE.utf8")) << "For this test to work, you need a german locale installed: `sudo locale-gen de_DE.UTF-8`";
 	os1.imbue(std::locale("de_DE.utf8"));
@@ -3054,6 +3062,10 @@ TEST_F(UnitType, to_string_locale)
 #if defined(_MSC_VER)
 	setlocale(LC_ALL, "en-US");
 	os2.imbue(std::locale("en-US"));
+#elif defined(__APPLE__)
+	// BSD libc (macOS) only recognizes the canonical `.UTF-8` spelling, not glibc's `en_US.utf8` alias.
+	EXPECT_STREQ("en_US.UTF-8", setlocale(LC_ALL, "en_US.UTF-8")) << "For this test to work, you need a USA locale installed.";
+	os2.imbue(std::locale("en_US.UTF-8"));
 #else
 	EXPECT_STREQ("en_US.utf8", setlocale(LC_ALL, "en_US.utf8")) << "For this test to work, you need a USA locale installed: `sudo locale-gen en_US.UTF-8`";
 	os2.imbue(std::locale("en_US.utf8"));
@@ -5047,6 +5059,38 @@ TEST_F(UnitMath, isunordered)
 	EXPECT_TRUE(units::isunordered(nan, zero));
 	EXPECT_TRUE(units::isunordered(zero, nan));
 	EXPECT_FALSE(units::isunordered(zero, zero));
+}
+
+TEST_F(UnitMath, signbit)
+{
+	meters<> zero(0.0);
+	meters<> pos(1.0);
+	meters<> neg(-1.0);
+	meters<> negZero(-0.0);
+
+	EXPECT_FALSE(std::signbit(zero));
+	EXPECT_FALSE(std::signbit(pos));
+	EXPECT_TRUE(std::signbit(neg));
+	EXPECT_TRUE(std::signbit(negZero));
+}
+
+TEST_F(UnitMath, stdExtensions)
+{
+	meters<> zero(0.0);
+	meters<> nan(NAN);
+	meters<> inf(INFINITY);
+
+	EXPECT_TRUE(std::isnan(nan));
+	EXPECT_FALSE(std::isnan(inf));
+	EXPECT_FALSE(std::isnan(zero));
+
+	EXPECT_TRUE(std::isinf(inf));
+	EXPECT_FALSE(std::isinf(nan));
+	EXPECT_FALSE(std::isinf(zero));
+
+	EXPECT_TRUE(std::isfinite(zero));
+	EXPECT_FALSE(std::isfinite(nan));
+	EXPECT_FALSE(std::isfinite(inf));
 }
 
 // Constexpr


### PR DESCRIPTION
## Summary

A **readability + robustness** release for the v3.x line — focused on what you see in the compiler and the
debugger. **No public API changes**: `meters<>` / `meters<double>` and every unit spell exactly as before.

### 1. Diagnostics name the unit, not the template soup
Named units are now classes deriving from `units::unit<...>` (instead of alias templates), so a diagnostic
reads `units::length::meters<double>` → `units::frequency::hertz<double>` instead of
`unit<conversion_factor<std::ratio<1>, dimension_t<...>>, double, linear_scale>` — for **both operands and
computed results** (`length*length` → `square_meters<double>`, etc.). Rendering only; representation/values/
API unchanged.

### 2. Fix #357 — include order no longer breaks the build
Forming an expression that reduces to a not-yet-included dimension (`velocity/length` → `1/time`) failed with
*"explicit specialization after instantiation."* The strong-type lookup is now an ADL customization point, so
a later-included header just adds a better overload — include order can't decide compilability.

### 3. Visual Studio natvis
`natvis/units.natvis` shows a unit as `3 m` in Watch/Locals/DataTips; attached to the target + installed
(MSVC-only, no-op elsewhere).

### 4. `std::` math extensions (upstream PR #356 by @carlfriess, merged into this branch)
`std::isnan/isinf/signbit` switched off the removed `operator()` to `raw()`; adds `std::isfinite`; macOS
locale branch for the locale test.

## Testing
- `unitLibTest` **238/238** green, incl. new `namedUnitReportedTypeIsPreserved` + `unitsAsContainerKeys`.
- New **error-message harness** (`test/errorMessages/`, 29 cases) grading readable-named-type presence and
  no-`conversion_factor`-soup — compiler-portable (g++/clang/MSVC) and wired into all three CI workflows.

## Under the hood
Trait/`std` specializations, arithmetic operators, `to_string`/`operator<<`, `name()`/`abbreviation()` all
see through / preserve the named class; `numeric_limits<Named>` returns the named type; `common_type
<dimensioned-named, scalar>` is SFINAE-empty (parity with the plain form); pure `dimensionless` stays a plain
alias (interchangeable with int/double).

Version bumped to **3.4.0**.
