### PR TITLE
fix: modf must not re-scale the fractional part of a scaled dimensionless unit

### DIFF
--- a/include/units/core.h
+++ b/include/units/core.h
@@ -4526,10 +4526,16 @@ namespace units
 	template<DimensionlessUnitType UnitType>
 	constexpr dimensionless<detail::floating_point_promotion_t<typename UnitType::underlying_type>> modf(const UnitType x, UnitType* intpart) noexcept
 	{
-		typename UnitType::underlying_type intp;
-		UnitType                           fracpart = std::modf(x.template to<decltype(intp)>(), &intp);
-		*intpart                                    = intp;
-		return fracpart;
+		using promoted = detail::floating_point_promotion_t<typename UnitType::underlying_type>;
+		// std::modf splits the NORMALIZED value; the integral and fractional parts are already in the
+		// quantity's own (normalized) units. Re-wrapping the fractional double through UnitType's
+		// value constructor would re-apply the unit's scale (e.g. percent's 1/100) a second time, so the
+		// fraction is returned as a plain dimensionless value and the integral part is converted back to
+		// UnitType through its converting constructor.
+		promoted intp;
+		promoted fracpart = std::modf(x.template to<promoted>(), &intp);
+		*intpart          = dimensionless<promoted>{intp};
+		return dimensionless<promoted>{fracpart};
 	}
 
 	/**

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -4916,6 +4916,18 @@ TEST_F(UnitMath, modf)
 	double         umodfr1;
 	decltype(uval) umodfr2;
 	EXPECT_EQ(std::modf(uval.to<double>(), &umodfr1), units::modf(uval, &umodfr2));
+
+	// A scaled dimensionless unit (percent) must not have its scale applied twice: modf(202.5%) is an
+	// integral 200% and a fractional 2.5%, i.e. value() 2.0 and 0.025 (regression for issue #312). The
+	// fractional part carries only the rounding of std::modf itself, so it is compared with a tolerance.
+	percent<double> pintpart;
+	auto            pfracpart = modf(percent<double>(202.5), &pintpart);
+	EXPECT_DOUBLE_EQ(2.0, pintpart.value());
+	EXPECT_NEAR(0.025, pfracpart.value(), 1e-12);
+	// sign is carried on both parts
+	auto npfracpart = modf(percent<double>(-202.5), &pintpart);
+	EXPECT_DOUBLE_EQ(-2.0, pintpart.value());
+	EXPECT_NEAR(-0.025, npfracpart.value(), 1e-12);
 }
 
 TEST_F(UnitMath, exp2)


### PR DESCRIPTION
`units::modf()` ran `std::modf` on the normalized value, then assigned the resulting fractional `double` back through the unit's value constructor, which re-applied the unit's scale. For a scaled dimensionless unit such as `percent`, that scaled the fraction a second time:

```cpp
percent<double> ip;
auto fp = modf(percent<double>{202.5}, &ip);
// before: ip.value()==2.0 (correct), fp.value()==0.00025  (wrong — 100x off)
// after:  ip.value()==2.0,           fp.value()==0.025
```

The fractional part is now returned as a `dimensionless` value (and the integral part converted back through the converting constructor), so the scale is applied exactly once. Ordinary dimensionless values are unaffected and the sign is carried on both parts. Adds a `percent` regression case to `UnitMath.modf`. Full suite green (238 tests).

Re-applies the diagnosis from #312 (by @ts826848); the v3.x signature had diverged from that patch (now `constexpr`, `DimensionlessUnitType`-constrained, promoted return), so it is re-implemented here. Closes #312.