### PR TITLE
docs: spelling a quantity type (meters / meters<> / meters<T>) and when to use auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,40 @@ meters d{5.0};          // braced construction
 > arithmetic, so `1_m / 2_m` is `0`, whereas `1.0_m / 2.0_m` is `0.5`. Use a decimal point (or write
 > `meters<double>`) when you want fractional results.
 
+**Spelling the type: `meters`, `meters<>`, `meters<T>`.** Three ways to name the type:
+
+- `meters<T>` — an explicit representation (`meters<double>`, `meters<float>`, `meters<int>`). Valid as a
+  variable, function parameter, return type, or member.
+- `meters<>` — the default representation; identical to `meters<double>`. Valid in the same positions.
+- `meters` — the bare name deduces the representation from the initializer (CTAD): `meters a(5.0)` is
+  `meters<double>`, `meters a(5)` is `meters<int>`. Valid only where an initializer is present to deduce
+  from — a local variable. A function parameter, a return type, and a class member have no initializer,
+  so they require `meters<>` or `meters<T>`.
+
+```cpp
+meters        local(5.0);      // bare name, deduced meters<double>
+meters<>      m;               // default representation
+meters<float> as_float(5.0f);  // explicit representation
+// void f(meters q);           // ill-formed: a parameter has no initializer to deduce from
+// meters make();              // ill-formed: a return type has no initializer to deduce from
+```
+
+**`auto` vs. an explicit type.** Use `auto` on the left when the right-hand side already states the unit:
+
+```cpp
+auto d = 5.0_m;                  // meters
+auto speed = 60.0_mi / 1.0_hr;   // a velocity
+```
+
+Write the type explicitly on the left when the compiler should confirm the dimensional analysis: naming
+the result type makes a mismatch a compile error rather than an accepted `auto` deduction.
+
+```cpp
+square_meters     area  = 15.0_m * 5.0_m;    // the result is an area
+meters_per_second speed = 100.0_m / 8.0_s;   // the result is a velocity
+// meters bad = 15.0_m * 5.0_m;              // ill-formed: the result is an area, not a length
+```
+
 **Convert** by assigning between compatible units (implicit, and only when lossless):
 
 ```cpp

--- a/docs/explain/ctad-and-adl-for-humans.md
+++ b/docs/explain/ctad-and-adl-for-humans.md
@@ -43,7 +43,7 @@ meters<double> d;   // explicit: there is no argument to deduce from
 ```
 
 > **Note — CTAD infers `int` vs `double` from what you write.** The deduced representation follows the
-> argument's type. This is deliberate and occasionally surprising:
+> argument's type:
 >
 > ```cpp
 > meters x(5);     // -> meters<int>     (5 is an int)
@@ -58,9 +58,8 @@ meters<double> d;   // explicit: there is no argument to deduce from
 > auto q = 1.0_m / 2.0_m;  // meters<double> math: q == 0.5
 > ```
 >
-> **When you want fractional results, write the decimal point** (or name the type: `meters<double>`).
-> This is the single most common surprise for new users, and it is the same rule the language applies to
-> `1 / 2 == 0` for plain `int`.
+> For fractional results, write the decimal point (or name the type: `meters<double>`). This is the same
+> rule the language applies to `1 / 2 == 0` for plain `int`.
 
 ### The 2.x alias template versus the 3.x class template
 


### PR DESCRIPTION
Adds an early README subsection covering two things new users ask immediately:

- **Spelling the type** — `meters<T>` (explicit representation) and `meters<>` (default) are valid as variables, parameters, return types, and members; bare `meters` is a CTAD placeholder valid only where an initializer is present to deduce from (so not as a parameter, return type, or member). Includes the ill-formed cases with the reason.
- **`auto` vs. an explicit type** — use `auto` when the right-hand side states the unit; name the result type explicitly when the compiler should confirm the dimensional analysis (a mismatch becomes a compile error instead of an accepted `auto` deduction).

Every snippet compiles. Also removes a "surprising" characterization from the int/double CTAD note in the CTAD/ADL guide (states the rule as fact).