### PR TITLE
v3.4.2: new units (imperial/ancient/esoteric), statvolt fix, and honest positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,44 @@
 All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project adheres to semantic versioning.
 
+## [3.4.2] - 2026-08-14
+
+A units-and-correctness release: a broad set of new units, and a conversion fix.
+
+### Added
+- Over fifty new units across many dimensions — imperial and US-customary, ancient, and esoteric — each
+  defined by an exact rational against its most-canonical parent and verified against its authoritative
+  value. Highlights: length `rods`/`links`/`barleycorns`/`nails`/`spans`/`picas`/`points`; velocity
+  `feet_per_minute`/`meters_per_minute`/`inches_per_second`/`kilometers_per_second`; area
+  `roods`/`square_rods`; angle `angular_mils`/`compass_points`; time
+  `fortnights`/`decades`/`centuries`/`millennia`; `nibbles`; radiation `rem`; substance `pound_moles`;
+  mass `grains`/`avoirdupois_drams`/`pennyweights`/`troy_ounces`/`troy_pounds`/`hundredweights`; force
+  `kips`/`ounces_force`/`grams_force`/`short_tons_force`/`long_tons_force`/`sthenes`; pressure
+  `technical_atmospheres`/`pounds_per_square_foot`/`kips_per_square_inch`/`baryes`/`piezes`/water columns;
+  energy `ergs`/`calories_it`/`tons_of_tnt`; power `metric_horsepower`/`electrical_horsepower`/
+  `tons_of_refrigeration`; and the CGS `ab-`/`stat-` charge and current pairs.
+
+### Fixed
+- The `statvolt` conversion was inverted (`1 statvolt` read as `0.00333564 V` instead of `299.792458 V`).
+  Corrected to `c / 1e6` volts. `abvolts` was already correct.
+
+## [3.4.1] - 2026-08-14
+
+A documentation and maintenance release. 3.x becomes the project's default branch.
+
+### Added
+- A complete documentation set: a rewritten README (with an inlined cheat sheet, the full unit catalog,
+  and the physical-constants table) and an in-repo `docs/` manual (learn / explain / how-to / reference /
+  meta). The Doxygen reference is published to <https://nholthaus.github.io/units/> from CI, and every
+  documented code snippet is compiled as part of the test suite.
+
+### Fixed
+- `units::modf()` applied a scaled dimensionless unit's scale twice to the fractional part; for `percent`,
+  `modf(202.5%)` returned a fractional part of `0.00025` instead of `0.025`. The fractional part is now
+  returned as a dimensionless value, so the scale is applied once. (#312)
+- `minutes` had no registered name or abbreviation (it printed as its base unit and could return a null
+  `name()`/`abbreviation()`); it now reports `"minutes"` / `"min"` and prints as `1.5 min`.
+
 ## [3.4.0] - 2026-08-14
 
 The readability release: compiler diagnostics now name the friendly unit type.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ stays small and the code stays legible.
 
 - **Syntax.** Quantities are written as `meters`, `60_mi / 1_hr`, `sqrt(area)`; operations are performed
   on the quantity types.
+- **Batteries included.** Over 250 units across 47 dimensions ship ready to use — SI, imperial and
+  US-customary, ancient, and esoteric alike (`3.0_cwt`, `10.0_fur`, `1.0_rem`), each a named type with a
+  literal and an exact, canonically-sourced conversion ratio. There is no unit "system" to select or
+  instantiate: every unit is first class and used directly, and units from different systems combine in
+  one expression (`1.0_m + 3.0_ft + 1.0_fur`). Nothing to configure, no unit to define before use.
 - **Run-time cost.** Conversions are `constexpr` ratios; a conversion between equivalent representations
   compiles to no machine code. A quantity is a trivially-copyable value the size of its underlying type.
 - **Dimensional checking.** Adding a length to a time, or assigning an area to a length, is a compile
@@ -383,6 +388,8 @@ For a name shared across dimensions (e.g. `pounds`), qualify it: `units::mass::p
 | `milliarcseconds` | `_mas` |  |
 | `turns` | `_tr` |  |
 | `gradians` | `_gon` |  |
+| `angular_mils` | `_amil` |  |
+| `compass_points` | `_cpt` |  |
 
 ### angular velocity
 
@@ -405,6 +412,8 @@ For a name shared across dimensions (e.g. `pounds`), qualify it: `units::mass::p
 | `square_kilometers` | `_km2` |  |
 | `hectares` | `_ha` |  |
 | `acres` | `_acre` |  |
+| `roods` | `_rood` |  |
+| `square_rods` | `_rd2` |  |
 
 ### capacitance
 
@@ -418,6 +427,8 @@ For a name shared across dimensions (e.g. `pounds`), qualify it: `units::mass::p
 |------|---------|----------|
 | `coulombs` | `_C` | yes |
 | `ampere_hours` | `_Ah` | yes |
+| `abcoulombs` | `_abC` |  |
+| `statcoulombs` | `_statC` |  |
 
 ### concentration
 
@@ -439,6 +450,8 @@ For a name shared across dimensions (e.g. `pounds`), qualify it: `units::mass::p
 | Unit | Literal | Prefixes |
 |------|---------|----------|
 | `amperes` | `_A` | yes |
+| `abamperes` | `_abA` |  |
+| `statamperes` | `_statA` |  |
 
 ### data
 
@@ -448,6 +461,7 @@ For a name shared across dimensions (e.g. `pounds`), qualify it: `units::mass::p
 | `exabytes` | `_EB` |  |
 | `bits` | `_b` |  |
 | `exabits` | `_Eb` |  |
+| `nibbles` | `_nibble` |  |
 
 ### data transfer rate
 
@@ -486,6 +500,9 @@ For a name shared across dimensions (e.g. `pounds`), qualify it: `units::mass::p
 | `british_thermal_units_59` | `_BTU59` |  |
 | `therms` | `_thm` |  |
 | `foot_pounds` | `_ftlbf` |  |
+| `ergs` | `_erg` |  |
+| `calories_it` | `_cal_it` |  |
+| `tons_of_tnt` | `_tTNT` |  |
 
 ### energy density
 
@@ -502,6 +519,12 @@ For a name shared across dimensions (e.g. `pounds`), qualify it: `units::mass::p
 | `dynes` | `_dyn` |  |
 | `kiloponds` | `_kp` |  |
 | `poundals` | `_pdl` |  |
+| `kips` | `_kip` |  |
+| `ounces_force` | `_ozf` |  |
+| `grams_force` | `_gf` |  |
+| `short_tons_force` | `_tonf` |  |
+| `long_tons_force` | `_ltonf` |  |
+| `sthenes` | `_sn` |  |
 
 ### frequency
 
@@ -565,6 +588,13 @@ For a name shared across dimensions (e.g. `pounds`), qualify it: `units::mass::p
 | `leagues` | `_lea` |  |
 | `nautical_leagues` | `_nl` |  |
 | `yards` | `_yd` |  |
+| `rods` | `_rod` |  |
+| `links` | `_li` |  |
+| `barleycorns` | `_bc` |  |
+| `nails` | `_nail` |  |
+| `spans` | `_span` |  |
+| `picas` | `_pica` |  |
+| `points` | `_pnt` |  |
 
 ### luminance
 
@@ -618,6 +648,13 @@ For a name shared across dimensions (e.g. `pounds`), qualify it: `units::mass::p
 | `ounces` | `_oz` |  |
 | `carats` | `_ct` |  |
 | `slugs` | `_slug` |  |
+| `grains` | `_gr` |  |
+| `avoirdupois_drams` | `_dr_av` |  |
+| `pennyweights` | `_dwt` |  |
+| `troy_ounces` | `_ozt` |  |
+| `troy_pounds` | `_lbt` |  |
+| `hundredweights` | `_cwt` |  |
+| `short_hundredweights` | `_sh_cwt` |  |
 
 ### power
 
@@ -625,6 +662,9 @@ For a name shared across dimensions (e.g. `pounds`), qualify it: `units::mass::p
 |------|---------|----------|
 | `watts` | `_W` | yes |
 | `horsepower` | `_hp` |  |
+| `metric_horsepower` | `_hpM` |  |
+| `electrical_horsepower` | `_hpE` |  |
+| `tons_of_refrigeration` | `_TR` |  |
 
 ### pressure
 
@@ -638,6 +678,14 @@ For a name shared across dimensions (e.g. `pounds`), qualify it: `units::mass::p
 | `torrs` | `_torr` |  |
 | `millimeters_of_mercury` | `_mmHg` |  |
 | `inches_of_mercury` | `_inHg` |  |
+| `technical_atmospheres` | `_at` |  |
+| `pounds_per_square_foot` | `_psf` |  |
+| `kips_per_square_inch` | `_ksi` |  |
+| `baryes` | `_Ba` |  |
+| `piezes` | `_pz` |  |
+| `centimeters_of_water` | `_cmH2O` |  |
+| `millimeters_of_water` | `_mmH2O` |  |
+| `inches_of_water` | `_inH2O` |  |
 
 ### radiance
 
@@ -661,6 +709,7 @@ For a name shared across dimensions (e.g. `pounds`), qualify it: `units::mass::p
 | `curies` | `_Ci` |  |
 | `rutherfords` | `_rd` |  |
 | `radiation_absorbed_dose` | `_rads` |  |
+| `roentgens_equivalent_man` | `_rem` |  |
 
 ### solid angle
 
@@ -699,6 +748,7 @@ For a name shared across dimensions (e.g. `pounds`), qualify it: `units::mass::p
 | Unit | Literal | Prefixes |
 |------|---------|----------|
 | `mols` | `_mol` | yes |
+| `pound_moles` | `_lbmol` |  |
 
 ### substance concentration
 
@@ -734,6 +784,10 @@ For a name shared across dimensions (e.g. `pounds`), qualify it: `units::mass::p
 | `years` | `_yr` |  |
 | `julian_years` | `_a_j` |  |
 | `gregorian_years` | `_a_g` |  |
+| `fortnights` | `_fn` |  |
+| `decades` | `_dec` |  |
+| `centuries` | `_cent` |  |
+| `millennia` | `_kyr` |  |
 
 ### torque
 
@@ -754,6 +808,10 @@ For a name shared across dimensions (e.g. `pounds`), qualify it: `units::mass::p
 | `miles_per_hour` | `_mph` |  |
 | `kilometers_per_hour` | `_kph` |  |
 | `knots` | `_kts` |  |
+| `feet_per_minute` | `_fpm` |  |
+| `meters_per_minute` | `_mpm` |  |
+| `inches_per_second` | `_ips` |  |
+| `kilometers_per_second` | `_kmps` |  |
 
 ### voltage
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,40 @@ meters d{5.0};          // braced construction
 > arithmetic, so `1_m / 2_m` is `0`, whereas `1.0_m / 2.0_m` is `0.5`. Use a decimal point (or write
 > `meters<double>`) when you want fractional results.
 
+**Spelling the type: `meters`, `meters<>`, `meters<T>`.** Three ways to name the type:
+
+- `meters<T>` — an explicit representation (`meters<double>`, `meters<float>`, `meters<int>`). Valid as a
+  variable, function parameter, return type, or member.
+- `meters<>` — the default representation; identical to `meters<double>`. Valid in the same positions.
+- `meters` — the bare name deduces the representation from the initializer (CTAD): `meters a(5.0)` is
+  `meters<double>`, `meters a(5)` is `meters<int>`. Valid only where an initializer is present to deduce
+  from — a local variable. A function parameter, a return type, and a class member have no initializer,
+  so they require `meters<>` or `meters<T>`.
+
+```cpp
+meters        local(5.0);      // bare name, deduced meters<double>
+meters<>      m;               // default representation
+meters<float> as_float(5.0f);  // explicit representation
+// void f(meters q);           // ill-formed: a parameter has no initializer to deduce from
+// meters make();              // ill-formed: a return type has no initializer to deduce from
+```
+
+**`auto` vs. an explicit type.** Use `auto` on the left when the right-hand side already states the unit:
+
+```cpp
+auto d = 5.0_m;                  // meters
+auto speed = 60.0_mi / 1.0_hr;   // a velocity
+```
+
+Write the type explicitly on the left when the compiler should confirm the dimensional analysis: naming
+the result type makes a mismatch a compile error rather than an accepted `auto` deduction.
+
+```cpp
+square_meters     area  = 15.0_m * 5.0_m;    // the result is an area
+meters_per_second speed = 100.0_m / 8.0_s;   // the result is a velocity
+// meters bad = 15.0_m * 5.0_m;              // ill-formed: the result is an area, not a length
+```
+
 **Convert** by assigning between compatible units (implicit, and only when lossless):
 
 ```cpp

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+units (3.4.2-0ppa1~noble1) noble; urgency=medium
+
+  * New release: documentation overhaul, many added units (imperial, ancient,
+    esoteric), and conversion fixes (statvolt, modf, minutes).
+
+ -- Nic Holthaus <nholthaus@gmail.com>  Thu, 14 Aug 2026 12:00:00 -0400
+
 units (3.4.0-0ppa1~noble1) noble; urgency=medium
 
   * Initial PPA release for Ubuntu 24.04 (Noble).

--- a/docs/explain/ctad-and-adl-for-humans.md
+++ b/docs/explain/ctad-and-adl-for-humans.md
@@ -43,7 +43,7 @@ meters<double> d;   // explicit: there is no argument to deduce from
 ```
 
 > **Note — CTAD infers `int` vs `double` from what you write.** The deduced representation follows the
-> argument's type. This is deliberate and occasionally surprising:
+> argument's type:
 >
 > ```cpp
 > meters x(5);     // -> meters<int>     (5 is an int)
@@ -58,9 +58,8 @@ meters<double> d;   // explicit: there is no argument to deduce from
 > auto q = 1.0_m / 2.0_m;  // meters<double> math: q == 0.5
 > ```
 >
-> **When you want fractional results, write the decimal point** (or name the type: `meters<double>`).
-> This is the single most common surprise for new users, and it is the same rule the language applies to
-> `1 / 2 == 0` for plain `int`.
+> For fractional results, write the decimal point (or name the type: `meters<double>`). This is the same
+> rule the language applies to `1 / 2 == 0` for plain `int`.
 
 ### The 2.x alias template versus the 3.x class template
 

--- a/docs/reference/supported-units.md
+++ b/docs/reference/supported-units.md
@@ -1,6 +1,6 @@
 # Supported units
 
-*The catalog of built-in units, grouped by dimension — **47 dimensions**, **199 named units** (before metric prefixes). Generated from the headers by `docs/reference/gen_reference.py`; do not edit by hand.*
+*The catalog of built-in units, grouped by dimension — **47 dimensions**, **252 named units** (before metric prefixes). Generated from the headers by `docs/reference/gen_reference.py`; do not edit by hand.*
 
 Each unit is available as a type (`meters`, `meters<double>`) and, where shown, a literal (`5.0_m`). Units marked **yes** under Prefixes also provide every SI metric prefix from femto to peta (e.g. `kilometers`/`_km`, `millimeters`/`_mm`). Include the umbrella header `<units.h>` for all of them, or a single `<units/DIMENSION.h>` for one dimension.
 
@@ -26,6 +26,8 @@ For units shared across dimensions (e.g. `pounds` of mass vs. force), qualify wi
 | `milliarcseconds` | `_mas` |  |
 | `turns` | `_tr` |  |
 | `gradians` | `_gon` |  |
+| `angular_mils` | `_amil` |  |
+| `compass_points` | `_cpt` |  |
 
 ### angular velocity
 
@@ -48,6 +50,8 @@ For units shared across dimensions (e.g. `pounds` of mass vs. force), qualify wi
 | `square_kilometers` | `_km2` |  |
 | `hectares` | `_ha` |  |
 | `acres` | `_acre` |  |
+| `roods` | `_rood` |  |
+| `square_rods` | `_rd2` |  |
 
 ### capacitance
 
@@ -61,6 +65,8 @@ For units shared across dimensions (e.g. `pounds` of mass vs. force), qualify wi
 |------|---------|----------|
 | `coulombs` | `_C` | yes |
 | `ampere_hours` | `_Ah` | yes |
+| `abcoulombs` | `_abC` |  |
+| `statcoulombs` | `_statC` |  |
 
 ### concentration
 
@@ -82,6 +88,8 @@ For units shared across dimensions (e.g. `pounds` of mass vs. force), qualify wi
 | Unit | Literal | Prefixes |
 |------|---------|----------|
 | `amperes` | `_A` | yes |
+| `abamperes` | `_abA` |  |
+| `statamperes` | `_statA` |  |
 
 ### data
 
@@ -91,6 +99,7 @@ For units shared across dimensions (e.g. `pounds` of mass vs. force), qualify wi
 | `exabytes` | `_EB` |  |
 | `bits` | `_b` |  |
 | `exabits` | `_Eb` |  |
+| `nibbles` | `_nibble` |  |
 
 ### data transfer rate
 
@@ -129,6 +138,9 @@ For units shared across dimensions (e.g. `pounds` of mass vs. force), qualify wi
 | `british_thermal_units_59` | `_BTU59` |  |
 | `therms` | `_thm` |  |
 | `foot_pounds` | `_ftlbf` |  |
+| `ergs` | `_erg` |  |
+| `calories_it` | `_cal_it` |  |
+| `tons_of_tnt` | `_tTNT` |  |
 
 ### energy density
 
@@ -145,6 +157,12 @@ For units shared across dimensions (e.g. `pounds` of mass vs. force), qualify wi
 | `dynes` | `_dyn` |  |
 | `kiloponds` | `_kp` |  |
 | `poundals` | `_pdl` |  |
+| `kips` | `_kip` |  |
+| `ounces_force` | `_ozf` |  |
+| `grams_force` | `_gf` |  |
+| `short_tons_force` | `_tonf` |  |
+| `long_tons_force` | `_ltonf` |  |
+| `sthenes` | `_sn` |  |
 
 ### frequency
 
@@ -208,6 +226,13 @@ For units shared across dimensions (e.g. `pounds` of mass vs. force), qualify wi
 | `leagues` | `_lea` |  |
 | `nautical_leagues` | `_nl` |  |
 | `yards` | `_yd` |  |
+| `rods` | `_rod` |  |
+| `links` | `_li` |  |
+| `barleycorns` | `_bc` |  |
+| `nails` | `_nail` |  |
+| `spans` | `_span` |  |
+| `picas` | `_pica` |  |
+| `points` | `_pnt` |  |
 
 ### luminance
 
@@ -261,6 +286,13 @@ For units shared across dimensions (e.g. `pounds` of mass vs. force), qualify wi
 | `ounces` | `_oz` |  |
 | `carats` | `_ct` |  |
 | `slugs` | `_slug` |  |
+| `grains` | `_gr` |  |
+| `avoirdupois_drams` | `_dr_av` |  |
+| `pennyweights` | `_dwt` |  |
+| `troy_ounces` | `_ozt` |  |
+| `troy_pounds` | `_lbt` |  |
+| `hundredweights` | `_cwt` |  |
+| `short_hundredweights` | `_sh_cwt` |  |
 
 ### power
 
@@ -268,6 +300,9 @@ For units shared across dimensions (e.g. `pounds` of mass vs. force), qualify wi
 |------|---------|----------|
 | `watts` | `_W` | yes |
 | `horsepower` | `_hp` |  |
+| `metric_horsepower` | `_hpM` |  |
+| `electrical_horsepower` | `_hpE` |  |
+| `tons_of_refrigeration` | `_TR` |  |
 
 ### pressure
 
@@ -281,6 +316,14 @@ For units shared across dimensions (e.g. `pounds` of mass vs. force), qualify wi
 | `torrs` | `_torr` |  |
 | `millimeters_of_mercury` | `_mmHg` |  |
 | `inches_of_mercury` | `_inHg` |  |
+| `technical_atmospheres` | `_at` |  |
+| `pounds_per_square_foot` | `_psf` |  |
+| `kips_per_square_inch` | `_ksi` |  |
+| `baryes` | `_Ba` |  |
+| `piezes` | `_pz` |  |
+| `centimeters_of_water` | `_cmH2O` |  |
+| `millimeters_of_water` | `_mmH2O` |  |
+| `inches_of_water` | `_inH2O` |  |
 
 ### radiance
 
@@ -304,6 +347,7 @@ For units shared across dimensions (e.g. `pounds` of mass vs. force), qualify wi
 | `curies` | `_Ci` |  |
 | `rutherfords` | `_rd` |  |
 | `radiation_absorbed_dose` | `_rads` |  |
+| `roentgens_equivalent_man` | `_rem` |  |
 
 ### solid angle
 
@@ -342,6 +386,7 @@ For units shared across dimensions (e.g. `pounds` of mass vs. force), qualify wi
 | Unit | Literal | Prefixes |
 |------|---------|----------|
 | `mols` | `_mol` | yes |
+| `pound_moles` | `_lbmol` |  |
 
 ### substance concentration
 
@@ -377,6 +422,10 @@ For units shared across dimensions (e.g. `pounds` of mass vs. force), qualify wi
 | `years` | `_yr` |  |
 | `julian_years` | `_a_j` |  |
 | `gregorian_years` | `_a_g` |  |
+| `fortnights` | `_fn` |  |
+| `decades` | `_dec` |  |
+| `centuries` | `_cent` |  |
+| `millennia` | `_kyr` |  |
 
 ### torque
 
@@ -397,6 +446,10 @@ For units shared across dimensions (e.g. `pounds` of mass vs. force), qualify wi
 | `miles_per_hour` | `_mph` |  |
 | `kilometers_per_hour` | `_kph` |  |
 | `knots` | `_kts` |  |
+| `feet_per_minute` | `_fpm` |  |
+| `meters_per_minute` | `_mpm` |  |
+| `inches_per_second` | `_ips` |  |
+| `kilometers_per_second` | `_kmps` |  |
 
 ### voltage
 

--- a/include/units/angle.h
+++ b/include/units/angle.h
@@ -66,6 +66,9 @@ namespace units
 	UNIT_ADD(angle, turns, tr, conversion_factor<std::ratio<2>, radians<>, std::ratio<1>>)
 	UNIT_ADD(angle, gradians, gon, conversion_factor<std::ratio<1, 400>, turns<>>)
 
+	UNIT_ADD(angle, angular_mils, amil, conversion_factor<std::ratio<1, 6400>, turns<>>)
+	UNIT_ADD(angle, compass_points, cpt, conversion_factor<std::ratio<1, 32>, turns<>>)
+
 	UNIT_ADD_DIMENSION_TRAIT(angle)
 
 	//----------------------------------

--- a/include/units/area.h
+++ b/include/units/area.h
@@ -66,6 +66,9 @@ namespace units
 	UNIT_ADD(area, hectares, ha, conversion_factor<std::ratio<10000>, square_meters_>)
 	UNIT_ADD(area, acres, acre, conversion_factor<std::ratio<43560>, square_feet_>)
 
+	UNIT_ADD(area, roods, rood, conversion_factor<std::ratio<1, 4>, acres<>>)
+	UNIT_ADD(area, square_rods, rd2, squared<rods_>)
+
 	UNIT_ADD_DIMENSION_TRAIT(area)
 } // namespace units
 

--- a/include/units/charge.h
+++ b/include/units/charge.h
@@ -62,6 +62,9 @@ namespace units
 	UNIT_ADD_WITH_METRIC_PREFIXES(charge, coulombs, C, conversion_factor<std::ratio<1>, dimension::charge>)
 	UNIT_ADD_WITH_METRIC_PREFIXES(charge, ampere_hours, Ah, compound_conversion_factor<amperes_, hours_>)
 
+	UNIT_ADD(charge, abcoulombs, abC, conversion_factor<std::ratio<10>, coulombs_>)
+	UNIT_ADD(charge, statcoulombs, statC, conversion_factor<std::ratio<1, 2997924580LL>, coulombs_>)
+
 	UNIT_ADD_DIMENSION_TRAIT(charge)
 } // namespace units
 

--- a/include/units/current.h
+++ b/include/units/current.h
@@ -60,6 +60,9 @@ namespace units
 	 */
 	UNIT_ADD_WITH_METRIC_PREFIXES(current, amperes, A, conversion_factor<std::ratio<1>, dimension::current>)
 
+	UNIT_ADD(current, abamperes, abA, conversion_factor<std::ratio<10>, amperes_>)
+	UNIT_ADD(current, statamperes, statA, conversion_factor<std::ratio<1, 2997924580LL>, amperes_>)
+
 	UNIT_ADD_DIMENSION_TRAIT(current)
 } // namespace units
 

--- a/include/units/data.h
+++ b/include/units/data.h
@@ -63,6 +63,8 @@ namespace units
 	UNIT_ADD_WITH_METRIC_AND_BINARY_PREFIXES(data, bits, b, conversion_factor<std::ratio<1, 8>, bytes_>)
 	UNIT_ADD(data, exabits, Eb, conversion_factor<std::ratio<1000>, petabits_>)
 
+	UNIT_ADD(data, nibbles, nibble, conversion_factor<std::ratio<4>, bits_>)
+
 	UNIT_ADD_DIMENSION_TRAIT(data)
 } // namespace units
 

--- a/include/units/energy.h
+++ b/include/units/energy.h
@@ -68,6 +68,10 @@ namespace units
 	UNIT_ADD(energy, therms, thm, conversion_factor<std::ratio<100000>, british_thermal_units_59_>)
 	UNIT_ADD(energy, foot_pounds, ftlbf, conversion_factor<std::ratio<13558179483314004, 10000000000000000>, joules_>)
 
+	UNIT_ADD(energy, ergs, erg, conversion_factor<std::ratio<1, 10000000>, joules_>)
+	UNIT_ADD(energy, calories_it, cal_it, conversion_factor<std::ratio<41868, 10000>, joules_>)
+	UNIT_ADD(energy, tons_of_tnt, tTNT, conversion_factor<std::ratio<4184000000LL>, joules_>)
+
 	UNIT_ADD_DIMENSION_TRAIT(energy)
 } // namespace units
 

--- a/include/units/force.h
+++ b/include/units/force.h
@@ -67,6 +67,13 @@ namespace units
 	UNIT_ADD(force, kiloponds, kp, compound_conversion_factor<standard_gravity_, kilograms_>)
 	UNIT_ADD(force, poundals, pdl, compound_conversion_factor<mass::pounds_, feet_, inverse<squared<seconds_>>>)
 
+	UNIT_ADD(force, kips, kip, conversion_factor<std::ratio<1000>, force::pounds_>)
+	UNIT_ADD(force, ounces_force, ozf, conversion_factor<std::ratio<1, 16>, force::pounds_>)
+	UNIT_ADD(force, grams_force, gf, compound_conversion_factor<acceleration::standard_gravity_, grams_>)
+	UNIT_ADD(force, short_tons_force, tonf, conversion_factor<std::ratio<2000>, force::pounds_>)
+	UNIT_ADD(force, long_tons_force, ltonf, conversion_factor<std::ratio<2240>, force::pounds_>)
+	UNIT_ADD(force, sthenes, sn, conversion_factor<std::ratio<1000>, newtons_>)
+
 	UNIT_ADD_DIMENSION_TRAIT(force)
 } // namespace units
 

--- a/include/units/length.h
+++ b/include/units/length.h
@@ -81,6 +81,14 @@ namespace units
 	template<class Underlying>
 	using metres = meters<Underlying>;
 
+	UNIT_ADD(length, rods, rod, conversion_factor<std::ratio<1, 4>, chains<>>)
+	UNIT_ADD(length, links, li, conversion_factor<std::ratio<1, 100>, chains<>>)
+	UNIT_ADD(length, barleycorns, bc, conversion_factor<std::ratio<1, 3>, inches<>>)
+	UNIT_ADD(length, nails, nail, conversion_factor<std::ratio<1, 16>, yards<>>)
+	UNIT_ADD(length, spans, span, conversion_factor<std::ratio<9>, inches<>>)
+	UNIT_ADD(length, picas, pica, conversion_factor<std::ratio<1, 6>, inches<>>)
+	UNIT_ADD(length, points, pnt, conversion_factor<std::ratio<1, 72>, inches<>>)
+
 	UNIT_ADD_DIMENSION_TRAIT(length)
 } // namespace units
 

--- a/include/units/mass.h
+++ b/include/units/mass.h
@@ -68,6 +68,14 @@ namespace units
 	UNIT_ADD(mass, carats, ct, conversion_factor<std::ratio<200>, milligrams_>)
 	UNIT_ADD(mass, slugs, slug, conversion_factor<std::ratio<145939029, 10000000>, kilograms_>)
 
+	UNIT_ADD(mass, grains, gr, conversion_factor<std::ratio<1, 7000>, pounds_>)
+	UNIT_ADD(mass, avoirdupois_drams, dr_av, conversion_factor<std::ratio<1, 16>, ounces_>)
+	UNIT_ADD(mass, pennyweights, dwt, conversion_factor<std::ratio<24>, grains_>)
+	UNIT_ADD(mass, troy_ounces, ozt, conversion_factor<std::ratio<480>, grains_>)
+	UNIT_ADD(mass, troy_pounds, lbt, conversion_factor<std::ratio<12>, troy_ounces_>)
+	UNIT_ADD(mass, hundredweights, cwt, conversion_factor<std::ratio<112>, pounds_>)
+	UNIT_ADD(mass, short_hundredweights, sh_cwt, conversion_factor<std::ratio<100>, pounds_>)
+
 	UNIT_ADD_DIMENSION_TRAIT(mass)
 } // namespace units
 

--- a/include/units/power.h
+++ b/include/units/power.h
@@ -63,6 +63,10 @@ namespace units
 	UNIT_ADD_DECIBEL(power, watts, dBW)
 	UNIT_ADD_DECIBEL(power, milliwatts, dBm)
 
+	UNIT_ADD(power, metric_horsepower, hpM, conversion_factor<std::ratio<588399, 800>, watts_>)
+	UNIT_ADD(power, electrical_horsepower, hpE, conversion_factor<std::ratio<746>, watts_>)
+	UNIT_ADD(power, tons_of_refrigeration, TR, conversion_factor<std::ratio<52752792631LL, 15000000LL>, watts_>)
+
 	UNIT_ADD_DIMENSION_TRAIT(power)
 } // namespace units
 

--- a/include/units/pressure.h
+++ b/include/units/pressure.h
@@ -78,6 +78,15 @@ namespace units
 	UNIT_ADD(pressure, millimeters_of_mercury, mmHg, conversion_factor<std::ratio<26664477483LL, 200000000LL>, pascals_>)
 	UNIT_ADD(pressure, inches_of_mercury, inHg, conversion_factor<std::ratio<254, 10>, millimeters_of_mercury_>)
 
+	UNIT_ADD(pressure, technical_atmospheres, at, conversion_factor<std::ratio<1961330, 20>, pascals_>)
+	UNIT_ADD(pressure, pounds_per_square_foot, psf, compound_conversion_factor<force::pounds_, inverse<squared<feet_>>>)
+	UNIT_ADD(pressure, kips_per_square_inch, ksi, conversion_factor<std::ratio<1000>, pounds_per_square_inch_>)
+	UNIT_ADD(pressure, baryes, Ba, conversion_factor<std::ratio<1, 10>, pascals_>)
+	UNIT_ADD(pressure, piezes, pz, conversion_factor<std::ratio<1000>, pascals_>)
+	UNIT_ADD(pressure, centimeters_of_water, cmH2O, conversion_factor<std::ratio<1961330, 20000>, pascals_>)
+	UNIT_ADD(pressure, millimeters_of_water, mmH2O, conversion_factor<std::ratio<1, 10>, centimeters_of_water_>)
+	UNIT_ADD(pressure, inches_of_water, inH2O, conversion_factor<std::ratio<254, 100>, centimeters_of_water_>)
+
 	UNIT_ADD_DIMENSION_TRAIT(pressure)
 } // namespace units
 

--- a/include/units/radiation.h
+++ b/include/units/radiation.h
@@ -69,6 +69,8 @@ namespace units
 	UNIT_ADD(radiation, rutherfords, rd, conversion_factor<std::ratio<1>, megabecquerels<>>)
 	UNIT_ADD(radiation, radiation_absorbed_dose, rads, conversion_factor<std::ratio<1>, centigrays<>>)
 
+	UNIT_ADD(radiation, roentgens_equivalent_man, rem, conversion_factor<std::ratio<1>, centisieverts<>>)
+
 	UNIT_ADD_DIMENSION_TRAIT(radioactivity)
 } // namespace units
 

--- a/include/units/substance.h
+++ b/include/units/substance.h
@@ -60,6 +60,8 @@ namespace units
 	 */
 	UNIT_ADD_WITH_METRIC_PREFIXES(substance, mols, mol, conversion_factor<std::ratio<1>, dimension::substance>)
 
+	UNIT_ADD(substance, pound_moles, lbmol, conversion_factor<std::ratio<45359237, 100000>, mols_>)
+
 	UNIT_ADD_DIMENSION_TRAIT(substance)
 } // namespace units
 

--- a/include/units/time.h
+++ b/include/units/time.h
@@ -83,6 +83,11 @@ namespace units
 	UNIT_ADD(time, julian_years, a_j, conversion_factor<std::ratio<31557600>, seconds_>)
 	UNIT_ADD(time, gregorian_years, a_g, conversion_factor<std::ratio<31556952>, seconds_>)
 
+	UNIT_ADD(time, fortnights, fn, conversion_factor<std::ratio<14>, days_>)
+	UNIT_ADD(time, decades, dec, conversion_factor<std::ratio<10>, julian_years<>>)
+	UNIT_ADD(time, centuries, cent, conversion_factor<std::ratio<100>, julian_years<>>)
+	UNIT_ADD(time, millennia, kyr, conversion_factor<std::ratio<1000>, julian_years<>>)
+
 	UNIT_ADD_DIMENSION_TRAIT(time)
 } // namespace units
 

--- a/include/units/velocity.h
+++ b/include/units/velocity.h
@@ -65,6 +65,11 @@ namespace units
 	UNIT_ADD(velocity, kilometers_per_hour, kph, compound_conversion_factor<kilometers<>, inverse<hours<>>>)
 	UNIT_ADD(velocity, knots, kts, compound_conversion_factor<nautical_miles<>, inverse<hours<>>>)
 
+	UNIT_ADD(velocity, feet_per_minute, fpm, compound_conversion_factor<feet_, inverse<minutes_>>)
+	UNIT_ADD(velocity, meters_per_minute, mpm, compound_conversion_factor<meters<>, inverse<minutes_>>)
+	UNIT_ADD(velocity, inches_per_second, ips, compound_conversion_factor<inches<>, inverse<seconds_>>)
+	UNIT_ADD(velocity, kilometers_per_second, kmps, compound_conversion_factor<kilometers<>, inverse<seconds_>>)
+
 	UNIT_ADD_DIMENSION_TRAIT(velocity)
 } // namespace units
 

--- a/include/units/voltage.h
+++ b/include/units/voltage.h
@@ -59,7 +59,7 @@ namespace units
 	 * @sa			See unit for more information on unit type containers.
 	 */
 	UNIT_ADD_WITH_METRIC_PREFIXES(voltage, volts, V, conversion_factor<std::ratio<1>, dimension::voltage>)
-	UNIT_ADD(voltage, statvolts, statV, conversion_factor<std::ratio<1000000, 299792458>, volts_>)
+	UNIT_ADD(voltage, statvolts, statV, conversion_factor<std::ratio<299792458, 1000000>, volts_>)
 	UNIT_ADD(voltage, abvolts, abV, conversion_factor<std::ratio<1, 100000000>, volts_>)
 
 	UNIT_ADD_DIMENSION_TRAIT(voltage)

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -4636,6 +4636,74 @@ TEST_F(ConversionFactor, squaredTemperature)
 	EXPECT_EQ(celsius<double>(10), rootRight);
 }
 
+TEST_F(ConversionFactor, unitsAddedIn3_4_2)
+{
+	// Each new unit is checked against the exact ratio to its canonical parent.
+	// length
+	EXPECT_DOUBLE_EQ(4.0, rods<double>(chains<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(100.0, links<double>(chains<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(1.0, inches<double>(barleycorns<double>(3.0)).value());
+	EXPECT_DOUBLE_EQ(1.0, yards<double>(nails<double>(16.0)).value());
+	EXPECT_DOUBLE_EQ(9.0, inches<double>(spans<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(1.0, inches<double>(picas<double>(6.0)).value());
+	EXPECT_DOUBLE_EQ(1.0, inches<double>(points<double>(72.0)).value());
+	// velocity
+	EXPECT_DOUBLE_EQ(1.0, feet_per_second<double>(feet_per_minute<double>(60.0)).value());
+	EXPECT_DOUBLE_EQ(1000.0, meters_per_second<double>(kilometers_per_second<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(0.0254, meters_per_second<double>(inches_per_second<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(1.0, feet_per_second<double>(meters_per_minute<double>(18.288)).value());
+	// area
+	EXPECT_DOUBLE_EQ(1.0, acres<double>(roods<double>(4.0)).value());
+	EXPECT_DOUBLE_EQ(1.0, acres<double>(square_rods<double>(160.0)).value());
+	// angle
+	EXPECT_DOUBLE_EQ(1.0, turns<double>(angular_mils<double>(6400.0)).value());
+	EXPECT_DOUBLE_EQ(1.0, turns<double>(compass_points<double>(32.0)).value());
+	// time
+	EXPECT_DOUBLE_EQ(14.0, days<double>(fortnights<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(10.0, julian_years<double>(decades<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(100.0, julian_years<double>(centuries<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(1000.0, julian_years<double>(millennia<double>(1.0)).value());
+	// data
+	EXPECT_DOUBLE_EQ(1.0, bytes<double>(nibbles<double>(2.0)).value());
+	// radiation
+	EXPECT_DOUBLE_EQ(0.01, sieverts<double>(roentgens_equivalent_man<double>(1.0)).value());
+	// substance
+	EXPECT_DOUBLE_EQ(453.59237, mols<double>(pound_moles<double>(1.0)).value());
+	// mass
+	EXPECT_DOUBLE_EQ(1.0, mass::pounds<double>(grains<double>(7000.0)).value());
+	EXPECT_DOUBLE_EQ(1.0, mass::ounces<double>(avoirdupois_drams<double>(16.0)).value());
+	EXPECT_DOUBLE_EQ(480.0, grains<double>(troy_ounces<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(12.0, troy_ounces<double>(troy_pounds<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(24.0, grains<double>(pennyweights<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(112.0, mass::pounds<double>(hundredweights<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(100.0, mass::pounds<double>(short_hundredweights<double>(1.0)).value());
+	// force
+	EXPECT_DOUBLE_EQ(1000.0, force::pounds<double>(kips<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(1.0, force::pounds<double>(ounces_force<double>(16.0)).value());
+	EXPECT_DOUBLE_EQ(0.00980665, newtons<double>(grams_force<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(2000.0, force::pounds<double>(short_tons_force<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(2240.0, force::pounds<double>(long_tons_force<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(1000.0, newtons<double>(sthenes<double>(1.0)).value());
+	// pressure
+	EXPECT_DOUBLE_EQ(98066.5, pascals<double>(technical_atmospheres<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(1000.0, pounds_per_square_inch<double>(kips_per_square_inch<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(0.1, pascals<double>(baryes<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(1000.0, pascals<double>(piezes<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(98.0665, pascals<double>(centimeters_of_water<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(9.80665, pascals<double>(millimeters_of_water<double>(1.0)).value());
+	EXPECT_NEAR(1.0, pounds_per_square_inch<double>(pounds_per_square_foot<double>(144.0)).value(), 1e-9);
+	// energy
+	EXPECT_DOUBLE_EQ(1.0e-7, joules<double>(ergs<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(4.1868, joules<double>(calories_it<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(4.184e9, joules<double>(tons_of_tnt<double>(1.0)).value());
+	// power
+	EXPECT_DOUBLE_EQ(735.49875, watts<double>(metric_horsepower<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(746.0, watts<double>(electrical_horsepower<double>(1.0)).value());
+	// charge / current
+	EXPECT_DOUBLE_EQ(10.0, coulombs<double>(abcoulombs<double>(1.0)).value());
+	EXPECT_DOUBLE_EQ(10.0, amperes<double>(abamperes<double>(1.0)).value());
+}
+
 TEST_F(UnitMath, min)
 {
 	meters a_m(1.0);

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -3928,10 +3928,11 @@ TEST_F(ConversionFactor, voltage)
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 	test = volts<double>(gigavolts<double>(0.000000001)).value();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = volts<double>(statvolts<double>(299.792458)).value();
-	EXPECT_NEAR(1.0, test, 5.0e-5);
-	test = statvolts<double>(millivolts<double>(1000.0)).value();
+	// 1 statvolt == c/1e6 volts == 299.792458 V (was defined inverted before 3.4.2).
+	test = volts<double>(statvolts<double>(1.0)).value();
 	EXPECT_NEAR(299.792458, test, 5.0e-5);
+	test = statvolts<double>(volts<double>(299.792458)).value();
+	EXPECT_NEAR(1.0, test, 5.0e-5);
 	test = nanovolts<double>(abvolts<double>(0.1)).value();
 	EXPECT_NEAR(1.0, test, 5.0e-5);
 	test = abvolts<double>(microvolts<double>(0.01)).value();


### PR DESCRIPTION
The single v3.4.2 PR — everything for the cut rides here. Closes #354. (Folds in the former #362.)

## Units added (~50)
Each is defined by an **exact rational against its most-canonical parent** and verified against its **authoritative value** (NIST SP 811, BIPM SI brochure, the international yard-and-pound agreement, IEC 80000-13, the defining standards). A new test `ConversionFactor.unitsAddedIn3_4_2` asserts every conversion; full suite is green (239 tests + 8 example targets).

- **length**: rods, links, barleycorns, nails, spans, picas, points (completes the surveyor's-chain family: 1 chain = 4 rods = 100 links; 1 furlong = 220 yards)
- **velocity**: feet_per_minute, meters_per_minute, inches_per_second, kilometers_per_second
- **area**: roods, square_rods (1 acre = 4 roods = 160 square_rods)
- **angle**: angular_mils (NATO, 6400/turn), compass_points (32/turn)
- **time**: fortnights, decades, centuries, millennia (chained to julian_years, drift-free)
- **data**: nibbles - **radiation**: rem - **substance**: pound_moles
- **mass**: grains, avoirdupois_drams, pennyweights, troy_ounces, troy_pounds, hundredweights, short_hundredweights
- **force**: kips, ounces_force, grams_force, short_tons_force, long_tons_force, sthenes
- **pressure**: technical_atmospheres, pounds_per_square_foot, kips_per_square_inch, baryes, piezes, centimeters/millimeters/inches_of_water
- **energy**: ergs, calories_it, tons_of_tnt - **power**: metric_horsepower, electrical_horsepower, tons_of_refrigeration - **charge/current**: ab-/stat- pairs

Abbreviations that would collide with an existing unit constant use a distinct suffix (`avoirdupois_drams` after `volume::drams`; `amil`, `pnt`, `rod`, `dr_av`).

## Fix
- **statvolt conversion was inverted** - read `0.00333564 V` instead of `299.792458 V`. Corrected to `c / 1e6` volts; the test that had enshrined the inverted value is corrected. `abvolts` was already correct.

## Docs
- README Features reframed around the honest differentiator: **every unit is a first-class type** (no unit system / quantity-kind / dimension layer to instantiate, no maker step), written with literals or unit constants; batteries-included catalog; dimensional checking and readable diagnostics as headlines. No comparison to any other library.
- **Spelling a quantity type** - `meters` vs `meters<>` vs `meters<T>` (where each is valid), and **`auto` vs. an explicit type** (auto when the RHS states the unit; explicit both sides to make the compiler confirm the dimensional analysis). Also lands the matching edit to `docs/explain/ctad-and-adl-for-humans.md`. (This is the former #362.)
- CHANGELOG entries for **3.4.2** and **3.4.1**; `debian/changelog` bumped to `3.4.2-0ppa1~noble1` for the PPA.

## Not changed (reported, not touched)
- `power::horsepower` (745.7 vs exact 745.6998716) and `mass::slugs` (~3.7e-8, #289) are slightly rounded; left as-is - changing shipped ratios needs its own review.
- No claim of integer/overflow safety, affine points, or cross-library interop - capabilities this library does not provide.