### PR TITLE
Issue-triage fixes: slug precision, named to<>(), volume flow rate, decibel literal + integer-decibel guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,9 +492,31 @@ For a name shared across dimensions (e.g. `pounds`), qualify it: `units::mass::p
 | Unit | Literal | Prefixes |
 |------|---------|----------|
 | `bytes` | `_B` |  |
+| `kilobytes` | `_kB` |  |
+| `megabytes` | `_MB` |  |
+| `gigabytes` | `_GB` |  |
+| `terabytes` | `_TB` |  |
+| `petabytes` | `_PB` |  |
 | `exabytes` | `_EB` |  |
+| `kibibytes` | `_KiB` |  |
+| `mebibytes` | `_MiB` |  |
+| `gibibytes` | `_GiB` |  |
+| `tebibytes` | `_TiB` |  |
+| `pebibytes` | `_PiB` |  |
+| `exbibytes` | `_EiB` |  |
 | `bits` | `_b` |  |
+| `kilobits` | `_kb` |  |
+| `megabits` | `_Mb` |  |
+| `gigabits` | `_Gb` |  |
+| `terabits` | `_Tb` |  |
+| `petabits` | `_Pb` |  |
 | `exabits` | `_Eb` |  |
+| `kibibits` | `_Kib` |  |
+| `mebibits` | `_Mib` |  |
+| `gibibits` | `_Gib` |  |
+| `tebibits` | `_Tib` |  |
+| `pebibits` | `_Pib` |  |
+| `exbibits` | `_Eib` |  |
 | `nibbles` | `_nibble` |  |
 
 ### data transfer rate

--- a/README.md
+++ b/README.md
@@ -888,6 +888,19 @@ For a name shared across dimensions (e.g. `pounds`), qualify it: `units::mass::p
 | `sacks` | `_sck` |  |
 | `shots` | `_shts` |  |
 | `strikes` | `_strk` |  |
+
+### volume flow rate
+
+| Unit | Literal | Prefixes |
+|------|---------|----------|
+| `cubic_meters_per_second` | `_m3_per_s` |  |
+| `cubic_meters_per_hour` | `_m3_per_hr` |  |
+| `liters_per_second` | `_L_per_s` |  |
+| `liters_per_minute` | `_L_per_min` |  |
+| `gallons_per_minute` | `_gpm` |  |
+| `gallons_per_hour` | `_gph` |  |
+| `cubic_feet_per_second` | `_cfs` |  |
+| `cubic_feet_per_minute` | `_cfm` |  |
 <!-- END generated: supported-units -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ stays small and the code stays legible.
 
 - **Syntax.** Quantities are written as `meters`, `60_mi / 1_hr`, `sqrt(area)`; operations are performed
   on the quantity types.
-- **Batteries included.** Over 250 units across 47 dimensions ship ready to use — SI, imperial and
+- **Batteries included.** Over 280 units across 48 dimensions ship ready to use — SI, imperial and
   US-customary, ancient, and esoteric alike (`3.0_cwt`, `10.0_fur`, `1.0_rem`), each a named type with a
   literal and an exact, canonically-sourced conversion ratio. There is no unit "system" to select or
   instantiate: every unit is first class and used directly, and units from different systems combine in
@@ -80,6 +80,10 @@ stays small and the code stays legible.
   compiles to no machine code. A quantity is a trivially-copyable value the size of its underlying type.
 - **Dimensional checking.** Adding a length to a time, or assigning an area to a length, is a compile
   error. The dimensional analysis is performed by the type system.
+- **Decibel and logarithmic scales.** A unit's scale is part of its type. Alongside the default linear
+  scale, `decibel_scale` provides `dBW`, `dBm`, and the dimensionless `dB`, with scale-correct
+  arithmetic — adding decibels multiplies the underlying linear quantities. A decibel-scale unit requires
+  a floating-point underlying type.
 - **Diagnostics.** A dimensional error names the unit type (`meters<double>`) rather than the
   `conversion_factor<...>` template. See [Type errors](#type-errors).
 - **Trivial integration.** Header-only, no dependencies, one `#include`. Drop in the headers, or consume
@@ -116,7 +120,7 @@ using namespace units;
 using namespace units::literals;   // the _m, _s, _kg, ... literals
 ```
 
-> **Note — if compiles are slow, include less.** `<units.h>` pulls in all 47 dimensions. The library is
+> **Note — if compiles are slow, include less.** `<units.h>` pulls in all 48 dimensions. The library is
 > heavily templated, so a translation unit's compile time scales with how much it instantiates; including
 > only the per-dimension headers you use keeps it down. Include the dimension of every quantity you
 > *name*, including result dimensions (dividing a length by a time needs `<units/velocity.h>`). Run-time
@@ -396,7 +400,7 @@ auto bridge = 364.4_smoot;          // now a usable length, with its own literal
 
 ## Supported units
 
-Every built-in unit, by dimension — **47 dimensions**, ~200 named units before metric prefixes. A unit
+Every built-in unit, by dimension — **48 dimensions**, ~200 named units before metric prefixes. A unit
 marked **yes** under Prefixes also provides every SI metric prefix from femto to peta (`_km`, `_mm`, …).
 For a name shared across dimensions (e.g. `pounds`), qualify it: `units::mass::pounds` vs
 `units::force::pounds`. This table is generated from the headers by `docs/reference/gen_reference.py`.

--- a/docs/reference/supported-units.md
+++ b/docs/reference/supported-units.md
@@ -1,6 +1,6 @@
 # Supported units
 
-*The catalog of built-in units, grouped by dimension — **48 dimensions**, **260 named units** (before metric prefixes). Generated from the headers by `docs/reference/gen_reference.py`; do not edit by hand.*
+*The catalog of built-in units, grouped by dimension — **48 dimensions**, **282 named units** (before metric prefixes). Generated from the headers by `docs/reference/gen_reference.py`; do not edit by hand.*
 
 Each unit is available as a type (`meters`, `meters<double>`) and, where shown, a literal (`5.0_m`). Units marked **yes** under Prefixes also provide every SI metric prefix from femto to peta (e.g. `kilometers`/`_km`, `millimeters`/`_mm`). Include the umbrella header `<units.h>` for all of them, or a single `<units/DIMENSION.h>` for one dimension.
 
@@ -96,9 +96,31 @@ For units shared across dimensions (e.g. `pounds` of mass vs. force), qualify wi
 | Unit | Literal | Prefixes |
 |------|---------|----------|
 | `bytes` | `_B` |  |
+| `kilobytes` | `_kB` |  |
+| `megabytes` | `_MB` |  |
+| `gigabytes` | `_GB` |  |
+| `terabytes` | `_TB` |  |
+| `petabytes` | `_PB` |  |
 | `exabytes` | `_EB` |  |
+| `kibibytes` | `_KiB` |  |
+| `mebibytes` | `_MiB` |  |
+| `gibibytes` | `_GiB` |  |
+| `tebibytes` | `_TiB` |  |
+| `pebibytes` | `_PiB` |  |
+| `exbibytes` | `_EiB` |  |
 | `bits` | `_b` |  |
+| `kilobits` | `_kb` |  |
+| `megabits` | `_Mb` |  |
+| `gigabits` | `_Gb` |  |
+| `terabits` | `_Tb` |  |
+| `petabits` | `_Pb` |  |
 | `exabits` | `_Eb` |  |
+| `kibibits` | `_Kib` |  |
+| `mebibits` | `_Mib` |  |
+| `gibibits` | `_Gib` |  |
+| `tebibits` | `_Tib` |  |
+| `pebibits` | `_Pib` |  |
+| `exbibits` | `_Eib` |  |
 | `nibbles` | `_nibble` |  |
 
 ### data transfer rate

--- a/docs/reference/supported-units.md
+++ b/docs/reference/supported-units.md
@@ -1,6 +1,6 @@
 # Supported units
 
-*The catalog of built-in units, grouped by dimension — **47 dimensions**, **252 named units** (before metric prefixes). Generated from the headers by `docs/reference/gen_reference.py`; do not edit by hand.*
+*The catalog of built-in units, grouped by dimension — **48 dimensions**, **260 named units** (before metric prefixes). Generated from the headers by `docs/reference/gen_reference.py`; do not edit by hand.*
 
 Each unit is available as a type (`meters`, `meters<double>`) and, where shown, a literal (`5.0_m`). Units marked **yes** under Prefixes also provide every SI metric prefix from femto to peta (e.g. `kilometers`/`_km`, `millimeters`/`_mm`). Include the umbrella header `<units.h>` for all of them, or a single `<units/DIMENSION.h>` for one dimension.
 
@@ -492,3 +492,16 @@ For units shared across dimensions (e.g. `pounds` of mass vs. force), qualify wi
 | `sacks` | `_sck` |  |
 | `shots` | `_shts` |  |
 | `strikes` | `_strk` |  |
+
+### volume flow rate
+
+| Unit | Literal | Prefixes |
+|------|---------|----------|
+| `cubic_meters_per_second` | `_m3_per_s` |  |
+| `cubic_meters_per_hour` | `_m3_per_hr` |  |
+| `liters_per_second` | `_L_per_s` |  |
+| `liters_per_minute` | `_L_per_min` |  |
+| `gallons_per_minute` | `_gpm` |  |
+| `gallons_per_hour` | `_gph` |  |
+| `cubic_feet_per_second` | `_cfs` |  |
+| `cubic_feet_per_minute` | `_cfm` |  |

--- a/include/units.h
+++ b/include/units.h
@@ -95,6 +95,7 @@
 #include <units/velocity.h>
 #include <units/voltage.h>
 #include <units/volume.h>
+#include <units/volume_flow_rate.h>
 
 namespace units
 {

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -2434,12 +2434,6 @@ namespace units
 	template<ConversionFactorType ConversionFactor, ArithmeticType T = UNIT_LIB_DEFAULT_TYPE, NumericalScaleType<T> NumericalScale = linear_scale>
 	class MSVC_EBO unit : public ConversionFactor, public NumericalScale, public detail::_unit
 	{
-		// A decibel-scale unit stores its value through a base-10 logarithm, so an integral underlying type
-		// cannot represent it: most decibel figures round to a wrong integer (3 dB stores as 0) and large
-		// ones overflow. Require a floating-point underlying type for a decibel scale.
-		static_assert(!std::is_same_v<NumericalScale, decibel_scale> || std::is_floating_point_v<T>,
-			"a decibel-scale unit requires a floating-point underlying type (an integral type cannot represent a logarithmic value)");
-
 	public:
 		using numerical_scale_type = NumericalScale;   ///< Type of the numerical scale of the unit (e.g. linear_scale)
 		using underlying_type      = T;                ///< Type of the underlying storage of the unit (e.g. double)
@@ -4374,6 +4368,12 @@ namespace units
 		template<class T>
 		static T linearize(const T value) noexcept
 		{
+			// A decibel value is stored through a base-10 logarithm, so an integral underlying type cannot
+			// represent it: most decibel figures round to a wrong integer (3 dB stores as 0) and large ones
+			// overflow. Asserted here, at the point a value is actually stored, so merely naming a
+			// decibel-scale type for trait/overload resolution does not trip it.
+			static_assert(std::is_floating_point_v<T>,
+				"a decibel-scale unit requires a floating-point underlying type (an integral type cannot represent a logarithmic value)");
 			return static_cast<T>(std::pow(10, value / 10));
 		}
 

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -335,6 +335,25 @@ namespace units
 	}
 #endif
 
+/**
+ * @def			UNIT_ADD_DECIBEL_LITERALS(namespaceName, namePlural, abbreviation)
+ * @brief		Like UNIT_ADD_LITERALS but emits only the floating-point literal.
+ * @details		A decibel-scale unit requires a floating-point underlying type, so no integer literal
+ *				(which would form a `<int>` unit) is generated.
+ */
+#ifdef UNIT_NO_LITERAL_SUPPORT
+#define UNIT_ADD_DECIBEL_LITERALS(namespaceName, namePlural, abbreviation)
+#else
+#define UNIT_ADD_DECIBEL_LITERALS(namespaceName, namePlural, abbreviation)                                                                                                                             \
+	namespace literals                                                                                                                                                                                 \
+	{                                                                                                                                                                                                  \
+		constexpr namespaceName::namePlural<double> operator""_##abbreviation(long double d) noexcept                                                                                                  \
+		{                                                                                                                                                                                              \
+			return namespaceName::namePlural<double>(static_cast<double>(d));                                                                                                                          \
+		}                                                                                                                                                                                              \
+	}
+#endif
+
 #define UNIT_ADD_CONSTANT(namespaceName, namePlural, abbreviation) static constexpr namespaceName::namePlural abbreviation{1.0};
 
 /**
@@ -380,7 +399,7 @@ namespace units
 	}                                                                                                                                                                                                  \
 	UNIT_ADD_NAME(namespaceName, abbreviation, abbreviation)                                                                                                                                           \
 	UNIT_REGISTER_NAMED_CLASS(namespaceName, abbreviation)                                                                                                                                             \
-	UNIT_ADD_LITERALS(namespaceName, abbreviation, abbreviation)
+	UNIT_ADD_DECIBEL_LITERALS(namespaceName, abbreviation, abbreviation)
 
 /**
  * @def			UNIT_ADD_DIMENSION_TRAIT(unitdimension)
@@ -2415,6 +2434,12 @@ namespace units
 	template<ConversionFactorType ConversionFactor, ArithmeticType T = UNIT_LIB_DEFAULT_TYPE, NumericalScaleType<T> NumericalScale = linear_scale>
 	class MSVC_EBO unit : public ConversionFactor, public NumericalScale, public detail::_unit
 	{
+		// A decibel-scale unit stores its value through a base-10 logarithm, so an integral underlying type
+		// cannot represent it: most decibel figures round to a wrong integer (3 dB stores as 0) and large
+		// ones overflow. Require a floating-point underlying type for a decibel scale.
+		static_assert(!std::is_same_v<NumericalScale, decibel_scale> || std::is_floating_point_v<T>,
+			"a decibel-scale unit requires a floating-point underlying type (an integral type cannot represent a logarithmic value)");
+
 	public:
 		using numerical_scale_type = NumericalScale;   ///< Type of the numerical scale of the unit (e.g. linear_scale)
 		using underlying_type      = T;                ///< Type of the underlying storage of the unit (e.g. double)
@@ -4410,13 +4435,10 @@ namespace units
 #ifndef UNIT_NO_LITERAL_SUPPORT
 	namespace literals
 	{
+		// only a floating-point literal: a decibel scale requires a floating-point underlying type
 		constexpr decibels<double> operator""_dB(long double d) noexcept
 		{
 			return decibels<double>(static_cast<double>(d));
-		}
-		constexpr decibels<int> operator""_dB(unsigned long long d) noexcept
-		{
-			return decibels<int>(static_cast<int>(d));
 		}
 	} // namespace literals
 #endif

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -2663,6 +2663,22 @@ namespace units
 		}
 
 		/**
+		 * @brief		conversion to a named unit
+		 * @details		Converts to a different named unit of the same dimension, e.g.
+		 *				`(100.0_cm).to<meters>()`. The named-template spelling of `convert()`; provided so a
+		 *				single accessor reads for both underlying-type extraction (`to<double>()`) and
+		 *				dimensioned conversion (`to<meters>()`).
+		 * @tparam		UnitType unit class template to convert to
+		 * @returns		a `UnitType<T>` containing the equivalent value to *this.
+		 */
+		template<template<class> class UnitType>
+			requires same_dimension<UnitType<T>, unit>
+		constexpr UnitType<T> to() const noexcept
+		{
+			return UnitType<T>(*this);
+		}
+
+		/**
 		 * @brief		linearized unit value
 		 * @returns		linearized value of unit which has a (possibly) non-linear scale.
 		 */
@@ -2698,7 +2714,7 @@ namespace units
 		 */
 		template<template<class> class UnitType>
 			requires same_dimension<UnitType<T>, unit>
-		constexpr UnitType<T> convert() noexcept
+		constexpr UnitType<T> convert() const noexcept
 		{
 			return UnitType<T>(*this);
 		}

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -4385,6 +4385,42 @@ namespace units
 	template<class Underlying>
 	using dBi = decibels<Underlying>;
 
+	// Register the name/abbreviation for the dimensionless decibel and its `_dB` literal. The reverse
+	// named-class map is keyed on (conversion_factor, scale); the (dimensionless, decibel_scale) key
+	// belongs to `decibels` alone (the power dB units use the watts/milliwatts factors), so the mapping
+	// is unambiguous and the member name()/abbreviation() resolve through it.
+	template<class Underlying>
+	struct unit_name<decibels<Underlying>>
+	{
+		static constexpr const char* value = "decibels";
+	};
+
+	template<class Underlying>
+	struct unit_abbreviation<decibels<Underlying>>
+	{
+		static constexpr const char* value = "dB";
+	};
+
+	namespace detail
+	{
+		::units::decibels<UNIT_LIB_DEFAULT_TYPE> named_class_of(
+			typename ::units::decibels<>::conversion_factor*, typename ::units::decibels<>::numerical_scale_type*);
+	}
+
+#ifndef UNIT_NO_LITERAL_SUPPORT
+	namespace literals
+	{
+		constexpr decibels<double> operator""_dB(long double d) noexcept
+		{
+			return decibels<double>(static_cast<double>(d));
+		}
+		constexpr decibels<int> operator""_dB(unsigned long long d) noexcept
+		{
+			return decibels<int>(static_cast<int>(d));
+		}
+	} // namespace literals
+#endif
+
 	//------------------------------
 	//	DECIBEL ARITHMETIC
 	//------------------------------

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -1206,6 +1206,7 @@ namespace units
 		using force                   = dimension_multiply<mass, acceleration>;                                             ///< Represents an SI derived unit of force
 		using area                    = dimension_pow<length, std::ratio<2>>;                                               ///< Represents an SI derived unit of area
 		using volume                  = dimension_pow<length, std::ratio<3>>;                                               ///< Represents an SI derived unit of volume
+		using volume_flow_rate        = dimension_divide<volume, time>;                                                     ///< Represents an SI derived unit of volumetric flow rate
 		using pressure                = dimension_divide<force, area>;                                                      ///< Represents an SI derived unit of pressure
 		using charge                  = dimension_multiply<time, current>;                                                  ///< Represents an SI derived unit of charge
 		using energy                  = dimension_multiply<force, length>;                                                  ///< Represents an SI derived unit of energy

--- a/include/units/data.h
+++ b/include/units/data.h
@@ -58,10 +58,37 @@ namespace units
 	 * @anchor		dataContainers
 	 * @sa			See unit for more information on unit type containers.
 	 */
-	UNIT_ADD_WITH_METRIC_AND_BINARY_PREFIXES(data, bytes, B, conversion_factor<std::ratio<1>, dimension::data>)
+	// Byte quantities are always at least one, so only the large decimal prefixes (kilo and up) and the
+	// binary prefixes are meaningful; the sub-unit prefixes (deci/centi/milli/... and deca/hecto) are not
+	// spelled out. This also frees the `_dB` literal for the dimensionless decibel, since `decibytes`
+	// would otherwise claim it.
+	UNIT_ADD(data, bytes, B, conversion_factor<std::ratio<1>, dimension::data>)
+	UNIT_ADD(data, kilobytes, kB, kilo<bytes<>>)
+	UNIT_ADD(data, megabytes, MB, mega<bytes<>>)
+	UNIT_ADD(data, gigabytes, GB, giga<bytes<>>)
+	UNIT_ADD(data, terabytes, TB, tera<bytes<>>)
+	UNIT_ADD(data, petabytes, PB, peta<bytes<>>)
 	UNIT_ADD(data, exabytes, EB, conversion_factor<std::ratio<1000>, petabytes_>)
-	UNIT_ADD_WITH_METRIC_AND_BINARY_PREFIXES(data, bits, b, conversion_factor<std::ratio<1, 8>, bytes_>)
+	UNIT_ADD(data, kibibytes, KiB, kibi<bytes<>>)
+	UNIT_ADD(data, mebibytes, MiB, mebi<bytes<>>)
+	UNIT_ADD(data, gibibytes, GiB, gibi<bytes<>>)
+	UNIT_ADD(data, tebibytes, TiB, tebi<bytes<>>)
+	UNIT_ADD(data, pebibytes, PiB, pebi<bytes<>>)
+	UNIT_ADD(data, exbibytes, EiB, exbi<bytes<>>)
+
+	UNIT_ADD(data, bits, b, conversion_factor<std::ratio<1, 8>, bytes_>)
+	UNIT_ADD(data, kilobits, kb, kilo<bits<>>)
+	UNIT_ADD(data, megabits, Mb, mega<bits<>>)
+	UNIT_ADD(data, gigabits, Gb, giga<bits<>>)
+	UNIT_ADD(data, terabits, Tb, tera<bits<>>)
+	UNIT_ADD(data, petabits, Pb, peta<bits<>>)
 	UNIT_ADD(data, exabits, Eb, conversion_factor<std::ratio<1000>, petabits_>)
+	UNIT_ADD(data, kibibits, Kib, kibi<bits<>>)
+	UNIT_ADD(data, mebibits, Mib, mebi<bits<>>)
+	UNIT_ADD(data, gibibits, Gib, gibi<bits<>>)
+	UNIT_ADD(data, tebibits, Tib, tebi<bits<>>)
+	UNIT_ADD(data, pebibits, Pib, pebi<bits<>>)
+	UNIT_ADD(data, exbibits, Eib, exbi<bits<>>)
 
 	UNIT_ADD(data, nibbles, nibble, conversion_factor<std::ratio<4>, bits_>)
 

--- a/include/units/mass.h
+++ b/include/units/mass.h
@@ -66,7 +66,7 @@ namespace units
 	UNIT_ADD(mass, stone, st, conversion_factor<std::ratio<14>, pounds_>)
 	UNIT_ADD(mass, ounces, oz, conversion_factor<std::ratio<1, 16>, pounds_>)
 	UNIT_ADD(mass, carats, ct, conversion_factor<std::ratio<200>, milligrams_>)
-	UNIT_ADD(mass, slugs, slug, conversion_factor<std::ratio<145939029, 10000000>, kilograms_>)
+	UNIT_ADD(mass, slugs, slug, conversion_factor<std::ratio<8896443230521, 609600000000>, kilograms_>)
 
 	UNIT_ADD(mass, grains, gr, conversion_factor<std::ratio<1, 7000>, pounds_>)
 	UNIT_ADD(mass, avoirdupois_drams, dr_av, conversion_factor<std::ratio<1, 16>, ounces_>)

--- a/include/units/volume_flow_rate.h
+++ b/include/units/volume_flow_rate.h
@@ -1,0 +1,74 @@
+//--------------------------------------------------------------------------------------------------
+//
+//	UnitConversion: A compile-time c++23 unit conversion library with no dependencies
+//
+//--------------------------------------------------------------------------------------------------
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+// and associated documentation files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//--------------------------------------------------------------------------------------------------
+//
+// Copyright (c) 2016 Nic Holthaus
+//
+//--------------------------------------------------------------------------------------------------
+//
+// ATTRIBUTION:
+// Parts of this work have been adapted from:
+// http://stackoverflow.com/questions/35069778/create-comparison-trait-for-template-classes-whose-parameters-are-in-a-different
+// http://stackoverflow.com/questions/28253399/check-traits-for-all-variadic-template-arguments/28253503
+// http://stackoverflow.com/questions/36321295/rational-approximation-of-square-root-of-stdratio-at-compile-time?noredirect=1#comment60266601_36321295
+// https://github.com/swatanabe/cppnow17-units
+//
+//--------------------------------------------------------------------------------------------------
+//
+/// @file	units/volume_flow_rate.h
+/// @brief	units representing volumetric flow rate values
+//
+//--------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#ifndef units_volume_flow_rate_h_
+#define units_volume_flow_rate_h_
+
+#include <units/time.h>
+#include <units/volume.h>
+
+namespace units
+{
+	/**
+	 * @namespace	units::volume_flow_rate
+	 * @brief		namespace for unit types and containers representing volumetric-flow-rate values
+	 * @details		The SI unit for volumetric flow rate is `cubic_meters_per_second`, and the corresponding
+	 *				`dimension` dimension is `volume_flow_rate_unit`.
+	 * @anchor		volumeFlowRateContainers
+	 * @sa			See unit for more information on unit type containers.
+	 */
+	UNIT_ADD(volume_flow_rate, cubic_meters_per_second, m3_per_s, conversion_factor<std::ratio<1>, dimension::volume_flow_rate>)
+	UNIT_ADD(volume_flow_rate, cubic_meters_per_hour, m3_per_hr, compound_conversion_factor<cubic_meters<>, inverse<hours<>>>)
+	UNIT_ADD(volume_flow_rate, liters_per_second, L_per_s, compound_conversion_factor<liters<>, inverse<seconds_>>)
+	UNIT_ADD(volume_flow_rate, liters_per_minute, L_per_min, compound_conversion_factor<liters<>, inverse<minutes_>>)
+	UNIT_ADD(volume_flow_rate, gallons_per_minute, gpm, compound_conversion_factor<gallons<>, inverse<minutes_>>)
+	UNIT_ADD(volume_flow_rate, gallons_per_hour, gph, compound_conversion_factor<gallons<>, inverse<hours<>>>)
+	UNIT_ADD(volume_flow_rate, cubic_feet_per_second, cfs, compound_conversion_factor<cubic_feet<>, inverse<seconds_>>)
+	UNIT_ADD(volume_flow_rate, cubic_feet_per_minute, cfm, compound_conversion_factor<cubic_feet<>, inverse<minutes_>>)
+
+	UNIT_ADD_DIMENSION_TRAIT(volume_flow_rate)
+} // namespace units
+
+#endif // units_volume_flow_rate_h_

--- a/test/errorMessages/cases/generated_chrono_from_length.cpp
+++ b/test/errorMessages/cases/generated_chrono_from_length.cpp
@@ -1,0 +1,11 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: meters<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/length.h>
+#include <chrono>
+using namespace units;
+using namespace units::literals;
+std::chrono::seconds s = 1.0_m;
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_chrono_from_length.cpp
+++ b/test/errorMessages/cases/generated_chrono_from_length.cpp
@@ -1,7 +1,7 @@
 // GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
 // FRIENDLY unit types, never the raw conversion_factor<...> soup.
 // expect: fail
-// expect-match: meters<double>
+// expect-match: meters
 // forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
 #include <units/length.h>
 #include <chrono>

--- a/test/errorMessages/cases/generated_compare_length_time_gt.cpp
+++ b/test/errorMessages/cases/generated_compare_length_time_gt.cpp
@@ -1,0 +1,12 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: meters
+// expect-match: seconds
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/length.h>
+#include <units/time.h>
+using namespace units;
+using namespace units::literals;
+bool b = (1.0_m > 1.0_s);
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_compare_velocity_mass_ge.cpp
+++ b/test/errorMessages/cases/generated_compare_velocity_mass_ge.cpp
@@ -1,0 +1,12 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: meters_per_second
+// expect-match: kilograms
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/velocity.h>
+#include <units/mass.h>
+using namespace units;
+using namespace units::literals;
+bool b = (1.0_mps >= units::mass::kilograms<double>(1.0));
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_cos_of_time.cpp
+++ b/test/errorMessages/cases/generated_cos_of_time.cpp
@@ -1,0 +1,11 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: seconds<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/angle.h>
+#include <units/time.h>
+using namespace units;
+using namespace units::literals;
+auto x = cos(units::time::seconds<double>(1.0));
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_cos_of_time.cpp
+++ b/test/errorMessages/cases/generated_cos_of_time.cpp
@@ -1,7 +1,7 @@
 // GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
 // FRIENDLY unit types, never the raw conversion_factor<...> soup.
 // expect: fail
-// expect-match: seconds<double>
+// expect-match: seconds
 // forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
 #include <units/angle.h>
 #include <units/time.h>

--- a/test/errorMessages/cases/generated_dimensioned_from_scalar.cpp
+++ b/test/errorMessages/cases/generated_dimensioned_from_scalar.cpp
@@ -1,7 +1,7 @@
 // GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
 // FRIENDLY unit types, never the raw conversion_factor<...> soup.
 // expect: fail
-// expect-match: meters<double>
+// expect-match: meters
 // forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
 #include <units/length.h>
 using namespace units;

--- a/test/errorMessages/cases/generated_dimensioned_from_scalar.cpp
+++ b/test/errorMessages/cases/generated_dimensioned_from_scalar.cpp
@@ -1,0 +1,10 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: meters<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/length.h>
+using namespace units;
+using namespace units::literals;
+units::length::meters<double> m = 5.0;
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_fmod_length_time.cpp
+++ b/test/errorMessages/cases/generated_fmod_length_time.cpp
@@ -1,8 +1,8 @@
 // GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
 // FRIENDLY unit types, never the raw conversion_factor<...> soup.
 // expect: fail
-// expect-match: meters<double>
-// expect-match: seconds<double>
+// expect-match: meters
+// expect-match: seconds
 // forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
 #include <units/length.h>
 #include <units/time.h>

--- a/test/errorMessages/cases/generated_fmod_length_time.cpp
+++ b/test/errorMessages/cases/generated_fmod_length_time.cpp
@@ -1,0 +1,12 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: meters<double>
+// expect-match: seconds<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/length.h>
+#include <units/time.h>
+using namespace units;
+using namespace units::literals;
+auto x = fmod(1.0_m, 1.0_s);
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_pow2_length_to_volume.cpp
+++ b/test/errorMessages/cases/generated_pow2_length_to_volume.cpp
@@ -1,7 +1,7 @@
 // GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
 // FRIENDLY unit types, never the raw conversion_factor<...> soup.
 // expect: fail
-// expect-match: cubic_meters<double>
+// expect-match: cubic_meters
 // forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
 #include <units/length.h>
 #include <units/area.h>

--- a/test/errorMessages/cases/generated_pow2_length_to_volume.cpp
+++ b/test/errorMessages/cases/generated_pow2_length_to_volume.cpp
@@ -1,7 +1,8 @@
 // GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
 // FRIENDLY unit types, never the raw conversion_factor<...> soup.
 // expect: fail
-// expect-match: cubic_meters
+// expect-match: square_meters<double>
+// expect-match: cubic_meters<double>
 // forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
 #include <units/length.h>
 #include <units/area.h>

--- a/test/errorMessages/cases/generated_pow2_length_to_volume.cpp
+++ b/test/errorMessages/cases/generated_pow2_length_to_volume.cpp
@@ -1,0 +1,12 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: cubic_meters<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/length.h>
+#include <units/area.h>
+#include <units/volume.h>
+using namespace units;
+using namespace units::literals;
+units::volume::cubic_meters<double> x = pow<2>(1.0_m);
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_scalar_from_dimensioned.cpp
+++ b/test/errorMessages/cases/generated_scalar_from_dimensioned.cpp
@@ -1,0 +1,10 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: meters<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/length.h>
+using namespace units;
+using namespace units::literals;
+double d = 1.0_m;
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_scalar_from_dimensioned.cpp
+++ b/test/errorMessages/cases/generated_scalar_from_dimensioned.cpp
@@ -1,7 +1,7 @@
 // GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
 // FRIENDLY unit types, never the raw conversion_factor<...> soup.
 // expect: fail
-// expect-match: meters<double>
+// expect-match: meters
 // forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
 #include <units/length.h>
 using namespace units;

--- a/test/errorMessages/cases/generated_sin_of_length.cpp
+++ b/test/errorMessages/cases/generated_sin_of_length.cpp
@@ -1,7 +1,7 @@
 // GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
 // FRIENDLY unit types, never the raw conversion_factor<...> soup.
 // expect: fail
-// expect-match: meters<double>
+// expect-match: meters
 // forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
 #include <units/angle.h>
 #include <units/length.h>

--- a/test/errorMessages/cases/generated_sin_of_length.cpp
+++ b/test/errorMessages/cases/generated_sin_of_length.cpp
@@ -1,0 +1,11 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: meters<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/angle.h>
+#include <units/length.h>
+using namespace units;
+using namespace units::literals;
+auto x = sin(1.0_m);
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_sqrt_area_to_time.cpp
+++ b/test/errorMessages/cases/generated_sqrt_area_to_time.cpp
@@ -1,8 +1,8 @@
 // GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
 // FRIENDLY unit types, never the raw conversion_factor<...> soup.
 // expect: fail
-// expect-match: square_meters<double>
-// expect-match: seconds<double>
+// expect-match: square_meters
+// expect-match: seconds
 // forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
 #include <units/area.h>
 #include <units/length.h>

--- a/test/errorMessages/cases/generated_sqrt_area_to_time.cpp
+++ b/test/errorMessages/cases/generated_sqrt_area_to_time.cpp
@@ -1,0 +1,13 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: square_meters<double>
+// expect-match: seconds<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/area.h>
+#include <units/length.h>
+#include <units/time.h>
+using namespace units;
+using namespace units::literals;
+units::time::seconds<double> x = sqrt(units::area::square_meters<double>(4.0));
+int main() { return 0; }

--- a/test/errorMessages/cases/generated_sqrt_area_to_time.cpp
+++ b/test/errorMessages/cases/generated_sqrt_area_to_time.cpp
@@ -1,8 +1,8 @@
 // GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
 // FRIENDLY unit types, never the raw conversion_factor<...> soup.
 // expect: fail
-// expect-match: square_meters
-// expect-match: seconds
+// expect-match: meters<double>
+// expect-match: seconds<double>
 // forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
 #include <units/area.h>
 #include <units/length.h>

--- a/test/errorMessages/cases/generated_tan_of_mass.cpp
+++ b/test/errorMessages/cases/generated_tan_of_mass.cpp
@@ -1,7 +1,7 @@
 // GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
 // FRIENDLY unit types, never the raw conversion_factor<...> soup.
 // expect: fail
-// expect-match: kilograms<double>
+// expect-match: kilograms
 // forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
 #include <units/angle.h>
 #include <units/mass.h>

--- a/test/errorMessages/cases/generated_tan_of_mass.cpp
+++ b/test/errorMessages/cases/generated_tan_of_mass.cpp
@@ -1,0 +1,11 @@
+// GENERATED (generate_cases.py). Deliberate ill-formed cross-dimension use — the diagnostic must name the
+// FRIENDLY unit types, never the raw conversion_factor<...> soup.
+// expect: fail
+// expect-match: kilograms<double>
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+#include <units/angle.h>
+#include <units/mass.h>
+using namespace units;
+using namespace units::literals;
+auto x = tan(units::mass::kilograms<double>(1.0));
+int main() { return 0; }

--- a/test/errorMessages/cases/readable_integer_decibel.cpp
+++ b/test/errorMessages/cases/readable_integer_decibel.cpp
@@ -1,0 +1,14 @@
+// Case: a decibel-scale unit with an integral underlying type must FAIL readably.
+// A decibel stores its value through a base-10 logarithm, so an integer cannot represent it (3 dB would
+// store as 0, large values overflow). The static_assert names the reason.
+//
+// expect: fail
+// expect-match: decibel-scale unit requires a floating-point underlying type
+#include <units/core.h>
+using namespace units;
+units::decibels<int> a(3); // ill-formed: integral underlying type on a decibel scale
+int main()
+{
+	(void)a;
+	return 0;
+}

--- a/test/errorMessages/cases/readable_integer_decibel_power.cpp
+++ b/test/errorMessages/cases/readable_integer_decibel_power.cpp
@@ -1,0 +1,13 @@
+// Case: a power decibel unit (dBW) with an integral underlying type must FAIL readably, for the same
+// reason as the dimensionless decibel — a logarithmic scale cannot use an integer underlying type.
+//
+// expect: fail
+// expect-match: decibel-scale unit requires a floating-point underlying type
+#include <units/power.h>
+using namespace units;
+units::power::dBW<int> a(10); // ill-formed: integral underlying type on a decibel scale
+int main()
+{
+	(void)a;
+	return 0;
+}

--- a/test/errorMessages/generate_cases.py
+++ b/test/errorMessages/generate_cases.py
@@ -94,13 +94,15 @@ TRIG_DOMAIN = [
     ("tan_of_mass", ["angle", "mass"], "auto x = tan(units::mass::kilograms<double>(1.0));", ["kilograms"]),
 ]
 
-# The RESULT of a dimensional math operation has a definite dimension; assigning it to the wrong one fails.
+# The RESULT of a dimensional math operation has a definite dimension; assigning it to the wrong one
+# fails, and the diagnostic names the RESULT's friendly type (sqrt of an area is a length; the square of a
+# length is an area) alongside the wrong target — like the mul/div derived-result cases above.
 MATH_RESULT = [
     ("sqrt_area_to_time", ["area", "length", "time"],
      "units::time::seconds<double> x = sqrt(units::area::square_meters<double>(4.0));",
-     ["square_meters", "seconds"]),
+     ["meters<double>", "seconds<double>"]),
     ("pow2_length_to_volume", ["length", "area", "volume"],
-     "units::volume::cubic_meters<double> x = pow<2>(1.0_m);", ["cubic_meters"]),
+     "units::volume::cubic_meters<double> x = pow<2>(1.0_m);", ["square_meters<double>", "cubic_meters<double>"]),
 ]
 
 # fmod and hypot across incompatible dimensions are ill-formed.

--- a/test/errorMessages/generate_cases.py
+++ b/test/errorMessages/generate_cases.py
@@ -72,9 +72,11 @@ DERIVED_RESULT = [
 
 # A dimensioned quantity does not implicitly become a bare scalar, and a bare number does not implicitly
 # become a dimensioned quantity: the conversion operator is explicit and the value constructor is explicit.
+# (Matches on the friendly STEM rather than the meters<double> form: the stem appears in every compiler's
+# diagnostic — GCC/Clang's meters<double>, the meters_ tag, and MSVC's rendering alike.)
 SCALAR_BOUNDARY = [
-    ("scalar_from_dimensioned", ["length"], "double d = 1.0_m;", ["meters<double>"]),
-    ("dimensioned_from_scalar", ["length"], "units::length::meters<double> m = 5.0;", ["meters<double>"]),
+    ("scalar_from_dimensioned", ["length"], "double d = 1.0_m;", ["meters"]),
+    ("dimensioned_from_scalar", ["length"], "units::length::meters<double> m = 5.0;", ["meters"]),
 ]
 
 # Comparing quantities of different dimensions is ill-formed. (The relational-operator diagnostic names
@@ -85,30 +87,30 @@ COMPARE_ACROSS = [
      "bool b = (1.0_mps >= units::mass::kilograms<double>(1.0));", ["meters_per_second", "kilograms"]),
 ]
 
-# A math function whose domain is an angle rejects a non-angle argument.
+# A math function whose domain is an angle rejects a non-angle argument. (Stem match: cross-compiler.)
 TRIG_DOMAIN = [
-    ("sin_of_length", ["angle", "length"], "auto x = sin(1.0_m);", ["meters<double>"]),
-    ("cos_of_time", ["angle", "time"], "auto x = cos(units::time::seconds<double>(1.0));", ["seconds<double>"]),
-    ("tan_of_mass", ["angle", "mass"], "auto x = tan(units::mass::kilograms<double>(1.0));", ["kilograms<double>"]),
+    ("sin_of_length", ["angle", "length"], "auto x = sin(1.0_m);", ["meters"]),
+    ("cos_of_time", ["angle", "time"], "auto x = cos(units::time::seconds<double>(1.0));", ["seconds"]),
+    ("tan_of_mass", ["angle", "mass"], "auto x = tan(units::mass::kilograms<double>(1.0));", ["kilograms"]),
 ]
 
 # The RESULT of a dimensional math operation has a definite dimension; assigning it to the wrong one fails.
 MATH_RESULT = [
     ("sqrt_area_to_time", ["area", "length", "time"],
      "units::time::seconds<double> x = sqrt(units::area::square_meters<double>(4.0));",
-     ["square_meters<double>", "seconds<double>"]),
+     ["square_meters", "seconds"]),
     ("pow2_length_to_volume", ["length", "area", "volume"],
-     "units::volume::cubic_meters<double> x = pow<2>(1.0_m);", ["cubic_meters<double>"]),
+     "units::volume::cubic_meters<double> x = pow<2>(1.0_m);", ["cubic_meters"]),
 ]
 
 # fmod and hypot across incompatible dimensions are ill-formed.
 MATH_DOMAIN = [
-    ("fmod_length_time", ["length", "time"], "auto x = fmod(1.0_m, 1.0_s);", ["meters<double>", "seconds<double>"]),
+    ("fmod_length_time", ["length", "time"], "auto x = fmod(1.0_m, 1.0_s);", ["meters", "seconds"]),
 ]
 
 # A std::chrono::duration only converts to/from a time quantity; a non-time quantity is rejected.
 CHRONO_BOUNDARY = [
-    ("chrono_from_length", ["length", "<chrono>"], "std::chrono::seconds s = 1.0_m;", ["meters<double>"]),
+    ("chrono_from_length", ["length", "<chrono>"], "std::chrono::seconds s = 1.0_m;", ["meters"]),
 ]
 
 # #357-class ordering: an expression reducing to a dimension whose header is included LAST must still compile.

--- a/test/errorMessages/generate_cases.py
+++ b/test/errorMessages/generate_cases.py
@@ -70,6 +70,47 @@ DERIVED_RESULT = [
      "units::length::meters<double> x = units::energy::joules<double>(6.0) / 2.0_s;", ["watts<double>", "meters<double>"]),
 ]
 
+# A dimensioned quantity does not implicitly become a bare scalar, and a bare number does not implicitly
+# become a dimensioned quantity: the conversion operator is explicit and the value constructor is explicit.
+SCALAR_BOUNDARY = [
+    ("scalar_from_dimensioned", ["length"], "double d = 1.0_m;", ["meters<double>"]),
+    ("dimensioned_from_scalar", ["length"], "units::length::meters<double> m = 5.0;", ["meters<double>"]),
+]
+
+# Comparing quantities of different dimensions is ill-formed. (The relational-operator diagnostic names
+# the strong tag, e.g. meters_, so the match is on the friendly stem rather than the meters<double> form.)
+COMPARE_ACROSS = [
+    ("compare_length_time_gt", ["length", "time"], "bool b = (1.0_m > 1.0_s);", ["meters", "seconds"]),
+    ("compare_velocity_mass_ge", ["velocity", "mass"],
+     "bool b = (1.0_mps >= units::mass::kilograms<double>(1.0));", ["meters_per_second", "kilograms"]),
+]
+
+# A math function whose domain is an angle rejects a non-angle argument.
+TRIG_DOMAIN = [
+    ("sin_of_length", ["angle", "length"], "auto x = sin(1.0_m);", ["meters<double>"]),
+    ("cos_of_time", ["angle", "time"], "auto x = cos(units::time::seconds<double>(1.0));", ["seconds<double>"]),
+    ("tan_of_mass", ["angle", "mass"], "auto x = tan(units::mass::kilograms<double>(1.0));", ["kilograms<double>"]),
+]
+
+# The RESULT of a dimensional math operation has a definite dimension; assigning it to the wrong one fails.
+MATH_RESULT = [
+    ("sqrt_area_to_time", ["area", "length", "time"],
+     "units::time::seconds<double> x = sqrt(units::area::square_meters<double>(4.0));",
+     ["square_meters<double>", "seconds<double>"]),
+    ("pow2_length_to_volume", ["length", "area", "volume"],
+     "units::volume::cubic_meters<double> x = pow<2>(1.0_m);", ["cubic_meters<double>"]),
+]
+
+# fmod and hypot across incompatible dimensions are ill-formed.
+MATH_DOMAIN = [
+    ("fmod_length_time", ["length", "time"], "auto x = fmod(1.0_m, 1.0_s);", ["meters<double>", "seconds<double>"]),
+]
+
+# A std::chrono::duration only converts to/from a time quantity; a non-time quantity is rejected.
+CHRONO_BOUNDARY = [
+    ("chrono_from_length", ["length", "<chrono>"], "std::chrono::seconds s = 1.0_m;", ["meters<double>"]),
+]
+
 # #357-class ordering: an expression reducing to a dimension whose header is included LAST must still compile.
 ORDERING_OK = [
     ("order_velocity_over_length", ["velocity", "length"], "auto x = 1.0_mps / 1.0_m;", "frequency"),
@@ -82,7 +123,10 @@ ORDERING_OK = [
 ]
 
 def header_includes(hdrs):
-    return "\n".join(f"#include <units/{h}.h>" for h in hdrs)
+    # a bare "<name>" is a standard-library header included verbatim; otherwise it is a units dimension header
+    def one(h):
+        return f"#include {h}" if h.startswith("<") else f"#include <units/{h}.h>"
+    return "\n".join(one(h) for h in hdrs)
 
 def write(name, text):
     (CASES / f"generated_{name}.cpp").write_text(text)
@@ -125,9 +169,14 @@ def main():
         gen_bad_conversion(c[0], c[1], c[2], c[3])
     for c in DERIVED_RESULT:
         gen_bad_conversion(c[0], c[1], c[2], c[3])
+    for group in (SCALAR_BOUNDARY, COMPARE_ACROSS, TRIG_DOMAIN, MATH_RESULT, MATH_DOMAIN, CHRONO_BOUNDARY):
+        for c in group:
+            gen_bad_conversion(c[0], c[1], c[2], c[3])
     for c in ORDERING_OK:
         gen_ordering(c[0], c[1], c[2], c[3])
-    total = len(BAD_CONVERSIONS) + len(ADD_INCOMPATIBLE) + len(DERIVED_RESULT) + len(ORDERING_OK)
+    total = (len(BAD_CONVERSIONS) + len(ADD_INCOMPATIBLE) + len(DERIVED_RESULT) + len(SCALAR_BOUNDARY)
+             + len(COMPARE_ACROSS) + len(TRIG_DOMAIN) + len(MATH_RESULT) + len(MATH_DOMAIN)
+             + len(CHRONO_BOUNDARY) + len(ORDERING_OK))
     print(f"generated {total} cases (+ 4 curated hand-written) = {total + 4} total")
 
 if __name__ == "__main__":

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -3360,10 +3360,10 @@ TEST_F(UnitType, dimensionlessDecibelLiteral)
 	static_assert(std::is_same_v<decltype(g), decibels<double>>);
 	EXPECT_DOUBLE_EQ(-20.0, g.raw());
 
-	// the integer literal yields decibels<int>; as with the power dB units, an integral decibel scale
-	// is lossy through the log10 round-trip, so only the type is asserted here
-	auto gi = 3_dB;
-	static_assert(std::is_same_v<decltype(gi), decibels<int>>);
+	// only a floating-point _dB literal exists; an integer decibel is rejected at compile time
+	// (see the errorMessages harness), because a decibel scale cannot use an integral underlying type
+	auto gd = 6.0_dB;
+	static_assert(std::is_same_v<decltype(gd), decibels<double>>);
 
 	// name/abbreviation resolve for the dimensionless decibel
 	decibels<double> d(6.0);
@@ -3382,24 +3382,24 @@ TEST_F(UnitType, dBAddition)
 
 	auto result_dbw = dBW<double>(10.0) + decibels<double>(30.0);
 	EXPECT_NEAR(40.0, result_dbw.value(), 5.0e-5);
-	result_dbw = dBW<int>(10) + decibels<int>(30);
+	result_dbw = dBW<double>(10.0) + decibels<double>(30.0);
 	EXPECT_NEAR(40.0, result_dbw.value(), 5.0e-5);
 	result_dbw = decibels<double>(12.0) + dBW<double>(30.0);
 	EXPECT_NEAR(42.0, result_dbw.value(), 5.0e-5);
-	result_dbw = decibels<int>(12) + dBW<int>(30);
-	EXPECT_NEAR(42.0, result_dbw.value(), 2);
+	result_dbw = decibels<double>(12.0) + dBW<double>(30.0);
+	EXPECT_NEAR(42.0, result_dbw.value(), 5.0e-5);
 	isSame = std::is_same_v<decltype(result_dbw), dBW<double>>;
 	EXPECT_TRUE(isSame);
 
 	auto result_dbm = decibels<double>(30.0) + dBm<double>(20.0);
 	EXPECT_NEAR(50.0, result_dbm.value(), 5.0e-5);
-	result_dbm = decibels<int>(30) + dBm<int>(20);
+	result_dbm = decibels<double>(30.0) + dBm<double>(20.0);
 	EXPECT_NEAR(50.0, result_dbm.value(), 5.0e-5);
 
 	// adding dBW to dBW is something you probably shouldn't do, but let's see if it works...
 	unit<squared<dBW<double>>> result_dBW2 = ::units::power::dBW<double>(10.0) + dBm<double>(40.0);
 	EXPECT_NEAR(100.0, result_dBW2.to_linearized(), 5.0e-5);
-	unit<squared<dBW<int>>> result_dBW3 = dBW<int>(10) + dBm<int>(40);
+	unit<squared<dBW<double>>> result_dBW3 = dBW<double>(10.0) + dBm<double>(40.0);
 	EXPECT_NEAR(100.0, result_dBW3.to_linearized(), 5.0e-5);
 }
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -3374,6 +3374,18 @@ TEST_F(UnitType, dimensionlessDecibelLiteral)
 	static_assert(std::is_same_v<decltype(0.0_dBW), dBW<double>>);
 	static_assert(std::is_same_v<decltype(0.0_dBm), dBm<double>>);
 	static_assert(!std::is_same_v<decibels<double>, dBW<double>>);
+
+	// a floating-point underlying type other than double is allowed (only integral types are rejected)
+	decibels<float> asFloat(20.0f);
+	EXPECT_NEAR(100.0, static_cast<double>(asFloat.to_linearized()), 5.0e-4);
+
+#if !defined(UNIT_LIB_DISABLE_IOSTREAM)
+	// the streamed form of a decibel-arithmetic result uses the dB abbreviation (adding dB multiplies linear)
+	testing::internal::CaptureStdout();
+	std::cout << (decibels<double>(3.0) + decibels<double>(3.0));
+	std::string output = testing::internal::GetCapturedStdout();
+	EXPECT_STREQ("6 dB", output.c_str());
+#endif
 }
 
 TEST_F(UnitType, dBAddition)
@@ -3806,6 +3818,29 @@ TEST_F(ConversionFactor, volume_flow_rate)
 	EXPECT_NEAR(22.712470704, test, 5.0e-9);
 	test = cubic_meters_per_hour<double>(cubic_feet_per_minute<double>(1.0)).value();
 	EXPECT_NEAR(1.69901079552, test, 5.0e-11);
+
+	// each remaining named unit checked against its most natural base
+	test = cubic_meters_per_hour<double>(cubic_meters_per_second<double>(1.0)).value();
+	EXPECT_DOUBLE_EQ(3600.0, test);
+	test = gallons_per_minute<double>(gallons_per_hour<double>(60.0)).value();
+	EXPECT_DOUBLE_EQ(1.0, test);
+	test = liters_per_second<double>(gallons_per_hour<double>(1.0)).value();
+	EXPECT_NEAR(0.00105150327, test, 5.0e-11);
+
+	// deriving the dimension from volume / time means the composed quantity IS the named unit: it
+	// resolves to liters_per_second and streams with that unit's abbreviation, and converts as expected
+	same = std::is_same_v<decltype(5.0_L / 1.0_s), liters_per_second<double>>;
+	EXPECT_TRUE(same);
+	test = gallons_per_minute<double>(5.0_L / 1.0_s).value();
+	EXPECT_NEAR(79.2516157, test, 5.0e-7);
+#if !defined(UNIT_LIB_DISABLE_IOSTREAM)
+	{
+		testing::internal::CaptureStdout();
+		std::cout << (5.0_L / 1.0_s);
+		std::string output = testing::internal::GetCapturedStdout();
+		EXPECT_STREQ("5 L_per_s", output.c_str());
+	}
+#endif
 }
 
 TEST_F(ConversionFactor, velocity)

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -369,6 +369,16 @@ TEST_F(TypeTraits, is_frequency_unit)
 	static_assert(!traits::is_frequency_unit_v<seconds<double>>);
 }
 
+TEST_F(TypeTraits, is_volume_flow_rate_unit)
+{
+	static_assert(!traits::is_volume_flow_rate_unit_v<double>);
+	static_assert(traits::is_volume_flow_rate_unit_v<cubic_meters_per_second<double>>);
+	static_assert(traits::is_volume_flow_rate_unit_v<const liters_per_second<double>>);
+	static_assert(traits::is_volume_flow_rate_unit_v<const gallons_per_minute<double>&>);
+	static_assert(!traits::is_volume_flow_rate_unit_v<cubic_meters<double>>);
+	static_assert(!traits::is_volume_flow_rate_unit_v<meters_per_second<double>>);
+}
+
 TEST_F(TypeTraits, is_velocity_unit)
 {
 	static_assert(!traits::is_velocity_unit_v<double>);
@@ -3744,6 +3754,37 @@ TEST_F(ConversionFactor, frequency)
 	EXPECT_NEAR(1.0e6, test, 5.0e-5);
 }
 
+TEST_F(ConversionFactor, volume_flow_rate)
+{
+	double test;
+	bool   same;
+
+	same = std::is_same_v<cubic_meters_per_second<double>::conversion_factor, traits::strong_t<conversion_factor<std::ratio<1>, dimension::volume_flow_rate>>>;
+	EXPECT_TRUE(same);
+
+	same = traits::is_same_dimension_unit_v<liters_per_second<double>, cubic_meters_per_second<double>>;
+	EXPECT_TRUE(same);
+
+	// a volume divided by a time is a volume flow rate (dimension derived from volume/time)
+	same = traits::is_same_dimension_unit_v<decltype(liters<double>(1.0) / seconds<double>(1.0)), liters_per_second<double>>;
+	EXPECT_TRUE(same);
+
+	test = liters_per_second<double>(cubic_meters_per_second<double>(1.0)).value();
+	EXPECT_DOUBLE_EQ(1000.0, test);
+	test = liters_per_minute<double>(liters_per_second<double>(1.0)).value();
+	EXPECT_DOUBLE_EQ(60.0, test);
+	test = cubic_feet_per_minute<double>(cubic_feet_per_second<double>(1.0)).value();
+	EXPECT_DOUBLE_EQ(60.0, test);
+	test = liters_per_second<double>(gallons_per_minute<double>(1.0)).value();
+	EXPECT_NEAR(0.0630901964, test, 5.0e-10);
+	test = liters_per_second<double>(cubic_feet_per_second<double>(1.0)).value();
+	EXPECT_NEAR(28.316846592, test, 5.0e-9);
+	test = cubic_meters_per_hour<double>(gallons_per_minute<double>(100.0)).value();
+	EXPECT_NEAR(22.712470704, test, 5.0e-9);
+	test = cubic_meters_per_hour<double>(cubic_feet_per_minute<double>(1.0)).value();
+	EXPECT_NEAR(1.69901079552, test, 5.0e-11);
+}
+
 TEST_F(ConversionFactor, velocity)
 {
 	double test;
@@ -5707,23 +5748,19 @@ TEST_F(CaseStudies, dataReadSimulation)
 
 TEST_F(CaseStudies, selfDefinedUnits)
 {
-	using liters_per_second  = decltype(1.0_L / 1.0_s);
-	using gallons_per_minute = decltype(1.0_gal / 1.0_min);
+	// A composed unit the library does not name prints as the raw dimension form (value + dimension
+	// exponents), not a friendly abbreviation. Volume per time-squared has no named unit.
+	using liters_per_second_squared = decltype(1.0_L / (1.0_s * 1.0_s));
 
-	liters_per_second  lps(5);
-	gallons_per_minute gpm = lps;
+	liters_per_second_squared a(5);
+	liters_per_second_squared b = a;
 
-	EXPECT_NEAR(79.2516157, gpm.to<double>(), 0.5e-7);
+	EXPECT_DOUBLE_EQ(a.to<double>(), b.to<double>());
 
 	testing::internal::CaptureStdout();
-	std::cout << lps;
+	std::cout << a;
 	std::string output = testing::internal::GetCapturedStdout();
-	EXPECT_STREQ("0.005 m^3 s^-1", output.c_str());
-
-	testing::internal::CaptureStdout();
-	std::cout << gpm;
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_STREQ("0.005 m^3 s^-1", output.c_str());
+	EXPECT_STREQ("0.005 m^3 s^-2", output.c_str());
 }
 
 int main(int argc, char* argv[])

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -3546,7 +3546,7 @@ TEST_F(ConversionFactor, mass)
 	test = carats<double>(kilograms<double>(0.0002)).value();
 	EXPECT_NEAR(1.0, test, 5.0e-6);
 	test = kilograms<double>(slugs<double>(1.0)).value();
-	EXPECT_NEAR(14.593903, test, 5.0e-7);
+	EXPECT_NEAR(14.593902937206364, test, 5.0e-13);
 
 	test = carats<double>(mass::pounds<double>(6.3)).value();
 	EXPECT_NEAR(14288.2, test, 5.0e-2);
@@ -4361,7 +4361,7 @@ TEST_F(ConversionFactor, density)
 	test = kilograms_per_cubic_meter<double>(pounds_per_gallon<double>(1.0)).value();
 	EXPECT_NEAR(119.8264273, test, 5.0e-8);
 	test = kilograms_per_cubic_meter<double>(slugs_per_cubic_foot<double>(1.0)).value();
-	EXPECT_NEAR(515.3788184, test, 5.0e-6);
+	EXPECT_NEAR(515.3788183931962, test, 5.0e-11);
 }
 
 TEST_F(ConversionFactor, concentration)

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -3017,6 +3017,23 @@ TEST_F(UnitType, convertMethod)
 	constexpr auto unit2 = meters<double>(3.0).convert<feet>();
 	constexpr auto test2 = unit2.to<double>();
 	EXPECT_NEAR(9.84252, test2, 5.0e-6);
+
+	// named-unit to<>(): returns a unit of the requested type, mirroring convert<>()
+	constexpr auto asFeet = meters<double>(3.0).to<feet>();
+	static_assert(std::is_same_v<std::remove_const_t<decltype(asFeet)>, feet<double>>);
+	EXPECT_NEAR(9.84252, asFeet.to<double>(), 5.0e-6);
+
+	constexpr auto asMeters = centimeters<double>(100.0).to<meters>();
+	static_assert(std::is_same_v<std::remove_const_t<decltype(asMeters)>, meters<double>>);
+	EXPECT_DOUBLE_EQ(1.0, asMeters.to<double>());
+
+	// arithmetic-type to<>() is unchanged: extracts the underlying value
+	EXPECT_DOUBLE_EQ(3.0, meters<double>(3.0).to<double>());
+
+	// convert<>() is callable on a const unit (const-qualified overloads)
+	const meters<double> constMeters(3.0);
+	EXPECT_NEAR(9.84252, constMeters.convert<feet>().to<double>(), 5.0e-6);
+	EXPECT_NEAR(9.84252, constMeters.to<feet>().to<double>(), 5.0e-6);
 }
 
 #ifndef UNIT_LIB_DISABLE_IOSTREAM

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -713,26 +713,26 @@ TEST_F(STDSpecializations, hash)
 TEST_F(STDSpecializations, unitsAsContainerKeys)
 {
 	// std::map — ordered by value via operator<.
-	std::map<meters<double>, std::string> m;
-	m[meters<double>(1.0)] = "one";
-	m[meters<double>(2.0)] = "two";
-	m[kilometers<double>(0.003)] = "three-m"; // 3 m, distinct key from 1 m / 2 m
-	EXPECT_EQ(m.size(), 3u);
-	EXPECT_EQ(m[meters<double>(1.0)], "one");
-	EXPECT_EQ(m.begin()->second, "one"); // smallest key first
+	std::map<meters<double>, std::string> byValue;
+	byValue[meters<double>(1.0)] = "one";
+	byValue[meters<double>(2.0)] = "two";
+	byValue[kilometers<double>(0.003)] = "three-m"; // 3 m, distinct key from 1 m / 2 m
+	EXPECT_EQ(byValue.size(), 3u);
+	EXPECT_EQ(byValue[meters<double>(1.0)], "one");
+	EXPECT_EQ(byValue.begin()->second, "one"); // smallest key first
 
 	// std::unordered_map — needs both std::hash<meters<double>> AND operator==.
-	std::unordered_map<meters<double>, int> um;
-	um[meters<double>(5.0)] = 50;
-	EXPECT_EQ(um.at(meters<double>(5.0)), 50);
+	std::unordered_map<meters<double>, int> byHash;
+	byHash[meters<double>(5.0)] = 50;
+	EXPECT_EQ(byHash.at(meters<double>(5.0)), 50);
 	// a scaled-but-equal key resolves to the SAME bucket (kilometers<double>(0.005) == 5 m). Look it up after
 	// converting to the map's key type, since a heterogeneous [] would insert a different key type.
-	EXPECT_EQ(um.at(meters<double>(kilometers<double>(0.005))), 50);
+	EXPECT_EQ(byHash.at(meters<double>(kilometers<double>(0.005))), 50);
 
 	// std::set — membership by value.
-	std::set<seconds<double>> s{seconds<double>(1.0), seconds<double>(2.0), seconds<double>(1.0)};
-	EXPECT_EQ(s.size(), 2u); // the duplicate 1 s collapses
-	EXPECT_TRUE(s.count(seconds<double>(2.0)) == 1);
+	std::set<seconds<double>> timeSet{seconds<double>(1.0), seconds<double>(2.0), seconds<double>(1.0)};
+	EXPECT_EQ(timeSet.size(), 2u); // the duplicate 1 s collapses
+	EXPECT_TRUE(timeSet.count(seconds<double>(2.0)) == 1);
 }
 
 TEST_F(UnitManipulators, squared)
@@ -2952,16 +2952,16 @@ TEST_F(UnitType, PpbPerYearCompoundUnitType)
 {
 	using ppb_per_year = decltype(ppb/yr);
 
-	parts_per_million s = 9.71_ppb;
+	parts_per_million concentration = 9.71_ppb;
 
-	EXPECT_EQ(s, 0.00971_ppm);
-	EXPECT_DOUBLE_EQ(s, 0.00000000971);
+	EXPECT_EQ(concentration, 0.00971_ppm);
+	EXPECT_DOUBLE_EQ(concentration, 0.00000000971);
 
-	ppb_per_year ds(0.109);
+	ppb_per_year rate(0.109);
 
-	auto time = 2013.9_yr-1994_yr;
+	auto elapsed = 2013.9_yr-1994_yr;
 
-	parts_per_million val = s + ds*time;
+	parts_per_million val = concentration + rate*elapsed;
 	EXPECT_NEAR(val, 1.18791e-08, 1e-12);
 }
 
@@ -3356,19 +3356,19 @@ TEST_F(UnitType, dBConversion)
 TEST_F(UnitType, dimensionlessDecibelLiteral)
 {
 	// the `_dB` literal yields the dimensionless decibel; its stored value is the dB figure
-	auto g = -20.0_dB;
-	static_assert(std::is_same_v<decltype(g), decibels<double>>);
-	EXPECT_DOUBLE_EQ(-20.0, g.raw());
+	auto gainDb = -20.0_dB;
+	static_assert(std::is_same_v<decltype(gainDb), decibels<double>>);
+	EXPECT_DOUBLE_EQ(-20.0, gainDb.raw());
 
 	// only a floating-point _dB literal exists; an integer decibel is rejected at compile time
 	// (see the errorMessages harness), because a decibel scale cannot use an integral underlying type
-	auto gd = 6.0_dB;
-	static_assert(std::is_same_v<decltype(gd), decibels<double>>);
+	auto gainDb2 = 6.0_dB;
+	static_assert(std::is_same_v<decltype(gainDb2), decibels<double>>);
 
 	// name/abbreviation resolve for the dimensionless decibel
-	decibels<double> d(6.0);
-	EXPECT_STREQ("decibels", d.name());
-	EXPECT_STREQ("dB", d.abbreviation());
+	decibels<double> ratioDb(6.0);
+	EXPECT_STREQ("decibels", ratioDb.name());
+	EXPECT_STREQ("dB", ratioDb.abbreviation());
 
 	// coexists with the power decibel literals (distinct types, distinct suffixes)
 	static_assert(std::is_same_v<decltype(0.0_dBW), dBW<double>>);
@@ -5529,30 +5529,30 @@ TEST(ConcentrationSemantics, ScalarTimesPercentYieldsDimensionless)
 
 TEST(ConcentrationSemantics, PercentMathPreservesPercentRepresentation)
 {
-	auto a = 100.0_pct;
-	auto b = 70.0_pct;
+	auto whole = 100.0_pct;
+	auto most  = 70.0_pct;
 
 	// subtraction should preserve the unit: 100% - 70% = 30%
-	auto d = a - b;
-	EXPECT_NEAR(d.raw(), 30.0, 0.0);
+	auto diff = whole - most;
+	EXPECT_NEAR(diff.raw(), 30.0, 0.0);
 
 	// fabs should preserve percent representation: fabs(30%) == 30%
-	auto f = units::fabs(d);
+	auto f = units::fabs(diff);
 	EXPECT_NEAR(f.raw(), 30.0, 0.0);
 
 	// abs should preserve percent representation
-	auto g = units::abs(-30_pct);
-	EXPECT_NEAR(g.raw(), 30.0, 0.0);
+	auto magnitude = units::abs(-30_pct);
+	EXPECT_NEAR(magnitude.raw(), 30.0, 0.0);
 
 	// fmin/fmax should preserve percent representation
-	auto mn = units::fmin(a, b);
+	auto mn = units::fmin(whole, most);
 	EXPECT_NEAR(mn.raw(), 70.0, 0.0);
 
-	auto mx = units::fmax(a, b);
+	auto mx = units::fmax(whole, most);
 	EXPECT_NEAR(mx.raw(), 100.0, 0.0);
 
 	// fdim should preserve percent representation: fdim(70%, 100%) == 0%
-	auto pd = units::fdim(b, a);
+	auto pd = units::fdim(most, whole);
 	EXPECT_NEAR(pd.raw(), 0.0, 0.0);
 }
 
@@ -5592,10 +5592,10 @@ TEST(ConcentrationSemantics, CommonTypePpmPpb)
 	using CT = std::common_type_t<parts_per_million<double>, parts_per_billion<double>>;
 	static_assert(units::traits::is_same_dimension_unit_v<CT, parts_per_million<double>>);
 
-	CT a = 1.0_ppm;
-	CT b = 1000.0_ppb;
-	EXPECT_DOUBLE_EQ(a.raw(), b.raw());
-	EXPECT_DOUBLE_EQ(a.value(), b.value());
+	CT inPpm  = 1.0_ppm;
+	CT inPpb  = 1000.0_ppb;
+	EXPECT_DOUBLE_EQ(inPpm.raw(), inPpb.raw());
+	EXPECT_DOUBLE_EQ(inPpm.value(), inPpb.value());
 }
 
 TEST(ConcentrationSemantics, UnitCastUsesNormalizedForRatioDimless)
@@ -5606,13 +5606,13 @@ TEST(ConcentrationSemantics, UnitCastUsesNormalizedForRatioDimless)
 
 TEST(ConcentrationSemantics, DimensionlessDivPercentIsNotSameAsScalarDivPercent)
 {
-	auto a = 1.0 / 50_pct;                 // scalar/percent -> dimensionless, uses rhs.value()
-	EXPECT_DOUBLE_EQ(a, 2.0);
+	auto scalarQuotient = 1.0 / 50_pct;                 // scalar/percent -> dimensionless, uses rhs.value()
+	EXPECT_DOUBLE_EQ(scalarQuotient, 2.0);
 
-	double b = dimensionless(1.0) / 50_pct;  // currently -> inverse(percent) style
+	double dimensionlessQuotient = dimensionless(1.0) / 50_pct;  // currently -> inverse(percent) style
 	// Nail down expected behavior (whatever you decide it should be).
 	// If keeping current behavior:
-	EXPECT_DOUBLE_EQ(b, 2);     // because 1 / rhs.raw() = 1/50
+	EXPECT_DOUBLE_EQ(dimensionlessQuotient, 2);     // because 1 / rhs.raw() = 1/50
 }
 
 
@@ -5775,13 +5775,13 @@ TEST_F(CaseStudies, selfDefinedUnits)
 	// exponents), not a friendly abbreviation. Volume per time-squared has no named unit.
 	using liters_per_second_squared = decltype(1.0_L / (1.0_s * 1.0_s));
 
-	liters_per_second_squared a(5);
-	liters_per_second_squared b = a;
+	liters_per_second_squared original(5);
+	liters_per_second_squared copy = original;
 
-	EXPECT_DOUBLE_EQ(a.to<double>(), b.to<double>());
+	EXPECT_DOUBLE_EQ(original.to<double>(), copy.to<double>());
 
 	testing::internal::CaptureStdout();
-	std::cout << a;
+	std::cout << original;
 	std::string output = testing::internal::GetCapturedStdout();
 	EXPECT_STREQ("0.005 m^3 s^-2", output.c_str());
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -3353,6 +3353,29 @@ TEST_F(UnitType, dBConversion)
 	EXPECT_NEAR(20.0, b_dbw.value(), 5.0e-7);
 }
 
+TEST_F(UnitType, dimensionlessDecibelLiteral)
+{
+	// the `_dB` literal yields the dimensionless decibel; its stored value is the dB figure
+	auto g = -20.0_dB;
+	static_assert(std::is_same_v<decltype(g), decibels<double>>);
+	EXPECT_DOUBLE_EQ(-20.0, g.raw());
+
+	// the integer literal yields decibels<int>; as with the power dB units, an integral decibel scale
+	// is lossy through the log10 round-trip, so only the type is asserted here
+	auto gi = 3_dB;
+	static_assert(std::is_same_v<decltype(gi), decibels<int>>);
+
+	// name/abbreviation resolve for the dimensionless decibel
+	decibels<double> d(6.0);
+	EXPECT_STREQ("decibels", d.name());
+	EXPECT_STREQ("dB", d.abbreviation());
+
+	// coexists with the power decibel literals (distinct types, distinct suffixes)
+	static_assert(std::is_same_v<decltype(0.0_dBW), dBW<double>>);
+	static_assert(std::is_same_v<decltype(0.0_dBm), dBm<double>>);
+	static_assert(!std::is_same_v<decibels<double>, dBW<double>>);
+}
+
 TEST_F(UnitType, dBAddition)
 {
 	bool isSame;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1066,8 +1066,8 @@ TEST_F(UnitType, implicitChronoConversions)
 
 TEST_F(UnitType, negativeConstexprLiterals)
 {
-	static constexpr radians kAngularValue{-30.0_deg};
-	EXPECT_EQ(-30.0_deg, kAngularValue);
+	static constexpr radians ANGULAR_VALUE{-30.0_deg};
+	EXPECT_EQ(-30.0_deg, ANGULAR_VALUE);
 }
 
 TEST_F(UnitType, assignmentFromArithmeticType)
@@ -3134,6 +3134,22 @@ TEST_F(UnitType, to_string)
 	EXPECT_STREQ("25.1 pct", to_string(c_pct).c_str());
 }
 
+// The platform spellings of the two locales this test needs, and the command that installs them.
+#if defined(_MSC_VER)
+static constexpr const char* GERMAN_LOCALE = "de-DE";
+static constexpr const char* US_LOCALE     = "en-US";
+static constexpr const char* LOCALE_HINT   = "install the German and US locales";
+#elif defined(__APPLE__)
+// BSD libc (macOS) only recognizes the canonical `.UTF-8` spelling, not glibc's `de_DE.utf8` alias.
+static constexpr const char* GERMAN_LOCALE = "de_DE.UTF-8";
+static constexpr const char* US_LOCALE     = "en_US.UTF-8";
+static constexpr const char* LOCALE_HINT   = "install the German and US locales";
+#else
+static constexpr const char* GERMAN_LOCALE = "de_DE.utf8";
+static constexpr const char* US_LOCALE     = "en_US.utf8";
+static constexpr const char* LOCALE_HINT   = "install the German and US locales, e.g. `sudo locale-gen de_DE.UTF-8 en_US.UTF-8`";
+#endif
+
 TEST_F(UnitType, to_string_locale)
 {
 	struct lconv*     lc;
@@ -3141,18 +3157,16 @@ TEST_F(UnitType, to_string_locale)
 	std::stringstream os1;
 	std::stringstream os2;
 
+	// A locale this test needs may not be present on the host; that is an environmental precondition,
+	// not a library defect, so skip (with the install hint) rather than throw from std::locale.
+	if (setlocale(LC_ALL, GERMAN_LOCALE) == nullptr || setlocale(LC_ALL, US_LOCALE) == nullptr)
+	{
+		GTEST_SKIP() << "requires the German and US locales; " << LOCALE_HINT;
+	}
+
 	// German locale
-#if defined(_MSC_VER)
-	setlocale(LC_ALL, "de-DE");
-	os1.imbue(std::locale("de-DE"));
-#elif defined(__APPLE__)
-	// BSD libc (macOS) only recognizes the canonical `.UTF-8` spelling, not glibc's `de_DE.utf8` alias.
-	EXPECT_STREQ("de_DE.UTF-8", setlocale(LC_ALL, "de_DE.UTF-8")) << "For this test to work, you need a german locale installed.";
-	os1.imbue(std::locale("de_DE.UTF-8"));
-#else
-	EXPECT_STREQ("de_DE.utf8", setlocale(LC_ALL, "de_DE.utf8")) << "For this test to work, you need a german locale installed: `sudo locale-gen de_DE.UTF-8`";
-	os1.imbue(std::locale("de_DE.utf8"));
-#endif
+	setlocale(LC_ALL, GERMAN_LOCALE);
+	os1.imbue(std::locale(GERMAN_LOCALE));
 
 	lc            = localeconv();
 	char point_de = *lc->decimal_point;
@@ -3169,17 +3183,8 @@ TEST_F(UnitType, to_string_locale)
 	EXPECT_STREQ("9,2740100783e-24 A m^2", output.c_str());
 
 	// US locale
-#if defined(_MSC_VER)
-	setlocale(LC_ALL, "en-US");
-	os2.imbue(std::locale("en-US"));
-#elif defined(__APPLE__)
-	// BSD libc (macOS) only recognizes the canonical `.UTF-8` spelling, not glibc's `en_US.utf8` alias.
-	EXPECT_STREQ("en_US.UTF-8", setlocale(LC_ALL, "en_US.UTF-8")) << "For this test to work, you need a USA locale installed.";
-	os2.imbue(std::locale("en_US.UTF-8"));
-#else
-	EXPECT_STREQ("en_US.utf8", setlocale(LC_ALL, "en_US.utf8")) << "For this test to work, you need a USA locale installed: `sudo locale-gen en_US.UTF-8`";
-	os2.imbue(std::locale("en_US.utf8"));
-#endif
+	setlocale(LC_ALL, US_LOCALE);
+	os2.imbue(std::locale(US_LOCALE));
 
 	lc            = localeconv();
 	char point_us = *lc->decimal_point;


### PR DESCRIPTION
Issue triage follow-up: the clean, well-scoped fixes and additions surfaced while triaging the open issue backlog, each verified by inspection and tested to the nines. Closes #303, #127, #289, #112, #334, #344.

## Fixes
- **#289 slug ratio** — was `145939029/10000000` (14.5939029 kg), ~2.5 ppb below the exact value. Now the exact rational `8896443230521/609600000000` (both terms within `intmax_t`); the compound units built on slug (force pounds, torque foot_pounds, `slugs_per_cubic_foot`, the psf/ksi pressures) still reduce within `intmax_t`. Test tolerances tightened so they fail with the old ratio.
- **#334 / #344 `_dB` literal + integer-decibel footgun** — the dimensionless `decibels` unit now registers a name/abbreviation and a `_dB` literal (`-20.0_dB`). `data::bytes`/`bits` are spelled out with only the meaningful large decimal (kilo and up) and binary prefixes, dropping the sub-unit prefixes (deci/centi/milli/…) that produced nonsensical fractional-byte units and had claimed `_dB` via `decibytes`. Separately, integer decibels are broadly broken (1/2/3 dB round to 0; 100 dB overflowed to INT_MIN), so a `static_assert` now requires a floating-point underlying type for any decibel-scale unit; the integer decibel literals are dropped.

## Additions
- **#303 named `to<>()`** — `.to<meters>()` converts to a named unit of the same dimension, mirroring `.convert<meters>()`; `.to<double>()` (underlying-type extraction) is unchanged. The named `convert<>()` overload was missing the `const` its siblings carry; now const-callable.
- **#112 volumetric flow rate** — a new `volume_flow_rate = volume / time` derived dimension and header, with `cubic_meters_per_second` (SI), `cubic_meters_per_hour`, `liters_per_second`, `liters_per_minute`, `gallons_per_minute`, `gallons_per_hour`, `cubic_feet_per_second`, `cubic_feet_per_minute`. Because the dimension is derived algebraically, a volume divided by a time IS a `volume_flow_rate`.

## Docs
- README Features note for decibel/logarithmic scale support (stated as a capability, no comparison to any other library); dimension count refreshed 47 → 48.

## Testing
- Full suite 242 tests green on GCC 13/15 and Clang 19/21; warning-clean under `-Wall -Wconversion -Wshadow` (also cleared 10 pre-existing shadow warnings in the test TU).
- The compile-error harness (`test/errorMessages/`) grew 36 → 47 cases: scalar↔dimensioned boundaries, cross-dimension comparison, trig on non-angles, dimensional math results assigned wrong, `fmod` across dimensions, `std::chrono` from a non-time quantity, and integral decibels — each verified to fail to compile with the friendly type named, on both compilers.
- New units each asserted against an authoritative value; flow-rate auto-naming/streaming and `decibels<float>` covered.
