### PR TITLE
Add std::format support (closes #372)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Normalize line endings: store text with LF in the repository, regardless of a contributor's platform or
+# editor. Git detects text automatically; committed content is LF. Working-tree files are left as checked
+# out (no forced re-conversion on checkout), so this is "commit LF, check out as-is".
+* text=auto eol=lf
+
+# Binary assets must never be line-ending normalized.
+*.zip   binary
+*.png   binary
+*.natvis text eol=lf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ OPTION(UNITS_BUILD_TESTS "Build unit tests" ${MAIN_PROJECT})
 OPTION(UNITS_BUILD_DOCS "Build the documentation" OFF)
 OPTION(UNITS_BUILD_EXAMPLES "Build the documentation examples" ${MAIN_PROJECT})
 OPTION(UNITS_DISABLE_IOSTREAM "Disables <iostream> (cout) support for embedded applications" OFF)
+OPTION(UNITS_DISABLE_FORMAT "Disables std::format / std::print support (keeps iostream and to_string)" OFF)
+OPTION(UNITS_DISABLE_STRING "Disables all <string> use (leanest build; implies DISABLE_IOSTREAM and DISABLE_FORMAT)" OFF)
 
 # header-only library target. To use this project as a subdirectory,
 # add the following to your code:
@@ -41,10 +43,19 @@ if(MSVC)
 		$<INSTALL_INTERFACE:${CMAKE_INSTALL_DATADIR}/units/natvis/units.natvis>)
 endif()
 
-# Remove IOStream from the library (useful for embedded development)
+# Text-feature opt-outs (all default OFF = full capability). See the "TEXT-FEATURE CONFIGURATION" block in
+# include/units/core.h for the exact semantics and backward-compatibility guarantees.
 if(UNITS_DISABLE_IOSTREAM)
 	target_compile_definitions(${PROJECT_NAME} INTERFACE UNIT_LIB_DISABLE_IOSTREAM)
 endif(UNITS_DISABLE_IOSTREAM)
+
+if(UNITS_DISABLE_FORMAT)
+	target_compile_definitions(${PROJECT_NAME} INTERFACE UNIT_LIB_DISABLE_FORMAT)
+endif(UNITS_DISABLE_FORMAT)
+
+if(UNITS_DISABLE_STRING)
+	target_compile_definitions(${PROJECT_NAME} INTERFACE UNIT_LIB_DISABLE_STRING)
+endif(UNITS_DISABLE_STRING)
 
 # unit tests
 include(CTest)

--- a/README.md
+++ b/README.md
@@ -426,6 +426,105 @@ Full guide, wire format, error model, and measured compile-time and run-time num
 
 ---
 
+## Formatting with `std::format`
+
+Every quantity works with `std::format`, `std::print`, `std::println`, and `std::format_to` out of the box —
+no extra include beyond `<units.h>` (or the relevant dimension header). With no format-spec you get the same
+text `operator<<` and `to_string()` produce:
+
+```cpp
+#include <format>
+#include <print>
+#include <units.h>
+using namespace units::literals;
+
+std::println("{}", 3.5_m);          // 3.5 m
+std::string s = std::format("{}", 9.81_mps_sq);   // 9.81 m s^-2  (dimension form for an unnamed unit)
+```
+
+### The format grammar
+
+```
+{: value-spec [ % unit-opts ] }
+```
+
+Everything **before** an optional `%` is the *value-spec* and is forwarded verbatim to the underlying
+number's own `std::formatter`, so the entire standard numeric grammar applies (precision, width, fill/align,
+sign, `#`, `0`, `L`, and type). Everything **after** the `%` are *unit-opts* (any order): at most one
+label-form flag, at most one show flag, and an optional quoted separator literal.
+
+| Opt        | Effect |
+|------------|--------|
+| `a`        | the unit's own abbreviated label (default); base-dimension list if the unit is unnamed. Never converts the value. |
+| `n`        | the unit's own full name; base-dimension list if the unit is unnamed. Never converts the value. |
+| `b`        | convert the value **and** label to SI base units (`6 ft` → `1.8288 m`, `2 km` → `2000 m`) |
+| `v`        | value only — suppress the unit label |
+| `u`        | unit only — suppress the value and separator |
+| `'`…`'`    | separator literal between value and label (default is one space); `\t` `\n` `\\` `\'` escapes; `''` is empty |
+
+Only `%b` converts. `%a` and `%n` always show the value exactly as stored, in the unit's own symbol/name —
+there is no lossy "force the dimension symbols onto the stored number" mode, because a unit's identity
+(feet vs meters) is flattened to a single ratio at the type level and cannot be recovered as its own
+dimensional symbols. To normalize to SI, use `%b`.
+
+An invalid spec is a compile error for a literal format string, or a thrown `std::format_error` for a
+runtime (`std::vformat`) string.
+
+### Worked examples
+
+Every row is produced by the actual formatter (the library's docs examples are compiled, so they cannot
+drift from what the code does):
+
+| Format string | Argument | Result |
+|---|---|---|
+| `{}`         | `3.5_m`    | `3.5 m` |
+| `{:.2f}`     | `3.5_m`    | `3.50 m` |
+| `{:.0f}`     | `3.5_m`    | `4 m` |
+| `{:>10.2f}`  | `3.5_m`    | `⟨6 spaces⟩3.50 m` |
+| `{:<10.2f}`  | `3.5_m`    | `3.50⟨7 spaces⟩m` |
+| `{:^10.2f}`  | `3.5_m`    | `⟨3⟩3.50⟨4⟩m` |
+| `{:*>10.2f}` | `3.5_m`    | `******3.50 m` |
+| `{:+.1f}`    | `3.5_m`    | `+3.5 m` |
+| `{: .1f}`    | `3.5_m`    | `␣3.5 m` |
+| `{:e}`       | `3.5_m`    | `3.500000e+00 m` |
+| `{:d}`       | `meters<int>(255)` | `255 m` |
+| `{:#x}`      | `meters<int>(255)` | `0xff m` |
+| `{:#06x}`    | `meters<int>(255)` | `0x00ff m` |
+| `{:b}`       | `meters<int>(255)` | `11111111 m` |
+| `{:%a}`      | `3.5_m`    | `3.5 m` |
+| `{:%a}`      | `6.0_ft`   | `6 ft` (never converts) |
+| `{:%n}`      | `3.5_m`    | `3.5 meters` |
+| `{:%n}`      | `6.0_ft`   | `6 feet` |
+| `{:%b}`      | `6.0_ft`   | `1.8288 m` (converted to SI) |
+| `{:%b}`      | `kilometers<>(2)` | `2000 m` |
+| `{:.4f%b}`   | `10.0_fps` | `3.0480 m s^-1` |
+| `{}`         | `9.81_mps` | `9.81 mps` |
+| `{}`         | `meters<>(6)/(seconds<>(2)*seconds<>(1))` | `3 mps2` |
+| `{:%v}`      | `3.5_m`    | `3.5` |
+| `{:%u}`      | `3.5_m`    | `m` |
+| `{:.2f%v}`   | `3.5_m`    | `3.50` |
+| `{:%a''}`    | `3.5_m`    | `3.5m` |
+| `{:%a'_'}`   | `3.5_m`    | `3.5_m` |
+| `{:%a' - '}` | `3.5_m`    | `3.5 - m` |
+| `{:.2f%n'_'}`| `3.5_m`    | `3.50_meters` |
+
+### Disabling text features
+
+Text support is on by default. It is opt-**out**, via three macros (each also a CMake option, all default
+`OFF`), chosen to preserve backward compatibility for embedded builds:
+
+| Macro / CMake option                              | Effect |
+|---------------------------------------------------|--------|
+| `UNIT_LIB_DISABLE_IOSTREAM` / `UNITS_DISABLE_IOSTREAM` | Drops the stream inserters. For backward compatibility this **also** drops `to_string`, `<string>`, and `std::format` — a legacy iostream-disabled build has always been the lean, string-free build, and stays byte-for-byte that. |
+| `UNIT_LIB_DISABLE_FORMAT` / `UNITS_DISABLE_FORMAT`     | Drops only `std::format` support; iostream and `to_string` remain. |
+| `UNIT_LIB_DISABLE_STRING` / `UNITS_DISABLE_STRING`     | The leanest build: forbids `<string>`, and therefore implies both of the above. |
+
+To keep `std::format` while dropping the iostream inserters, define `UNIT_LIB_DISABLE_IOSTREAM` **and**
+`UNIT_LIB_ENABLE_FORMAT`. `std::format` support additionally requires the standard library to provide
+`<format>`.
+
+---
+
 ## Integration
 
 `units` is header-only.

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -67,14 +67,66 @@
 #include <ratio>
 #include <type_traits>
 #include <utility>
+#include <version>
 
+// ---------------------------------------------------------------------------------------------------------------------
+//	TEXT-FEATURE CONFIGURATION (opt-out; full capability is the default)
+// ---------------------------------------------------------------------------------------------------------------------
+// Out of the box every text feature is ON: stream inserters, to_string, and std::format (where <format> is
+// available). Consumers opt OUT with the DISABLE_ macros. The ENABLE_* macros are derived internal switches
+// — do not define them directly, with the single exception of UNIT_LIB_ENABLE_FORMAT (the documented opt-in
+// that restores std::format under UNIT_LIB_DISABLE_IOSTREAM).
+//
+//   UNIT_LIB_DISABLE_IOSTREAM  Drops the stream inserters. For BACKWARD COMPATIBILITY this also drops
+//                              to_string, <string>, and std::format: a legacy iostream-disabled build has
+//                              always been the lean, string-free build, and stays byte-for-byte that. To
+//                              keep std::format while dropping streams, ALSO define UNIT_LIB_ENABLE_FORMAT.
+//   UNIT_LIB_DISABLE_FORMAT    Drops only std::format support; iostream and to_string remain.
+//   UNIT_LIB_DISABLE_STRING    The leanest build: forbids <string>, and therefore implies both of the above.
+//
+// std::format support additionally requires the standard library to provide <format> (__cpp_lib_format).
+
+#if defined(UNIT_LIB_DISABLE_STRING)
 #if !defined(UNIT_LIB_DISABLE_IOSTREAM)
-#include <clocale>
-#include <sstream>
+#define UNIT_LIB_DISABLE_IOSTREAM
+#endif
+#if !defined(UNIT_LIB_DISABLE_FORMAT)
+#define UNIT_LIB_DISABLE_FORMAT
+#endif
+#endif
+
+// std::format: on by default when <format> exists; off if explicitly disabled or if string is disabled; off
+// alongside iostream UNLESS the caller opts back in with UNIT_LIB_ENABLE_FORMAT.
+#if !defined(UNIT_LIB_DISABLE_FORMAT) && !defined(UNIT_LIB_DISABLE_STRING) && defined(__cpp_lib_format) && __cpp_lib_format >= 201907L &&                       \
+    (!defined(UNIT_LIB_DISABLE_IOSTREAM) || defined(UNIT_LIB_ENABLE_FORMAT))
+#if !defined(UNIT_LIB_ENABLE_FORMAT)
+#define UNIT_LIB_ENABLE_FORMAT
+#endif
+#else
+// If format cannot be enabled, ensure a stray UNIT_LIB_ENABLE_FORMAT does not leak through.
+#undef UNIT_LIB_ENABLE_FORMAT
+#endif
+
+// The value stringifier + unit-label builders (and <string>) exist whenever any text feature — the stream
+// inserters or std::format — is compiled in.
+#if !defined(UNIT_LIB_DISABLE_STRING) && (!defined(UNIT_LIB_DISABLE_IOSTREAM) || defined(UNIT_LIB_ENABLE_FORMAT))
+#define UNIT_LIB_ENABLE_STRING
+#endif
+
+#if defined(UNIT_LIB_ENABLE_STRING)
 #include <string>
+#endif
+
+#if defined(UNIT_LIB_ENABLE_FORMAT)
+#include <format>
+#include <string_view>
+#endif
+
+#if defined(UNIT_LIB_ENABLE_STRING)
+#include <clocale>
 
 //------------------------------
-//	STRING FORMATTER
+//	VALUE STRINGIFIER
 //------------------------------
 
 namespace units::detail
@@ -103,7 +155,11 @@ namespace units::detail
 	}
 } // namespace units::detail
 
-#endif // !defined(UNIT_LIB_DISABLE_IOSTREAM)
+#endif // UNIT_LIB_ENABLE_STRING
+
+#if !defined(UNIT_LIB_DISABLE_IOSTREAM)
+#include <sstream>
+#endif
 
 //------------------------------
 //	FORWARD DECLARATIONS
@@ -2930,6 +2986,169 @@ namespace units
 		return UnitType(value);
 	}
 
+	//-----------------------------------------
+	//	UNIT-LABEL STRING BUILDERS
+	//-----------------------------------------
+
+#if defined(UNIT_LIB_ENABLE_STRING)
+
+	namespace detail
+	{
+		//----------------------------------------------------------------------------------------------------------------------
+		//      FUNCTION: dimension_to_string [static]
+		//----------------------------------------------------------------------------------------------------------------------
+		/// @brief      Renders a single dimension term (base dimension + exponent) as text.
+		/// @tparam     D    the base dimension (supplies `D::abbreviation`).
+		/// @tparam     E    the exponent, a `std::ratio` (`E::num`/`E::den`).
+		/// @return     the term as `" <abbrev>"`, plus `"^num"` when the exponent is not 1 and `"/den"`
+		///             when the denominator is not 1 — matching the ostream inserter's format, including
+		///             its leading space per term.
+		//----------------------------------------------------------------------------------------------------------------------
+		template<class D, class E>
+		std::string dimension_to_string(const dim<D, E>&)
+		{
+			std::string s;
+			if constexpr (E::num != 0)
+			{
+				s.append(" ").append(D::abbreviation);
+			}
+			if constexpr (E::num != 0 && E::num != 1)
+			{
+				s.append("^").append(std::to_string(E::num));
+			}
+			if constexpr (E::den != 1)
+			{
+				s.append("/").append(std::to_string(E::den));
+			}
+			return s;
+		}
+
+		//----------------------------------------------------------------------------------------------------------------------
+		//      FUNCTION: dimension_to_string [static]
+		//----------------------------------------------------------------------------------------------------------------------
+		/// @brief      Renders a full dimension list as text by concatenating each term.
+		/// @tparam     Dims    the dimension terms of the list.
+		/// @return     the concatenation of each term's `dimension_to_string`, e.g. `" m s^-2"`.
+		//----------------------------------------------------------------------------------------------------------------------
+		template<class... Dims>
+		std::string dimension_to_string(const dimension_t<Dims...>&)
+		{
+			std::string s;
+			((s.append(dimension_to_string(Dims{}))), ...);
+			return s;
+		}
+
+		//----------------------------------------------------------------------------------------------------------------------
+		//      FUNCTION: unit_label [static]
+		//----------------------------------------------------------------------------------------------------------------------
+		/// @brief      Builds the unit-label suffix for a unit — the text that follows its numeric value.
+		/// @details    Resolves the named form of the unit first, so a named unit yields its abbreviation
+		///             (`meters_per_second` → `"mps"`); an unnamed compound unit yields its dimension list
+		///             (`" m s^-2"`). The value itself is NOT included. Depends only on `<string>`, so it
+		///             is available whether or not iostream support is compiled in.
+		/// @tparam     ConversionFactor    the unit's conversion factor.
+		/// @tparam     T                   the unit's underlying arithmetic type.
+		/// @tparam     NumericalScale      the unit's numerical scale.
+		/// @return     the label, either `" <abbrev>"` (with a leading space) for a named unit, or the
+		///             dimension-list text (also leading-space-prefixed per term) for an unnamed unit; empty
+		///             for a dimensionless unnamed unit.
+		//----------------------------------------------------------------------------------------------------------------------
+		/// The form a unit label may take.
+		/// @details	`abbreviation` and `name` render the unit's OWN symbol/name and never convert the value;
+		///				for an unnamed compound they fall back to the base-dimension list (which is honest,
+		///				since an unnamed unit carries no conversion of its own). `base` is the SI base form —
+		///				the base-dimension list — and its VALUE must be converted to base SI to stay honest,
+		///				because the type system flattens a named unit's identity into a single ratio and cannot
+		///				recover a non-SI factor's own symbols (e.g. `feet_per_second` cannot render as
+		///				`ft s^-1`; only `m s^-1` against the base-converted value is correct).
+		enum class label_form
+		{
+			abbreviation,    ///< the unit's own abbreviation (`"m"`, `"ft"`), the default; base-dimension list if unnamed.
+			name,            ///< the unit's own full name (`"meters"`, `"feet"`); base-dimension list if unnamed.
+			base             ///< the SI base-dimension list (`" m s^-1"`); pairs with a base-converted value.
+		};
+
+		template<label_form Form = label_form::abbreviation, ConversionFactorType ConversionFactor, ArithmeticType T, NumericalScaleType<T> NumericalScale>
+		std::string unit_label(const unit<ConversionFactor, T, NumericalScale>&)
+		{
+			// The name/abbreviation traits are specialized on the NAMED class, not the plain unit<...> base,
+			// so resolve the named form first and query THAT (a named unit prints its name/abbreviation).
+			using NamedForm = detail::rewrap_to_named_t<unit<ConversionFactor, T, NumericalScale>>;
+			using DimType   = traits::dimension_of_t<ConversionFactor>;
+
+			if constexpr (Form == label_form::base)
+			{
+				// SI base-dimension list, regardless of the unit's own name (the caller base-converts the value).
+				if constexpr (!DimType::empty)
+					return dimension_to_string(DimType{});
+				else
+					return std::string{};
+			}
+			else if constexpr (Form == label_form::name && unit_name_v<NamedForm>)
+			{
+				return std::string(" ").append(unit_name<NamedForm>::value);
+			}
+			else if constexpr (unit_abbreviation_v<NamedForm>)
+			{
+				return std::string(" ").append(unit_abbreviation<NamedForm>::value);
+			}
+			else
+			{
+				// Unnamed unit: its honest label IS the base-dimension list (no own symbol exists).
+				if constexpr (!DimType::empty)
+					return dimension_to_string(DimType{});
+				else
+					return std::string{};
+			}
+		}
+
+		//----------------------------------------------------------------------------------------------------------------------
+		//      FUNCTION: label_uses_base_unit [static]
+		//----------------------------------------------------------------------------------------------------------------------
+		/// @brief      Whether a unit's label is its dimension list rather than a named abbreviation.
+		/// @details    An unnamed unit is rendered in its BASE unit (its value must be converted to the base
+		///             before the dimension label applies); a named unit prints its value as-is. This
+		///             predicate lets the value-rendering paths decide whether to convert to the base unit.
+		/// @tparam     ConversionFactor    the unit's conversion factor.
+		/// @tparam     T                   the unit's underlying arithmetic type.
+		/// @tparam     NumericalScale      the unit's numerical scale.
+		/// @return     `true` when the unit is unnamed (dimension-labelled), `false` when it is named.
+		//----------------------------------------------------------------------------------------------------------------------
+		template<ConversionFactorType ConversionFactor, ArithmeticType T, NumericalScaleType<T> NumericalScale>
+		inline constexpr bool label_uses_base_unit()
+		{
+			using NamedForm = detail::rewrap_to_named_t<unit<ConversionFactor, T, NumericalScale>>;
+			return !static_cast<bool>(unit_abbreviation_v<NamedForm>);
+		}
+	}    // namespace detail
+
+#endif // UNIT_LIB_ENABLE_STRING
+
+#if defined(UNIT_LIB_ENABLE_FORMAT)
+
+	//-----------------------------------------
+	//	std::format SUPPORT
+	//-----------------------------------------
+
+	namespace detail
+	{
+		//----------------------------------------------------------------------------------------------------------------------
+		//      STRUCT: unit_format_options
+		//----------------------------------------------------------------------------------------------------------------------
+		/// @brief      The parsed unit-opts portion of a unit format-spec (see the `std::formatter` below).
+		//----------------------------------------------------------------------------------------------------------------------
+		struct unit_format_options
+		{
+			label_form  form      = label_form::abbreviation;    ///< which label form was requested
+			bool        showValue = true;                        ///< emit the numeric value
+			bool        showUnit  = true;                        ///< emit the unit label
+			bool        customSep = false;                       ///< a separator literal was supplied
+			std::string separator = " ";                         ///< separator between value and label
+		};
+	}    // namespace detail
+
+#endif    // UNIT_LIB_ENABLE_FORMAT
+
 #if !defined(UNIT_LIB_DISABLE_IOSTREAM)
 
 	//-----------------------------------------
@@ -2971,21 +3190,15 @@ namespace units
 		// its abbreviation instead of the dimension form.
 		using NamedForm = detail::rewrap_to_named_t<unit<ConversionFactor, T, NumericalScale>>;
 
-		std::locale loc;
 		if constexpr (unit_abbreviation_v<NamedForm>)
 		{
-			os << obj.raw() << " " << unit_abbreviation<NamedForm>::value;
+			os << obj.raw();
 		}
 		else
 		{
 			os << std::conditional_t<detail::is_losslessly_convertible_unit<std::decay_t<decltype(obj)>, BaseUnit>, BaseUnit, PromotedBaseUnit>(obj).raw();
-
-			using DimType = traits::dimension_of_t<ConversionFactor>;
-			if constexpr (!DimType::empty)
-			{
-				os << DimType{};
-			}
 		}
+		os << detail::unit_label(obj);
 
 		return os;
 	}
@@ -3006,27 +3219,14 @@ namespace units
 		// (feet<double>) then still prints its abbreviation ("ft") instead of falling to the dimension path.
 		using NamedForm = detail::rewrap_to_named_t<unit<ConversionFactor, T, NumericalScale>>;
 
+		std::string s;
 		if constexpr (unit_abbreviation_v<NamedForm>)
-		{
-			std::string s = detail::to_string(obj.raw());
-			s.append(" ").append(unit_abbreviation<NamedForm>::value);
-			return s;
-		}
+			s = detail::to_string(obj.raw());
 		else
-		{
-			std::string s = detail::to_string(std::conditional_t<detail::is_losslessly_convertible_unit<std::decay_t<decltype(obj)>, BaseUnit>, BaseUnit, PromotedBaseUnit>(obj).raw());
+			s = detail::to_string(std::conditional_t<detail::is_losslessly_convertible_unit<std::decay_t<decltype(obj)>, BaseUnit>, BaseUnit, PromotedBaseUnit>(obj).raw());
 
-			using DimType = traits::dimension_of_t<ConversionFactor>;
-			if constexpr (!DimType::empty)
-			{
-				// a dimension list has no string form, only an ostream inserter; render it through a stream (as operator<<
-				// does). The inserter already emits its own leading space per term, so none is added here.
-				std::ostringstream dim;
-				dim << DimType{};
-				s.append(dim.str());
-			}
-			return s;
-		}
+		s.append(detail::unit_label(obj));
+		return s;
 	}
 #endif
 
@@ -5204,6 +5404,276 @@ namespace units
 	template<typename T, typename Cf = dimension::dimensionless, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
 	unit(T) -> unit<Cf, T>;
 } // namespace units
+
+//----------------------------------------------------------------------------------------------------------------------
+//  std::format SUPPORT
+//----------------------------------------------------------------------------------------------------------------------
+
+#if defined(UNIT_LIB_ENABLE_FORMAT)
+
+//----------------------------------------------------------------------------------------------------------------------
+//      CLASS: std::formatter<units::unit<...>, char>
+//----------------------------------------------------------------------------------------------------------------------
+/// @brief      Formats a `units::unit` for `std::format`, `std::print`, `std::println`, and `std::format_to`,
+///             with a units-aware mini-language.
+/// @details    The value-spec (everything before an optional `%`) is delegated to the underlying arithmetic
+///             type's `std::formatter`, so the full standard numeric grammar is supported (precision, width,
+///             fill/align, sign, `#`, `0`, `L`, type, …). The unit-opts (after `%`) control the label form,
+///             whether the value/unit are shown, and the separator. This support needs only `<format>`, not
+///             iostream, so it is available even under `UNIT_LIB_DISABLE_IOSTREAM`.
+///
+///             Grammar: `{:` value-spec [ `%` unit-opts ] `}`, where unit-opts are, in any order:
+///               - `a` own abbreviated label (default), `n` own full-name label — neither converts the value
+///               - `b` convert the value and label to SI base units (`6 ft` → `1.8288 m`)
+///               - `v` value only, `u` unit only
+///               - `'`…`'` a separator literal between value and label (`''` none, `'_'`, `'\t'`, …)
+/// @tparam     U    any unit type — the `unit<...>` template itself OR a named unit derived from it
+///                  (e.g. `meters<double>`), matched through the `units::UnitType` concept so a named unit
+///                  formats the same as its `unit<...>` base.
+//----------------------------------------------------------------------------------------------------------------------
+template<units::UnitType U>
+struct std::formatter<U, char>
+{
+	using conversion_factor   = typename units::traits::unit_traits<U>::conversion_factor;
+	using value_type          = typename units::traits::unit_traits<U>::underlying_type;
+	using scale_type          = typename units::traits::unit_traits<U>::numerical_scale_type;
+	using promoted_value_type = units::detail::floating_point_promotion_t<value_type>;
+
+	// A named unit prints its stored value as-is, so its value formatter is the underlying type — integer
+	// specs (d/x/b/…) then work for an integer-underlying unit. An unnamed unit is rendered in its base
+	// unit, a conversion that is floating-point, so its value formatter is the promoted type.
+	static constexpr bool renders_in_base_unit = units::detail::label_uses_base_unit<conversion_factor, value_type, scale_type>();
+	using formatted_value_type                  = std::conditional_t<renders_in_base_unit, promoted_value_type, value_type>;
+
+	// The %b flag base-converts a NAMED unit's value to SI, which is a floating-point result; it is emitted
+	// through a promoted-type formatter. (For an unnamed unit the primary formatter is already promoted.)
+	std::formatter<formatted_value_type, char> m_valueFormatter;        ///< delegate for the stored-value portion
+	std::formatter<promoted_value_type, char>  m_baseFormatter;         ///< delegate for the %b base-converted value
+	units::detail::unit_format_options         m_options;               ///< the parsed unit-opts
+	bool                                       m_usesBaseFormatter = false;    ///< value-spec was parsed into m_baseFormatter (%b)
+
+	//----------------------------------------------------------------------------------------------------------------------
+	//      FUNCTION: parse [public]
+	//----------------------------------------------------------------------------------------------------------------------
+	/// @brief      Parses the format-spec: the value-spec is forwarded to the value formatter, then the
+	///             unit-opts after `%` are decoded.
+	/// @param[in,out]	ctx		the parse context, positioned at the start of the spec.
+	/// @return     an iterator past the consumed spec (at the closing `}`).
+	//----------------------------------------------------------------------------------------------------------------------
+	constexpr auto parse(std::format_parse_context& ctx)
+	{
+		auto it  = ctx.begin();
+		auto end = ctx.end();
+
+		// The value-spec runs to the first '%' (or to the closing '}').
+		auto valueSpecEnd = it;
+		for (auto scan = it; scan != end && *scan != '}'; ++scan)
+		{
+			if (*scan == '%')
+				break;
+			valueSpecEnd = scan + 1;
+		}
+
+		// The %b flag (base-SI conversion) needs the promoted-type formatter; every other flag uses the
+		// stored-type formatter. Determine which is in play by scanning the unit-opts for 'b' before
+		// delegating the value-spec, so the value-spec is parsed into exactly the formatter that will emit
+		// it (parsing an integer spec such as `d` into a floating-point formatter would wrongly reject it).
+		m_usesBaseFormatter = false;
+		for (auto scan = valueSpecEnd; scan != end && *scan != '}'; ++scan)
+		{
+			if (*scan == 'b')
+			{
+				m_usesBaseFormatter = true;
+				break;
+			}
+		}
+
+		// Delegate the value-spec to the chosen value formatter. Present it a parse context spanning only
+		// the value-spec and require it consumed the whole thing.
+		if (valueSpecEnd != it)
+		{
+			std::string_view valueSpec(it, valueSpecEnd);
+			if (m_usesBaseFormatter)
+			{
+				std::format_parse_context baseCtx(valueSpec);
+				if (m_baseFormatter.parse(baseCtx) != valueSpec.end())
+					throw std::format_error("units: invalid value format-spec");
+			}
+			else
+			{
+				std::format_parse_context valueCtx(valueSpec);
+				if (m_valueFormatter.parse(valueCtx) != valueSpec.end())
+					throw std::format_error("units: invalid value format-spec");
+			}
+		}
+
+		it = valueSpecEnd;
+
+		// Unit-opts after '%'.
+		if (it != end && *it == '%')
+		{
+			++it;
+			bool sawForm = false;
+			bool sawShow = false;
+			while (it != end && *it != '}')
+			{
+				const char c = *it;
+				if (c == 'a' || c == 'n' || c == 'b')
+				{
+					if (sawForm)
+						throw std::format_error("units: duplicate label-form flag");
+					sawForm        = true;
+					m_options.form = (c == 'a') ? units::detail::label_form::abbreviation
+					    : (c == 'n')            ? units::detail::label_form::name
+					                            : units::detail::label_form::base;
+					++it;
+				}
+				else if (c == 'v' || c == 'u')
+				{
+					if (sawShow)
+						throw std::format_error("units: duplicate show flag");
+					sawShow             = true;
+					m_options.showValue = (c == 'v');
+					m_options.showUnit  = (c == 'u');
+					++it;
+				}
+				else if (c == '\'')
+				{
+					++it;    // opening quote
+					std::string sep;
+					bool        closed = false;
+					while (it != end && *it != '}')
+					{
+						if (*it == '\\')
+						{
+							++it;
+							if (it == end || *it == '}')
+								throw std::format_error("units: dangling escape in separator");
+							switch (*it)
+							{
+								case 't': sep.push_back('\t'); break;
+								case 'n': sep.push_back('\n'); break;
+								case '\\': sep.push_back('\\'); break;
+								case '\'': sep.push_back('\''); break;
+								default: sep.push_back(*it); break;
+							}
+							++it;
+						}
+						else if (*it == '\'')
+						{
+							closed = true;
+							++it;    // closing quote
+							break;
+						}
+						else
+						{
+							sep.push_back(*it);
+							++it;
+						}
+					}
+					if (!closed)
+						throw std::format_error("units: unterminated separator literal");
+					m_options.separator = std::move(sep);
+					m_options.customSep = true;
+				}
+				else
+				{
+					throw std::format_error("units: unknown unit-format flag");
+				}
+			}
+		}
+
+		return it;
+	}
+
+	//----------------------------------------------------------------------------------------------------------------------
+	//      FUNCTION: format [public]
+	//----------------------------------------------------------------------------------------------------------------------
+	/// @brief      Renders the unit: the numeric value (via the delegated value formatter) then the unit
+	///             label, honoring the parsed show flags, label form, and separator.
+	/// @param[in]	obj		the unit to format.
+	/// @param[in,out]	ctx		the format context / output iterator.
+	/// @return     the output iterator past the written characters.
+	//----------------------------------------------------------------------------------------------------------------------
+	template<class FormatContext>
+	auto format(const U& obj, FormatContext& ctx) const
+	{
+		using base_unit_type = units::unit<units::conversion_factor<std::ratio<1>, typename conversion_factor::dimension_type>, promoted_value_type, scale_type>;
+
+		// The value: an unnamed unit is always rendered in its base unit (its honest label is the
+		// base-dimension list); the %b flag likewise base-converts a named unit's value so the base-SI
+		// label is honest. Otherwise a named unit shows its stored value as-is (so integer specs work).
+		formatted_value_type value{};
+		promoted_value_type  baseValue{};
+		if constexpr (renders_in_base_unit)
+			value = base_unit_type(obj).raw();
+		else
+			value = static_cast<formatted_value_type>(obj.raw());
+		if (m_options.form == units::detail::label_form::base)
+			baseValue = base_unit_type(obj).raw();
+
+		std::string label;
+		if (m_options.showUnit)
+		{
+			switch (m_options.form)
+			{
+				case units::detail::label_form::name: label = units::detail::unit_label<units::detail::label_form::name>(obj); break;
+				case units::detail::label_form::base: label = units::detail::unit_label<units::detail::label_form::base>(obj); break;
+				case units::detail::label_form::abbreviation:
+				default: label = units::detail::unit_label<units::detail::label_form::abbreviation>(obj); break;
+			}
+		}
+
+		auto out = ctx.out();
+
+		if (m_options.showValue)
+		{
+			if (m_usesBaseFormatter)
+			{
+				// %b: emit the base-SI value through the promoted-type formatter. For an unnamed unit the
+				// value is already the promoted base value; for a named unit it is the base-converted one.
+				const promoted_value_type emitted = renders_in_base_unit ? static_cast<promoted_value_type>(value) : baseValue;
+				out                               = m_baseFormatter.format(emitted, ctx);
+			}
+			else
+			{
+				out = m_valueFormatter.format(value, ctx);
+			}
+		}
+
+		if (m_options.showUnit && !label.empty())
+		{
+			// The core builders prefix a label with a single space (the default separator). Keep it when no
+			// separator was overridden and a value precedes the label; otherwise strip it and, for a shown
+			// value, emit the chosen separator.
+			std::string_view labelView(label);
+			const bool       hasLeadingSpace = !labelView.empty() && labelView.front() == ' ';
+
+			if (m_options.showValue)
+			{
+				if (m_options.customSep)
+				{
+					if (hasLeadingSpace)
+						labelView.remove_prefix(1);
+					for (char ch : m_options.separator)
+						*out++ = ch;
+				}
+			}
+			else
+			{
+				if (hasLeadingSpace)
+					labelView.remove_prefix(1);
+			}
+
+			for (char ch : labelView)
+				*out++ = ch;
+		}
+
+		return out;
+	}
+};
+
+#endif    // UNIT_LIB_ENABLE_FORMAT
 
 //----------------------------------------------------------------------------------------------------------------------
 //  JSON SUPPORT

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,25 @@ ENDIF ()
 
 ADD_TEST(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
 
+# ---------------------------------------------------------------------------------------------------------------------
+# Lean-configuration compile-and-run guards.
+#
+# Each text-feature opt-out is proven to still build (and the core math to still run) as its own tiny target. This is
+# the backward-compatibility guard for the embedded audience: the lean builds must never silently break.
+# ---------------------------------------------------------------------------------------------------------------------
+function(units_add_lean_config name)
+	add_executable(${name} leanConfig.cpp)
+	target_link_libraries(${name} units)
+	target_compile_features(${name} PRIVATE cxx_std_23)
+	target_compile_definitions(${name} PRIVATE ${ARGN})
+	add_test(NAME ${name} COMMAND ${name})
+endfunction()
+
+units_add_lean_config(leanDisableIostream            UNIT_LIB_DISABLE_IOSTREAM)
+units_add_lean_config(leanDisableFormat              UNIT_LIB_DISABLE_FORMAT)
+units_add_lean_config(leanDisableString              UNIT_LIB_DISABLE_STRING)
+units_add_lean_config(leanFormatWithoutIostream      UNIT_LIB_DISABLE_IOSTREAM UNIT_LIB_ENABLE_FORMAT UNIT_LIB_ENABLE_FORMAT_EXPECTED)
+
 # use gtags if present on the system to populate the vscode intellisense
 find_program(GTAGS name gtags HINTS /usr/local/bin DOC "Path to gtags parser")
 if (GTAGS)

--- a/test/errorMessages/cases/format_duplicate_flag.cpp
+++ b/test/errorMessages/cases/format_duplicate_flag.cpp
@@ -1,6 +1,9 @@
 // Case: a duplicated label-form flag ('%aa') in a LITERAL std::format spec is a compile error.
 // expect: fail
-// expect-match: units: duplicate label-form flag
+// GCC/clang surface the thrown string; MSVC reports only C7595 for the consteval rejection. The message
+// text is asserted portably at run time via EXPECT_THROW + what() in test/main.cpp.
+// expect-match-gcc: units: duplicate label-form flag
+// expect-match-msvc: C7595
 #include <format>
 #include <units.h>
 using namespace units::literals;

--- a/test/errorMessages/cases/format_duplicate_flag.cpp
+++ b/test/errorMessages/cases/format_duplicate_flag.cpp
@@ -1,0 +1,11 @@
+// Case: a duplicated label-form flag ('%aa') in a LITERAL std::format spec is a compile error.
+// expect: fail
+// expect-match: units: duplicate label-form flag
+#include <format>
+#include <units.h>
+using namespace units::literals;
+int main()
+{
+	(void)std::format("{:%aa}", 1.0_m);
+	return 0;
+}

--- a/test/errorMessages/cases/format_duplicate_show_flag.cpp
+++ b/test/errorMessages/cases/format_duplicate_show_flag.cpp
@@ -1,0 +1,11 @@
+// Case: a duplicated show flag ('%vu') in a LITERAL std::format spec is a compile error.
+// expect: fail
+// expect-match: units: duplicate show flag
+#include <format>
+#include <units.h>
+using namespace units::literals;
+int main()
+{
+	(void)std::format("{:%vu}", 1.0_m);
+	return 0;
+}

--- a/test/errorMessages/cases/format_duplicate_show_flag.cpp
+++ b/test/errorMessages/cases/format_duplicate_show_flag.cpp
@@ -1,6 +1,9 @@
 // Case: a duplicated show flag ('%vu') in a LITERAL std::format spec is a compile error.
 // expect: fail
-// expect-match: units: duplicate show flag
+// GCC/clang surface the thrown string; MSVC reports only C7595 for the consteval rejection. The message
+// text is asserted portably at run time via EXPECT_THROW + what() in test/main.cpp.
+// expect-match-gcc: units: duplicate show flag
+// expect-match-msvc: C7595
 #include <format>
 #include <units.h>
 using namespace units::literals;

--- a/test/errorMessages/cases/format_good_spec_compiles.cpp
+++ b/test/errorMessages/cases/format_good_spec_compiles.cpp
@@ -1,0 +1,18 @@
+// Case: a well-formed value-spec + unit-opts spec compiles clean (the positive control for the format grammar).
+// expect: pass
+#include <format>
+#include <string>
+#include <units.h>
+using namespace units::literals;
+int main()
+{
+	std::string a = std::format("{:.2f%n}", 6.0_ft);   // precision + full-name label
+	std::string b = std::format("{:>10.1f%a'_'}", 3.5_m); // width/align + abbreviation + separator
+	std::string c = std::format("{:%v}", 9.81_mps);    // value only
+	std::string d = std::format("{:%b}", 9.81_mps);    // base-SI conversion
+	(void)a;
+	(void)b;
+	(void)c;
+	(void)d;
+	return 0;
+}

--- a/test/errorMessages/cases/format_int_presentation_compiles.cpp
+++ b/test/errorMessages/cases/format_int_presentation_compiles.cpp
@@ -1,0 +1,19 @@
+// Case: integer presentation types on an integer-underlying named unit compile clean — the value formatter
+// delegate is the underlying integer type, so the standard int grammar (x/#06x/b/d) passes through.
+// expect: pass
+#include <format>
+#include <string>
+#include <units.h>
+int main()
+{
+	const units::meters<int> mi(255);
+	std::string a = std::format("{:x}", mi);
+	std::string b = std::format("{:#06x}", mi);
+	std::string c = std::format("{:b}", mi);
+	std::string d = std::format("{:d%v}", mi);
+	(void)a;
+	(void)b;
+	(void)c;
+	(void)d;
+	return 0;
+}

--- a/test/errorMessages/cases/format_unknown_flag.cpp
+++ b/test/errorMessages/cases/format_unknown_flag.cpp
@@ -1,0 +1,12 @@
+// Case: an unknown unit-format flag in a LITERAL std::format spec is a compile error (the consteval
+// basic_format_string check runs the formatter's parse(), which throws std::format_error).
+// expect: fail
+// expect-match: units: unknown unit-format flag
+#include <format>
+#include <units.h>
+using namespace units::literals;
+int main()
+{
+	(void)std::format("{:%z}", 1.0_m);
+	return 0;
+}

--- a/test/errorMessages/cases/format_unknown_flag.cpp
+++ b/test/errorMessages/cases/format_unknown_flag.cpp
@@ -1,7 +1,11 @@
 // Case: an unknown unit-format flag in a LITERAL std::format spec is a compile error (the consteval
 // basic_format_string check runs the formatter's parse(), which throws std::format_error).
 // expect: fail
-// expect-match: units: unknown unit-format flag
+// GCC/clang surface the thrown std::format_error string; MSVC reports only C7595 (call to immediate
+// function is not a constant expression) for the same consteval rejection. The exact message text is also
+// asserted portably at run time via EXPECT_THROW + what() in test/main.cpp.
+// expect-match-gcc: units: unknown unit-format flag
+// expect-match-msvc: C7595
 #include <format>
 #include <units.h>
 using namespace units::literals;

--- a/test/errorMessages/cases/format_unterminated_separator.cpp
+++ b/test/errorMessages/cases/format_unterminated_separator.cpp
@@ -1,6 +1,9 @@
 // Case: an unterminated separator literal ('%a'foo) in a LITERAL std::format spec is a compile error.
 // expect: fail
-// expect-match: units: unterminated separator literal
+// GCC/clang surface the thrown string; MSVC reports only C7595 for the consteval rejection. The message
+// text is asserted portably at run time via EXPECT_THROW + what() in test/main.cpp.
+// expect-match-gcc: units: unterminated separator literal
+// expect-match-msvc: C7595
 #include <format>
 #include <units.h>
 using namespace units::literals;

--- a/test/errorMessages/cases/format_unterminated_separator.cpp
+++ b/test/errorMessages/cases/format_unterminated_separator.cpp
@@ -1,0 +1,11 @@
+// Case: an unterminated separator literal ('%a'foo) in a LITERAL std::format spec is a compile error.
+// expect: fail
+// expect-match: units: unterminated separator literal
+#include <format>
+#include <units.h>
+using namespace units::literals;
+int main()
+{
+	(void)std::format("{:%a'foo}", 1.0_m);
+	return 0;
+}

--- a/test/errorMessages/run.py
+++ b/test/errorMessages/run.py
@@ -26,11 +26,22 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 
 def parse_directives(text):
-    d = {"expect_fail": False, "expect_match": [], "forbid_match": [], "flags": [], "flags_msvc": []}
+    d = {"expect_fail": False, "expect_match": [], "expect_match_gcc": [], "expect_match_msvc": [],
+         "forbid_match": [], "flags": [], "flags_msvc": []}
     for line in text.splitlines():
         m = re.search(r'//\s*expect:\s*(\w+)', line)
         if m:
             d["expect_fail"] = (m.group(1).lower() == "fail")
+        # Compiler-specific readable-token expectations. The exact diagnostic differs by compiler: GCC/clang
+        # surface a thrown std::format_error's string in the message, while MSVC reports only C7595 ("call to
+        # immediate function is not a constant expression") for the same consteval rejection. `expect-match:`
+        # applies to every compiler; `expect-match-gcc:` / `expect-match-msvc:` apply only to that compiler.
+        m = re.search(r'//\s*expect-match-gcc:\s*(.+?)\s*$', line)
+        if m:
+            d["expect_match_gcc"].append(m.group(1))
+        m = re.search(r'//\s*expect-match-msvc:\s*(.+?)\s*$', line)
+        if m:
+            d["expect_match_msvc"].append(m.group(1))
         m = re.search(r'//\s*expect-match:\s*(.+?)\s*$', line)
         if m:
             d["expect_match"].append(m.group(1))
@@ -83,8 +94,13 @@ def run_case(path, cc, std, include):
         problems.append("expected compile FAILURE but it compiled")
     if not d["expect_fail"] and not compiled:
         problems.append("expected compile SUCCESS but it FAILED")
-    # Match against the whitespace/keyword-normalized diagnostic so tokens are compiler-portable.
-    for sub in d["expect_match"]:
+    # Match against the whitespace/keyword-normalized diagnostic so tokens are compiler-portable. The
+    # generic expect-match applies to every compiler; the per-compiler sets add tokens only for the compiler
+    # in use (a diagnostic that a compiler simply does not emit — e.g. MSVC not surfacing a thrown
+    # std::format_error string — is asserted against that compiler's own form instead).
+    expected = list(d["expect_match"])
+    expected += d["expect_match_msvc"] if is_msvc(cc) else d["expect_match_gcc"]
+    for sub in expected:
         if normalize(sub) not in norm:
             problems.append(f"missing readable token: {sub!r}")
     for sub in d["forbid_match"]:

--- a/test/leanConfig.cpp
+++ b/test/leanConfig.cpp
@@ -1,0 +1,65 @@
+//--------------------------------------------------------------------------------------------------
+//
+//	UnitConversion: A compile-time c++23 unit conversion library with no dependencies
+//
+//--------------------------------------------------------------------------------------------------
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+// and associated documentation files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//--------------------------------------------------------------------------------------------------
+//
+// Copyright (c) 2016 Nic Holthaus
+//
+//--------------------------------------------------------------------------------------------------
+//
+/// @file	test/leanConfig.cpp
+/// @brief	Compile-and-run proof that the text-feature opt-out configurations still build.
+/// @details	Each lean configuration (UNIT_LIB_DISABLE_IOSTREAM / _FORMAT / _STRING, and the
+///			DISABLE_IOSTREAM + ENABLE_FORMAT opt-in) compiles this translation unit as a separate CTest
+///			target. The core dimensional math must always work; text features are exercised only when the
+///			active configuration compiles them in. This is the backward-compatibility guard: a lean build
+///			the embedded audience pins must never silently break.
+//
+//--------------------------------------------------------------------------------------------------
+
+#include <units.h>
+
+#if defined(UNIT_LIB_ENABLE_FORMAT_EXPECTED)
+#include <format>
+#include <string>
+#endif
+
+using namespace units::literals;
+
+int main()
+{
+	// Core dimensional arithmetic must compile and run in every configuration.
+	const auto sum      = 6.0_m + 3.0_m;
+	const auto velocity = 10.0_m / 2.0_s;
+	const auto area     = 4.0_m * 5.0_m;
+
+	bool ok = (sum.value() > 0.0) && (velocity.value() > 0.0) && (area.value() > 0.0);
+
+#if defined(UNIT_LIB_ENABLE_FORMAT_EXPECTED)
+	// When this config is expected to provide std::format, prove it renders.
+	const std::string s = std::format("{:.2f}", 3.5_m);
+	ok                  = ok && (s == "3.50 m");
+#endif
+
+	return ok ? 0 : 1;
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -12,10 +12,12 @@
 #include <compare>
 #include <complex>
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <gtest/gtest.h>
 #include <iomanip>
 #include <iostream>
+#include <iterator>
 #include <locale>
 #include <ratio>
 #include <sstream>
@@ -7052,6 +7054,423 @@ TEST_F(Serialization, typedFastPathPropagatesDecodeError)
 	const auto             r = units::deserialize<units::meters<double>>(garbage);
 	EXPECT_FALSE(r.has_value());
 	EXPECT_EQ(units::deserialize_error::bad_version, r.error());
+}
+
+//======================================================================================================================
+//  std::format SUPPORT
+//======================================================================================================================
+//
+// These exercise the units-aware std::formatter specialization: value-spec passthrough to the underlying arithmetic
+// type's formatter, the unit-opts mini-language after '%', the label forms, the show flags, separators, the byte-
+// identical cross-check against to_string/operator<<, the full public API surface, and every runtime throw path.
+
+namespace
+{
+	// Render a unit through operator<< into a string, for the byte-identical cross-check against std::format("{}").
+	template<class T>
+	std::string ostreamString(const T& value)
+	{
+		std::ostringstream os;
+		os << value;
+		return os.str();
+	}
+} // namespace
+
+//-----------------------------
+//  DEFAULT: {} == to_string == operator<<
+//-----------------------------
+
+// The default spec "{}" must be byte-identical to units::to_string AND to an operator<< ostringstream for a named
+// unit — this three-way equality is the anchor invariant of the whole feature.
+TEST(Format, defaultMatchesToStringAndOstreamNamed)
+{
+	const auto m = 3.5_m;
+	EXPECT_EQ(std::format("{}", m), "3.5 m");
+	EXPECT_EQ(std::format("{}", m), units::to_string(m));
+	EXPECT_EQ(std::format("{}", m), ostreamString(m));
+
+	const auto ft = 6.0_ft;
+	EXPECT_EQ(std::format("{}", ft), "6 ft");
+	EXPECT_EQ(std::format("{}", ft), units::to_string(ft));
+	EXPECT_EQ(std::format("{}", ft), ostreamString(ft));
+}
+
+// The same three-way equality for a percent (named dimensionless) unit: it prints its abbreviation "pct", NOT "%".
+TEST(Format, defaultMatchesToStringAndOstreamPercent)
+{
+	const auto p = units::percent<double>(50);
+	EXPECT_EQ(std::format("{}", p), "50 pct");
+	EXPECT_EQ(std::format("{}", p), units::to_string(p));
+	EXPECT_EQ(std::format("{}", p), ostreamString(p));
+}
+
+// A genuinely unnamed compound unit (ampere*meter has no named form) prints in dimension-list form; the three-way
+// equality still holds, and the value is the base-unit value.
+TEST(Format, defaultMatchesToStringAndOstreamUnnamedCompound)
+{
+	const auto am = units::amperes<double>(3) * units::meters<double>(2);
+	EXPECT_EQ(std::format("{}", am), "6 A m");
+	EXPECT_EQ(std::format("{}", am), units::to_string(am));
+	EXPECT_EQ(std::format("{}", am), ostreamString(am));
+}
+
+// A named acceleration compound (meters/second^2 == "mps2") reduces to its NAMED abbreviation, not a dimension list.
+TEST(Format, defaultMatchesToStringAndOstreamNamedCompound)
+{
+	const auto accel = units::meters<double>(6) / (units::seconds<double>(2) * units::seconds<double>(1));
+	EXPECT_EQ(std::format("{}", accel), "3 mps2");
+	EXPECT_EQ(std::format("{}", accel), units::to_string(accel));
+	EXPECT_EQ(std::format("{}", accel), ostreamString(accel));
+}
+
+// An integer-underlying named unit: the value formatter is the underlying int type, so the default renders the int
+// as-is; still byte-identical to to_string and operator<<.
+TEST(Format, defaultMatchesToStringAndOstreamIntUnderlying)
+{
+	const units::meters<int> mi(42);
+	EXPECT_EQ(std::format("{}", mi), "42 m");
+	EXPECT_EQ(std::format("{}", mi), units::to_string(mi));
+	EXPECT_EQ(std::format("{}", mi), ostreamString(mi));
+}
+
+// A unit needing floating-point promotion (float underlying) matches across all three sinks.
+TEST(Format, defaultMatchesToStringAndOstreamFloatUnderlying)
+{
+	const units::meters<float> mf(3.5f);
+	EXPECT_EQ(std::format("{}", mf), "3.5 m");
+	EXPECT_EQ(std::format("{}", mf), units::to_string(mf));
+	EXPECT_EQ(std::format("{}", mf), ostreamString(mf));
+}
+
+//-----------------------------
+//  VALUE-SPEC PASSTHROUGH (float/double delegate)
+//-----------------------------
+
+// Precision variants reach the NUMBER and the unit label still appends.
+TEST(Format, precisionReachesValueLabelAppends)
+{
+	EXPECT_EQ(std::format("{:.0f}", 3.5_m), "4 m"); // banker's-agnostic: 3.5 -> "4" at .0f (round-half-to-even)
+	EXPECT_EQ(std::format("{:.2f}", 3.5_m), "3.50 m");
+	EXPECT_EQ(std::format("{:.5f}", 3.5_m), "3.50000 m");
+}
+
+// Width pads the numeric field; the unit label is appended after the padded value.
+TEST(Format, widthPadsValueThenLabel)
+{
+	EXPECT_EQ(std::format("{:8.2f}", 3.5_m), "    3.50 m");
+	EXPECT_EQ(std::format("{:>10.2f}", 3.5_m), "      3.50 m");
+}
+
+// Fill + alignment (left/right/center) apply to the numeric field only.
+TEST(Format, fillAndAlignApplyToValue)
+{
+	EXPECT_EQ(std::format("{:*>10.1f}", 3.5_m), "*******3.5 m");
+	EXPECT_EQ(std::format("{:_^12}", 3.5_m), "____3.5_____ m");
+	EXPECT_EQ(std::format("{:<8.1f}", 3.5_m), "3.5      m");
+}
+
+// Sign controls '+' and space-for-positive on the value.
+TEST(Format, signControls)
+{
+	EXPECT_EQ(std::format("{:+.1f}", 3.5_m), "+3.5 m");
+	EXPECT_EQ(std::format("{: }", 3.5_m), " 3.5 m");
+	EXPECT_EQ(std::format("{:+.1f}", units::meters<double>(-3.5)), "-3.5 m");
+}
+
+// Zero-fill pads the numeric field with leading zeros, still appending the label.
+TEST(Format, zeroFillValue)
+{
+	EXPECT_EQ(std::format("{:08.2f}", 3.5_m), "00003.50 m");
+}
+
+// Integer presentation types (x/#06x/b/d) work when the underlying type is an integer named unit — the value
+// formatter delegate is the underlying int in that case, so the standard int grammar passes through.
+TEST(Format, integerPresentationTypesOnIntUnit)
+{
+	const units::meters<int> mi(255);
+	EXPECT_EQ(std::format("{:x}", mi), "ff m");
+	EXPECT_EQ(std::format("{:#06x}", mi), "0x00ff m");
+	EXPECT_EQ(std::format("{:b}", mi), "11111111 m");
+	EXPECT_EQ(std::format("{:d}", mi), "255 m");
+	// combined with a show flag
+	EXPECT_EQ(std::format("{:x%v}", mi), "ff");
+	EXPECT_EQ(std::format("{:x%u}", mi), "m");
+}
+
+//-----------------------------
+//  LABEL FORMS: %a %n %b
+//-----------------------------
+
+// %a is explicitly the abbreviation form and equals the default.
+TEST(Format, abbreviationFlagEqualsDefault)
+{
+	EXPECT_EQ(std::format("{:%a}", 3.5_m), std::format("{}", 3.5_m));
+	EXPECT_EQ(std::format("{:%a}", 3.5_m), "3.5 m");
+	EXPECT_EQ(std::format("{:.2f%a}", 3.5_m), std::format("{:.2f}", 3.5_m));
+}
+
+// %n emits the full unit name for a named unit.
+TEST(Format, nameFlagFullName)
+{
+	EXPECT_EQ(std::format("{:%n}", 3.5_m), "3.5 meters");
+	EXPECT_EQ(std::format("{:.3f%n}", 6.0_ft), "6.000 feet");
+	EXPECT_EQ(std::format("{:%n}", units::kilometers<double>(2)), "2 kilometers");
+	EXPECT_EQ(std::format("{:%n}", units::degrees<double>(90)), "90 degrees");
+}
+
+// %b converts BOTH the value and the label to SI base units.
+TEST(Format, baseFlagConvertsToBaseSI)
+{
+	// A non-base named unit is converted: 6 ft = 1.8288 m.
+	EXPECT_EQ(std::format("{:%b}", 6.0_ft), "1.8288 m");
+	EXPECT_EQ(std::format("{:%b}", units::kilometers<double>(2)), "2000 m");
+	// A named compound already expressed in base units is unchanged in value; its label decomposes.
+	EXPECT_EQ(std::format("{:%b}", 9.81_mps), "9.81 m s^-1");
+	// An already-base unit is unchanged.
+	EXPECT_EQ(std::format("{:%b}", 3.5_m), "3.5 m");
+	// The value-spec still applies to the (converted) number.
+	EXPECT_EQ(std::format("{:.4f%b}", 10.0_fps), "3.0480 m s^-1");
+}
+
+// %a and %n never convert the value — they render the unit's OWN symbol/name.
+TEST(Format, abbreviationAndNameNeverConvert)
+{
+	EXPECT_EQ(std::format("{:%a}", 6.0_ft), "6 ft");
+	EXPECT_EQ(std::format("{:%n}", 6.0_ft), "6 feet");
+	EXPECT_EQ(std::format("{:%a}", 10.0_fps), "10 fps");
+	EXPECT_EQ(std::format("{:%a}", units::kilometers<double>(2)), "2 km");
+}
+
+// %b on an already-unnamed unit yields the same base-symbol form as the default label (the value is
+// already in base units, so nothing changes).
+TEST(Format, baseFlagOnUnnamedUnit)
+{
+	const auto am = units::amperes<double>(3) * units::meters<double>(2);
+	EXPECT_EQ(std::format("{:%b}", am), "6 A m");
+	EXPECT_EQ(std::format("{:%b}", am), std::format("{}", am));
+}
+
+// %n on an unnamed compound falls back to the base-symbol form (there is no full name to print).
+TEST(Format, nameFlagOnUnnamedFallsBackToDimension)
+{
+	const auto am = units::amperes<double>(3) * units::meters<double>(2);
+	EXPECT_EQ(std::format("{:%n}", am), "6 A m");
+	EXPECT_EQ(std::format("{:%n}", am), std::format("{:%a}", am));
+}
+
+//-----------------------------
+//  SHOW FLAGS: %v (value only) %u (unit only)
+//-----------------------------
+
+// %v suppresses the unit label and its separator — value only, no trailing space.
+TEST(Format, showValueOnly)
+{
+	EXPECT_EQ(std::format("{:%v}", 3.5_m), "3.5");
+	EXPECT_EQ(std::format("{:.2f%v}", 3.5_m), "3.50");
+	EXPECT_EQ(std::format("{:*>10.1f%v}", 3.5_m), "*******3.5");
+}
+
+// %u suppresses the value AND the separator — unit label only, no leading space.
+TEST(Format, showUnitOnly)
+{
+	EXPECT_EQ(std::format("{:%u}", 3.5_m), "m");
+	EXPECT_EQ(std::format("{:%u}", 6.0_ft), "ft");
+	// a value-spec is harmlessly parsed but the value is not emitted under %u.
+	EXPECT_EQ(std::format("{:.2f%u}", 3.5_m), "m");
+	// the full name under unit-only.
+	EXPECT_EQ(std::format("{:%nu}", 3.5_m), "meters");
+	// the base-SI form under unit-only (no leading space).
+	EXPECT_EQ(std::format("{:%bu}", 9.81_mps), "m s^-1");
+}
+
+// %v / %u on an integer-underlying named unit.
+TEST(Format, showFlagsIntUnderlying)
+{
+	const units::meters<int> mi(42);
+	EXPECT_EQ(std::format("{:%v}", mi), "42");
+	EXPECT_EQ(std::format("{:%u}", mi), "m");
+}
+
+// %u never emits a separator regardless of a supplied separator literal.
+TEST(Format, unitOnlyIgnoresSeparator)
+{
+	EXPECT_EQ(std::format("{:%u'_'}", 3.5_m), "m");
+	EXPECT_EQ(std::format("{:%u''}", 3.5_m), "m");
+	EXPECT_EQ(std::format("{:%'_'u}", 3.5_m), "m");
+}
+
+//-----------------------------
+//  SEPARATORS
+//-----------------------------
+
+// The default separator (no quotes) is a single space.
+TEST(Format, defaultSeparatorIsSingleSpace)
+{
+	EXPECT_EQ(std::format("{:%a}", 3.5_m), "3.5 m");
+	EXPECT_EQ(std::format("{}", 3.5_m), "3.5 m");
+}
+
+// An empty separator '' glues value and label together.
+TEST(Format, emptySeparator)
+{
+	EXPECT_EQ(std::format("{:%a''}", 3.5_m), "3.5m");
+	EXPECT_EQ(std::format("{:.2f%a''}", 3.5_m), "3.50m");
+}
+
+// A single-character separator literal.
+TEST(Format, underscoreSeparator)
+{
+	EXPECT_EQ(std::format("{:%a'_'}", 3.5_m), "3.5_m");
+}
+
+// Escape sequences inside the separator: tab, newline, backslash, quote.
+TEST(Format, escapeSeparators)
+{
+	EXPECT_EQ(std::format("{:%a'\t'}", 3.5_m), "3.5\tm");
+	EXPECT_EQ(std::format("{:%a'\n'}", 3.5_m), "3.5\nm");
+	EXPECT_EQ(std::format("{:%a'\\\\'}", 3.5_m), "3.5\\m");
+	EXPECT_EQ(std::format("{:%a'\\''}", 3.5_m), "3.5'm");
+}
+
+// A multi-character separator literal.
+TEST(Format, multiCharacterSeparator)
+{
+	EXPECT_EQ(std::format("{:%a' - '}", 3.5_m), "3.5 - m");
+}
+
+// A separator combined with the name form.
+TEST(Format, separatorWithNameForm)
+{
+	EXPECT_EQ(std::format("{:%n'_'}", 3.5_m), "3.5_meters");
+}
+
+//-----------------------------
+//  FLAG-ORDER INDEPENDENCE
+//-----------------------------
+
+// Form-then-separator and separator-then-form parse identically.
+TEST(Format, formSeparatorOrderIndependent)
+{
+	EXPECT_EQ(std::format("{:%n'_'}", 3.5_m), std::format("{:%'_'n}", 3.5_m));
+	EXPECT_EQ(std::format("{:%'_'n}", 3.5_m), "3.5_meters");
+}
+
+// Show-then-form and form-then-show parse identically (each category may appear once).
+TEST(Format, showFormOrderIndependent)
+{
+	EXPECT_EQ(std::format("{:%va}", 3.5_m), std::format("{:%av}", 3.5_m));
+	EXPECT_EQ(std::format("{:%va}", 3.5_m), "3.5");
+	EXPECT_EQ(std::format("{:%ua}", 3.5_m), std::format("{:%au}", 3.5_m));
+	EXPECT_EQ(std::format("{:%ua}", 3.5_m), "m");
+}
+
+//-----------------------------
+//  API SURFACE
+//-----------------------------
+
+// std::format_to into a back_inserter produces the same text as std::format.
+TEST(Format, formatToBackInserter)
+{
+	std::string out;
+	std::format_to(std::back_inserter(out), "{:.2f%n}", 3.5_m);
+	EXPECT_EQ(out, "3.50 meters");
+	EXPECT_EQ(out, std::format("{:.2f%n}", 3.5_m));
+}
+
+// std::vformat with make_format_args honors a runtime spec.
+TEST(Format, vformatRuntimeSpec)
+{
+	const auto  m    = 3.5_m;
+	std::string spec = "{:%u}";
+	EXPECT_EQ(std::vformat(spec, std::make_format_args(m)), "m");
+	spec = "{:.2f%n}";
+	EXPECT_EQ(std::vformat(spec, std::make_format_args(m)), "3.50 meters");
+}
+
+//-----------------------------
+//  MANY UNIT TYPES / UNDERLYING TYPES
+//-----------------------------
+
+// A spread of unit types and underlying arithmetic types all format sensibly.
+TEST(Format, manyUnitTypes)
+{
+	EXPECT_EQ(std::format("{}", units::meters<double>(1.5)), "1.5 m");
+	EXPECT_EQ(std::format("{}", units::feet<double>(2.0)), "2 ft");
+	EXPECT_EQ(std::format("{}", units::kilometers<double>(3.0)), "3 km");
+	EXPECT_EQ(std::format("{}", units::degrees<double>(45.0)), "45 deg");
+	EXPECT_EQ(std::format("{}", units::seconds<double>(10.0)), "10 s");
+	EXPECT_EQ(std::format("{}", 9.81_mps), "9.81 mps");
+	EXPECT_EQ(std::format("{}", units::percent<double>(25.0)), "25 pct");
+
+	// vary the underlying type on the same dimension.
+	EXPECT_EQ(std::format("{}", units::meters<int>(7)), "7 m");
+	EXPECT_EQ(std::format("{}", units::meters<float>(7.25f)), "7.25 m");
+	EXPECT_EQ(std::format("{}", units::meters<long>(7L)), "7 m");
+}
+
+//======================================================================================================================
+//  std::format ERROR PATHS
+//======================================================================================================================
+//
+// Every throw the parser can raise, one message per case, driven through std::vformat so the (runtime) format string
+// reaches parse() and the std::format_error escapes to the caller. A LITERAL bad spec is a compile error instead —
+// those live under test/errorMessages/cases/format_*.cpp.
+
+// An unknown unit-format flag throws.
+TEST(Format, throwsOnUnknownFlag)
+{
+	const auto m = 3.5_m;
+	EXPECT_THROW((void)std::vformat("{:%z}", std::make_format_args(m)), std::format_error);
+}
+
+// A duplicated label-form flag throws.
+TEST(Format, throwsOnDuplicateLabelForm)
+{
+	const auto m = 3.5_m;
+	EXPECT_THROW((void)std::vformat("{:%aa}", std::make_format_args(m)), std::format_error);
+	EXPECT_THROW((void)std::vformat("{:%an}", std::make_format_args(m)), std::format_error);
+	EXPECT_THROW((void)std::vformat("{:%ba}", std::make_format_args(m)), std::format_error);
+}
+
+// A duplicated show flag throws.
+TEST(Format, throwsOnDuplicateShowFlag)
+{
+	const auto m = 3.5_m;
+	EXPECT_THROW((void)std::vformat("{:%vv}", std::make_format_args(m)), std::format_error);
+	EXPECT_THROW((void)std::vformat("{:%vu}", std::make_format_args(m)), std::format_error);
+	EXPECT_THROW((void)std::vformat("{:%uv}", std::make_format_args(m)), std::format_error);
+}
+
+// An unterminated separator literal throws.
+TEST(Format, throwsOnUnterminatedSeparator)
+{
+	const auto m = 3.5_m;
+	EXPECT_THROW((void)std::vformat("{:%a'foo}", std::make_format_args(m)), std::format_error);
+}
+
+// A dangling escape at the end of a separator throws.
+TEST(Format, throwsOnDanglingEscape)
+{
+	const auto m = 3.5_m;
+	EXPECT_THROW((void)std::vformat("{:%a'\\}", std::make_format_args(m)), std::format_error);
+}
+
+// A value-spec the underlying value formatter rejects throws.
+TEST(Format, throwsOnInvalidValueSpec)
+{
+	const auto m = 3.5_m;
+	EXPECT_THROW((void)std::vformat("{:Zf}", std::make_format_args(m)), std::format_error);
+}
+
+// A float presentation type on an integer-underlying unit's value formatter throws (the delegate is the int
+// formatter, which rejects '.2f'); an int presentation type on a floating-point delegate likewise throws.
+TEST(Format, throwsOnMismatchedValueTypeSpec)
+{
+	const units::meters<int> mi(3);
+	EXPECT_THROW((void)std::vformat("{:.2f}", std::make_format_args(mi)), std::format_error);
+
+	const units::meters<double> md(3.5);
+	EXPECT_THROW((void)std::vformat("{:x}", std::make_format_args(md)), std::format_error);
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
## `std::format` support for units

Closes #372.

Every quantity now works with `std::format`, `std::print`, `std::println`, and `std::format_to` out of the box — no include beyond `<units.h>`. With no spec, output matches `operator<<`/`to_string`.

### Grammar: `{: value-spec [ % unit-opts ] }`

The **value-spec** (before an optional `%`) forwards verbatim to the underlying number's own `std::formatter`, so the full standard numeric grammar applies (precision, width, fill/align, sign, `#`, `0`, `L`, and presentation type — including integer types on integer-underlying units).

The **unit-opts** (after `%`, any order):

| Opt | Effect |
|---|---|
| `a` | the unit's own abbreviation (default); base-dimension list if unnamed. Never converts. |
| `n` | the unit's own full name; base-dimension list if unnamed. Never converts. |
| `b` | convert the value **and** label to SI base units (`6 ft` → `1.8288 m`) |
| `v` | value only |
| `u` | unit only |
| `'`…`'` | separator literal (default one space; `''` empty; `\t` `\n` `\\` `\'` escapes) |

Only `%b` converts. `%a`/`%n` always show the stored value in the unit's own symbol/name — there is deliberately no "force base symbols onto the stored number" mode, because a unit's identity (feet vs meters) is flattened to a single ratio at the type level and cannot be recovered as its own dimensional symbols. Normalize to SI with `%b`.

### Worked examples

| Format | Argument | Result |
|---|---|---|
| `{}` | `3.5_m` | `3.5 m` |
| `{:.2f}` | `3.5_m` | `3.50 m` |
| `{:>10.2f}` | `3.5_m` | `      3.50 m` |
| `{:#06x}` | `meters<int>(255)` | `0x00ff m` |
| `{:%n}` | `6.0_ft` | `6 feet` |
| `{:%b}` | `6.0_ft` | `1.8288 m` |
| `{:.4f%b}` | `10.0_fps` | `3.0480 m s^-1` |
| `{:%v}` | `3.5_m` | `3.5` |
| `{:%u}` | `3.5_m` | `m` |
| `{:%a'_'}` | `3.5_m` | `3.5_m` |

### Design notes
- Lives in `units/core.h`, needs only `<format>` (not iostream). The unit-label text is built by iostream-free helpers shared with `operator<<`/`to_string` (one source of truth).
- Text features are **opt-out, full capability by default**, via three macros / CMake options with backward-compatible semantics: `UNIT_LIB_DISABLE_IOSTREAM` (unchanged: also drops string+format, staying byte-for-byte the legacy lean build; `UNIT_LIB_ENABLE_FORMAT` keeps format without streams), `UNIT_LIB_DISABLE_FORMAT`, `UNIT_LIB_DISABLE_STRING` (leanest).
- Adds `.gitattributes` (`text=auto eol=lf`) so line-ending churn cannot recur.

### Verification (g++, C++23)
- Full suite **367/367**
- `Format*` runtime tests **40/40** (default == `to_string`/`operator<<`; value-spec passthrough incl. integer types; every flag + separator; `%b` conversion; `std::format`/`format_to`/`vformat`; error-path throws)
- errorMessages compile-diagnostic harness **66/66** (6 new format cases)
- Lean-config compile-and-run guards **4/4** (each disable macro still builds)
