### PR TITLE
Fix fma and a cluster of unit-math correctness bugs (closes #373)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,34 @@ That is enough for most use cases. How `meters a(5.0)` deduces its type and why 
 `units::` prefix are covered in [CTAD and ADL](docs/explain/ctad-and-adl-for-humans.md); the full
 walkthrough is in [Getting started](docs/learn/getting-started.md).
 
+### Temperatures and other affine units
+
+A few units are **affine**: they carry a datum offset, not just a scale. Degrees Celsius and Fahrenheit
+are the common examples — `0 °C` is `273.15 K`, not `0 K`. An affine quantity is an absolute **point** on a
+scale, and a *difference* of two points is a **delta** (an amount of temperature, with no datum). The
+library keeps this distinction quiet — you write ordinary arithmetic and it does the physically correct
+thing — but the rules are worth knowing:
+
+```cpp
+using namespace units::temperature;
+
+// point − point → a delta (the datum offsets cancel):
+auto d = celsius<double>(100.0) - fahrenheit<double>(32.0);   // 100 K  (a temperature difference)
+kelvin<double>(celsius<double>(0.0) - kelvin<double>(0.0));   // 273.15 K
+
+// point ± delta → move the point (compound assignment reads the rhs as a relative amount):
+celsius<double> t(20.0);
+t += celsius<double>(5.0);   // warm by 5 degrees → 25 °C   (still an absolute temperature)
+t -= celsius<double>(10.0);  // cool by 10 degrees → 15 °C
+
+// point + point is disabled — the sum of two absolute temperatures has no physical meaning:
+// auto bad = celsius<double>(20.0) + celsius<double>(5.0);   // does not compile (by design)
+```
+
+Comparisons (`==`, `<`, …) and conversions between affine units are exact and always available. Non-affine
+units (lengths, masses, everything without an offset) are unaffected — they add, subtract, and combine with
+no special cases.
+
 ---
 
 ## Type errors

--- a/include/units/angle.h
+++ b/include/units/angle.h
@@ -131,7 +131,7 @@ namespace units
 	radians<detail::floating_point_promotion_t<typename dimensionlessUnit::underlying_type>> acos(const dimensionlessUnit x) noexcept
 	{
 		return radians<detail::floating_point_promotion_t<typename dimensionlessUnit::underlying_type>>(
-			std::acos(x.template to<typename dimensionlessUnit::underlying_type>()));
+			std::acos(x.template to<detail::floating_point_promotion_t<typename dimensionlessUnit::underlying_type>>()));
 	}
 
 	/**
@@ -145,7 +145,7 @@ namespace units
 	radians<detail::floating_point_promotion_t<typename dimensionlessUnit::underlying_type>> asin(const dimensionlessUnit x) noexcept
 	{
 		return radians<detail::floating_point_promotion_t<typename dimensionlessUnit::underlying_type>>(
-			std::asin(x.template to<typename dimensionlessUnit::underlying_type>()));
+			std::asin(x.template to<detail::floating_point_promotion_t<typename dimensionlessUnit::underlying_type>>()));
 	}
 
 	/**
@@ -163,7 +163,7 @@ namespace units
 	radians<detail::floating_point_promotion_t<typename dimensionlessUnit::underlying_type>> atan(const dimensionlessUnit x) noexcept
 	{
 		return radians<detail::floating_point_promotion_t<typename dimensionlessUnit::underlying_type>>(
-			std::atan(x.template to<typename dimensionlessUnit::underlying_type>()));
+			std::atan(x.template to<detail::floating_point_promotion_t<typename dimensionlessUnit::underlying_type>>()));
 	}
 
 	/**
@@ -249,7 +249,7 @@ namespace units
 	dimensionless<detail::floating_point_promotion_t<typename dimensionlessUnit::underlying_type>> acosh(const dimensionlessUnit x) noexcept
 	{
 		return dimensionless<detail::floating_point_promotion_t<typename dimensionlessUnit::underlying_type>>(
-			std::acosh(x.template to<typename dimensionlessUnit::underlying_type>()));
+			std::acosh(x.template to<detail::floating_point_promotion_t<typename dimensionlessUnit::underlying_type>>()));
 	}
 
 	/**
@@ -264,7 +264,7 @@ namespace units
 	dimensionless<detail::floating_point_promotion_t<typename dimensionlessUnit::underlying_type>> asinh(const dimensionlessUnit x) noexcept
 	{
 		return dimensionless<detail::floating_point_promotion_t<typename dimensionlessUnit::underlying_type>>(
-			std::asinh(x.template to<typename dimensionlessUnit::underlying_type>()));
+			std::asinh(x.template to<detail::floating_point_promotion_t<typename dimensionlessUnit::underlying_type>>()));
 	}
 
 	/**
@@ -280,7 +280,7 @@ namespace units
 	dimensionless<detail::floating_point_promotion_t<typename dimensionlessUnit::underlying_type>> atanh(const dimensionlessUnit x) noexcept
 	{
 		return dimensionless<detail::floating_point_promotion_t<typename dimensionlessUnit::underlying_type>>(
-			std::atanh(x.template to<typename dimensionlessUnit::underlying_type>()));
+			std::atanh(x.template to<detail::floating_point_promotion_t<typename dimensionlessUnit::underlying_type>>()));
 	}
 } // namespace units
 

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -1930,6 +1930,16 @@ namespace units
 
 		template<ConversionFactorType Cf1, ConversionFactorType Cf2>
 		inline constexpr bool is_same_dimension_conversion_factor_v = is_same_dimension_conversion_factor<Cf1, Cf2>::value;
+
+		/**
+		 * @brief		`true` when a conversion factor carries a non-zero datum offset — i.e. it is AFFINE, not
+		 *				a pure scale (the archetype is temperature: degrees Celsius/Fahrenheit have an offset to
+		 *				the Kelvin datum). Absolute affine quantities do not add meaningfully, and their
+		 *				difference is a pure delta (the offsets cancel).
+		 * @tparam		Cf	the conversion factor to test.
+		 */
+		template<ConversionFactorType Cf>
+		inline constexpr bool is_affine_conversion_factor_v = !std::ratio_equal_v<typename conversion_factor_traits<Cf>::translation_ratio, std::ratio<0>>;
 	} // namespace traits
 
 	//------------------------------
@@ -2125,21 +2135,25 @@ namespace units
 		// PI REQUIRED, no translation
 		else if constexpr (!std::same_as<std::ratio<0>, PiRatio> && std::same_as<std::ratio<0>, Translation>)
 		{
-			using CommonUnderlying             = std::common_type_t<To, From, UNIT_LIB_DEFAULT_TYPE>;
-			constexpr long double PiRatioValue = PiRatio::num / PiRatio::den;
+			using CommonUnderlying = std::common_type_t<To, From, UNIT_LIB_DEFAULT_TYPE>;
+			// The pi exponent as a real number. Compute in long double: PiRatio::num/PiRatio::den are
+			// intmax_t, so an integer division here would truncate a fractional exponent (e.g. ratio<1,2>
+			// -> 0), which both corrupts the value and, for the fractional case, produced a non-constant
+			// expression / missing-return compile error.
+			constexpr long double PiRatioValue      = static_cast<long double>(PiRatio::num) / static_cast<long double>(PiRatio::den);
+			constexpr bool        integerExponent   = (PiRatio::num % PiRatio::den == 0);
 
-			// constexpr pi in numerator
-			if constexpr (PiRatioValue >= 1 && PiRatio::num % PiRatio::den == 0)
+			// A whole-number exponent uses the constexpr integer `pow`; a fractional exponent needs
+			// `std::pow` (not constant-evaluable), so that sole case degrades to a run-time computation.
+			if constexpr (integerExponent && PiRatioValue >= 0)
 			{
 				return static_cast<To>(normal_convert(static_cast<CommonUnderlying>(value) * static_cast<CommonUnderlying>(pow(detail::PI_VAL, PiRatioValue))));
 			}
-			// constexpr pi in denominator
-			else if constexpr (PiRatioValue <= -1 && PiRatio::num % PiRatio::den == 0)
+			else if constexpr (integerExponent)    // PiRatioValue < 0
 			{
 				return static_cast<To>(normal_convert(static_cast<CommonUnderlying>(value) / static_cast<CommonUnderlying>(pow(detail::PI_VAL, -PiRatioValue))));
 			}
-			// non-constexpr pi in numerator. This case (only) isn't actually constexpr.
-			else if constexpr (PiRatioValue < 1 && PiRatio::num / PiRatioValue > -1)
+			else    // fractional exponent (either sign): std::pow handles both directions
 			{
 				return static_cast<To>(normal_convert(static_cast<CommonUnderlying>(value) * static_cast<CommonUnderlying>(std::pow(detail::PI_VAL, PiRatioValue))));
 			}
@@ -2276,6 +2290,12 @@ namespace units
 
 	namespace traits
 	{
+		/// `true` when a unit type is affine — its conversion factor carries a non-zero datum offset (e.g. a
+		/// temperature in degrees Celsius/Fahrenheit). Absolute affine quantities do not add meaningfully;
+		/// their difference is a pure delta.
+		template<UnitType U>
+		inline constexpr bool is_affine_unit_v = is_affine_conversion_factor_v<typename unit_traits<U>::conversion_factor>;
+
 		/**
 		 * @ingroup		TypeTraits
 		 * @brief		`BinaryTypeTrait` for querying whether `U1` and `U2` are units of the same dimension.
@@ -3326,9 +3346,23 @@ namespace units
 	/** @endcond */ // END DOXYGEN IGNORE
 
 	template<UnitType UnitTypeLhs>
+		requires(!traits::is_affine_unit_v<UnitTypeLhs>)
 	constexpr UnitTypeLhs& operator+=(UnitTypeLhs& lhs, const detail::type_identity_t<UnitTypeLhs>& rhs) noexcept
 	{
 		lhs = lhs + rhs;
+		return lhs;
+	}
+
+	/// Compound addition for AFFINE units (e.g. temperatures). The lhs is an absolute point; the rhs is
+	/// interpreted as a RELATIVE delta and the point is moved in place by that magnitude, staying in the lhs
+	/// unit (celsius(20) += celsius(5) -> celsius(25), i.e. "warm by 5 degrees"). The rhs's datum offset is
+	/// intentionally not applied — only its magnitude in the lhs unit matters for a delta. (Binary `a + b`
+	/// of two absolute affine points is disabled; use `+=` to move a point by a relative amount.)
+	template<UnitType UnitTypeLhs>
+		requires(traits::is_affine_unit_v<UnitTypeLhs>)
+	constexpr UnitTypeLhs& operator+=(UnitTypeLhs& lhs, const detail::type_identity_t<UnitTypeLhs>& rhs) noexcept
+	{
+		lhs = UnitTypeLhs(lhs.raw() + rhs.raw());
 		return lhs;
 	}
 
@@ -3398,9 +3432,23 @@ namespace units
 	}
 
 	template<UnitType UnitTypeLhs>
+		requires(!traits::is_affine_unit_v<UnitTypeLhs>)
 	constexpr UnitTypeLhs& operator-=(UnitTypeLhs& lhs, const detail::type_identity_t<UnitTypeLhs>& rhs) noexcept
 	{
 		lhs = lhs - rhs;
+		return lhs;
+	}
+
+	/// Compound subtraction for AFFINE units (e.g. temperatures). The lhs is an absolute point; the rhs is
+	/// interpreted as a RELATIVE delta and the point is moved down in place by that magnitude, staying in the
+	/// lhs unit (celsius(20) -= celsius(5) -> celsius(15), i.e. "cool by 5 degrees"). The rhs's datum offset
+	/// is intentionally not applied. (Binary `a - b` of two absolute affine points yields a non-affine delta;
+	/// use `-=` to move a point down by a relative amount.)
+	template<UnitType UnitTypeLhs>
+		requires(traits::is_affine_unit_v<UnitTypeLhs>)
+	constexpr UnitTypeLhs& operator-=(UnitTypeLhs& lhs, const detail::type_identity_t<UnitTypeLhs>& rhs) noexcept
+	{
+		lhs = UnitTypeLhs(lhs.raw() - rhs.raw());
 		return lhs;
 	}
 
@@ -3733,8 +3781,12 @@ namespace units
 	//------------------------------
 
 	/// Addition operator for unit types with a linear_scale.
+	/// @note	Disabled when either operand is AFFINE (carries a datum offset, e.g. degrees Celsius): the sum
+	///			of two absolute affine quantities has no physical meaning (20 degC + 5 degC is not 25 degC in
+	///			any absolute sense). Non-affine units of the same dimension add normally.
 	template<UnitType UnitTypeLhs, UnitType UnitTypeRhs>
-		requires(same_dimension<UnitTypeLhs, UnitTypeRhs> && traits::has_linear_scale_v<UnitTypeLhs, UnitTypeRhs>)
+		requires(same_dimension<UnitTypeLhs, UnitTypeRhs> && traits::has_linear_scale_v<UnitTypeLhs, UnitTypeRhs> &&
+			!traits::is_affine_unit_v<UnitTypeLhs> && !traits::is_affine_unit_v<UnitTypeRhs>)
 	constexpr std::common_type_t<UnitTypeLhs, UnitTypeRhs> operator+(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
 		using CommonUnit = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
@@ -3796,13 +3848,38 @@ namespace units
 		return CommonUnit(InverseCommonUnit(lhs).value() + rhs.raw());
 	}
 
-	/// Subtraction operator for unit types with a linear_scale.
+	/// Subtraction operator for NON-AFFINE unit types with a linear_scale.
 	template<UnitType UnitTypeLhs, UnitType UnitTypeRhs>
-		requires(same_dimension<UnitTypeLhs, UnitTypeRhs> && traits::has_linear_scale_v<UnitTypeLhs, UnitTypeRhs>)
+		requires(same_dimension<UnitTypeLhs, UnitTypeRhs> && traits::has_linear_scale_v<UnitTypeLhs, UnitTypeRhs> &&
+			!traits::is_affine_unit_v<UnitTypeLhs> && !traits::is_affine_unit_v<UnitTypeRhs>)
 	constexpr std::common_type_t<UnitTypeLhs, UnitTypeRhs> operator-(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
 		using CommonUnit = decltype(lhs - rhs);
 		return CommonUnit(CommonUnit(lhs).raw() - CommonUnit(rhs).raw());
+	}
+
+	/// Subtraction operator for AFFINE unit types (e.g. temperatures with a datum offset).
+	/// @details	The difference of two absolute affine quantities is a DELTA: the datum offsets cancel, so
+	///				the result must be a pure (non-affine) quantity — otherwise storing it back into an affine
+	///				unit would re-apply the offset (e.g. celsius(0) - kelvin(0) would read 546.30 K instead of
+	///				the true 273.15 K delta). Both operands are reconciled to their common affine unit, their
+	///				raw values subtracted (the offsets cancel exactly), and the result returned in the
+	///				offset-stripped counterpart of that common unit so it never re-applies a datum.
+	template<UnitType UnitTypeLhs, UnitType UnitTypeRhs>
+		requires(same_dimension<UnitTypeLhs, UnitTypeRhs> && traits::has_linear_scale_v<UnitTypeLhs, UnitTypeRhs> &&
+			(traits::is_affine_unit_v<UnitTypeLhs> || traits::is_affine_unit_v<UnitTypeRhs>))
+	constexpr auto operator-(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
+	{
+		using CommonUnit    = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
+		using CommonCf      = typename traits::unit_traits<CommonUnit>::conversion_factor;
+		// The common unit with its datum offset removed: a pure delta in the same scale/dimension.
+		using DeltaCf       = conversion_factor<typename traits::conversion_factor_traits<CommonCf>::conversion_ratio,
+			typename traits::conversion_factor_traits<CommonCf>::dimension_type,
+			typename traits::conversion_factor_traits<CommonCf>::pi_exponent_ratio, std::ratio<0>>;
+		using DeltaUnit     = unit<traits::strong_t<DeltaCf>, typename CommonUnit::underlying_type, typename CommonUnit::numerical_scale_type>;
+		// The raw difference in the common affine unit is the true delta (offsets cancel); return it as a
+		// non-affine DeltaUnit so no offset is ever re-applied.
+		return DeltaUnit(CommonUnit(lhs).raw() - CommonUnit(rhs).raw());
 	}
 
 	/// Subtraction operator for dimensionless unit types with a linear_scale. dimensionless types can be implicitly
@@ -4154,13 +4231,18 @@ namespace units
 		return dimensionless<Under>(static_cast<Under>(lhs.value()) / static_cast<Under>(rhs.value()));
 	}
 
-	/// Modulo for convertible unit types with a linear scale. @returns the lhs value modulo the rhs value, whose type
-	/// is their common type
+	/// Modulo for convertible unit types with a linear scale. @returns the lhs value modulo the rhs value, in
+	/// their common (finer) unit.
+	/// @note	The result is the `std::common_type` of the operands — the finer of the two units — not the
+	///			lhs unit. Returning the lhs unit made the operator order-dependent: `meters % kilometers`
+	///			compiled (finer lhs) but `kilometers % meters` did not (converting the finer common result
+	///			back to the coarser lhs is lossy for an integer underlying, disabling the constructor). The
+	///			common-unit result mirrors `fmod` and removes the asymmetry.
 	template<DimensionedUnitType UnitTypeLhs, DimensionedUnitType UnitTypeRhs>
 		requires(same_dimension<UnitTypeLhs, UnitTypeRhs> && traits::has_linear_scale_v<UnitTypeLhs, UnitTypeRhs>)
-	constexpr traits::replace_underlying_t<UnitTypeLhs, typename std::common_type_t<UnitTypeLhs, UnitTypeRhs>::underlying_type> operator%(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
+	constexpr std::common_type_t<UnitTypeLhs, UnitTypeRhs> operator%(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
-		using CommonUnit = decltype(lhs % rhs);
+		using CommonUnit = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
 		return CommonUnit(CommonUnit(lhs).raw() % CommonUnit(rhs).raw());
 	}
 
@@ -4758,16 +4840,7 @@ namespace units
 	template<UnitType Unit>
 	constexpr detail::floating_point_promotion_t<Unit> ceil(const Unit x) noexcept
 	{
-		using promoted_t = detail::floating_point_promotion_t<Unit>;
-
-		const promoted_t xv = static_cast<promoted_t>(x.raw());
-		const long long  i  = static_cast<long long>(xv);
-
-		// For negative non-integers, truncation goes toward zero, which is already ceil.
-		// For positive non-integers, we need to bump up by 1.
-		const promoted_t y = (xv > static_cast<promoted_t>(i)) ? static_cast<promoted_t>(i + 1) : static_cast<promoted_t>(i);
-
-		return promoted_t(y);
+		return detail::floating_point_promotion_t<Unit>(std::ceil(x.raw()));
 	}
 
 	/**
@@ -4780,16 +4853,7 @@ namespace units
 	template<UnitType Unit>
 	constexpr detail::floating_point_promotion_t<Unit> floor(const Unit x) noexcept
 	{
-		using promoted_t = detail::floating_point_promotion_t<Unit>;
-
-		const promoted_t xv = static_cast<promoted_t>(x.raw());
-		const long long  i  = static_cast<long long>(xv);
-
-		// For negative non-integers, truncation goes toward zero, so we must subtract 1.
-		// For positive values (and exact integers), truncation already matches floor.
-		const promoted_t y = (xv < static_cast<promoted_t>(i)) ? static_cast<promoted_t>(i - 1) : static_cast<promoted_t>(i);
-
-		return promoted_t(y);
+		return detail::floating_point_promotion_t<Unit>(std::floor(x.raw()));
 	}
 
 	/**
@@ -4948,12 +5012,16 @@ namespace units
 	/**
 	 * @ingroup		UnitMath
 	 * @brief		Multiply-add
-	 * @details		Returns x*y+z. The function computes the result without losing precision in
-	 *				any intermediate result. The resulting unit type is a compound unit of x* y.
-	 * @param[in]	x	Values to be multiplied.
-	 * @param[in]	y	Values to be multiplied.
+	 * @details		Returns x*y+z, computed with a single rounding via `std::fma` — preserving both the
+	 *				accuracy and the performance contract of the underlying operation (a fused multiply-add
+	 *				maps to one hardware instruction where available). The three operands may be expressed in
+	 *				different units of their respective dimensions; each is reconciled to the result unit
+	 *				within the single fused step so the multiply and the add share a consistent basis. The
+	 *				result unit is the common type of the product `x*y` and the addend `z`.
+	 * @param[in]	x	Value to be multiplied.
+	 * @param[in]	y	Value to be multiplied.
 	 * @param[in]	z	Value to be added.
-	 * @returns		The result of x*y+z
+	 * @returns		The result of x*y+z.
 	 */
 	template<UnitType UnitTypeLhs, UnitType UnitMultiply, UnitType UnitAdd>
 		requires(traits::is_same_dimension_conversion_factor_v<
@@ -4962,8 +5030,15 @@ namespace units
 	constexpr auto fma(const UnitTypeLhs x, const UnitMultiply y, const UnitAdd z) noexcept
 		-> std::common_type_t<decltype(detail::floating_point_promotion_t<UnitTypeLhs>(x) * detail::floating_point_promotion_t<UnitMultiply>(y)), UnitAdd>
 	{
-		using CommonUnit = decltype(units::fma(x, y, z));
-		return CommonUnit(std::fma(x.raw(), y.raw(), CommonUnit(z).raw()));
+		using CommonUnit  = decltype(units::fma(x, y, z));
+		using ProductUnit = decltype(detail::floating_point_promotion_t<UnitTypeLhs>(x) * detail::floating_point_promotion_t<UnitMultiply>(y));
+
+		// Fold the product-unit -> result-unit conversion into one multiplicand (a compile-time-constant
+		// scale), so a SINGLE std::fma performs the multiply and the add in the result's basis with one
+		// rounding: x_raw * (y_raw * scale) + z_in_result. Feeding the raw operands directly (each in its
+		// own unit) would combine inconsistent bases and give a wrong result.
+		constexpr auto scale = CommonUnit(ProductUnit(1)).raw();
+		return CommonUnit(std::fma(x.raw(), y.raw() * scale, CommonUnit(z).raw()));
 	}
 
 	//----------------------------

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1968,6 +1968,47 @@ TEST_F(UnitType, unitTypeSubtraction)
 	EXPECT_NEAR(0.0, dim, 5.0e-6);
 }
 
+// Affine (offset-carrying) units: the difference of two absolute temperatures is a DELTA — the datum
+// offsets cancel and the result must not re-apply an offset. Previously celsius(0) - kelvin(0) read 546.30 K
+// (the +273.15 offset was re-applied); the delta is 273.15 K. Absolute affine ADDITION is disabled (no
+// physical meaning), so only subtraction is exercised here.
+TEST_F(UnitType, affineTemperatureSubtractionIsADelta)
+{
+	using namespace units::temperature;
+	EXPECT_NEAR(273.15, kelvin<double>(celsius<double>(0.0) - kelvin<double>(0.0)).value(), 5.0e-11);
+	EXPECT_NEAR(100.0, kelvin<double>(celsius<double>(100.0) - fahrenheit<double>(32.0)).value(), 5.0e-11);
+	EXPECT_NEAR(15.0, kelvin<double>(celsius<double>(20.0) - celsius<double>(5.0)).value(), 5.0e-11);
+	EXPECT_NEAR(56.0, kelvin<double>(fahrenheit<double>(212.0) - fahrenheit<double>(111.2)).value(), 5.0e-9);
+	// The result of an affine subtraction is a non-affine (delta) unit: converting it applies no offset.
+	static_assert(!traits::is_affine_unit_v<decltype(celsius<double>(0.0) - kelvin<double>(0.0))>,
+		"an affine temperature difference must be a non-affine delta type");
+	// A non-affine same-dimension subtraction/addition is unaffected.
+	EXPECT_NEAR(2.0, meters<double>(meters<double>(5.0) - meters<double>(3.0)).value(), 5.0e-12);
+}
+
+// Compound assignment on an affine unit treats the rhs as a RELATIVE delta and moves the absolute point in
+// place ("warm/cool by N degrees"), staying in the lhs unit. This is the point-centric convenience: the
+// point/delta distinction stays a quiet detail rather than a pervasive type calculus.
+TEST_F(UnitType, affineTemperatureCompoundAssignmentMovesPoint)
+{
+	using namespace units::temperature;
+	celsius<double> a(20.0);
+	a += celsius<double>(5.0);
+	EXPECT_NEAR(25.0, a.value(), 5.0e-12);    // warmed by 5 degrees, still absolute celsius
+	a -= celsius<double>(10.0);
+	EXPECT_NEAR(15.0, a.value(), 5.0e-12);    // cooled by 10 degrees
+
+	// The result stays an absolute affine point (not converted to a delta type).
+	static_assert(traits::is_affine_unit_v<decltype(a)>, "compound assignment keeps the affine point type");
+
+	// Non-affine compound assignment is unchanged.
+	meters<double> m(5.0);
+	m += meters<double>(3.0);
+	EXPECT_NEAR(8.0, m.value(), 5.0e-12);
+	m -= meters<double>(2.0);
+	EXPECT_NEAR(6.0, m.value(), 5.0e-12);
+}
+
 TEST_F(UnitType, unitTypeUnarySubtraction)
 {
 	meters<double> a_m(4.0);
@@ -2466,6 +2507,14 @@ TEST_F(UnitType, unitTypeModulo)
 	constexpr auto d_m = a_m % a_km;
 	EXPECT_EQ(200, d_m.value());
 	static_assert(has_equivalent_conversion_factor(d_m, a_m));
+
+	// Coarser lhs: the result is the common (finer) unit, so the operator is not order-dependent. This
+	// direction previously failed to compile (the result was declared as the lhs unit, and converting the
+	// finer common result back to the coarser integer kilometers is lossy → the constructor was disabled).
+	constexpr kilometers f_km(3);
+	constexpr auto       g_m = f_km % b_m;    // 3000 m % 1800 m = 1200 m, in meters (the finer common unit)
+	EXPECT_EQ(1200, g_m.value());
+	static_assert(has_equivalent_conversion_factor(g_m, b_m));
 
 	constexpr auto b_km = a_km % dimensionless<int>(3);
 	EXPECT_EQ(2, b_km.value());
@@ -4961,6 +5010,24 @@ TEST_F(UnitMath, asin)
 	EXPECT_NEAR(angle::degrees<double>(out4).to<double>(), angle::degrees<double>(asin(uin4)).to<double>(), 5.0e-12);
 }
 
+// Regression: the inverse trig / hyperbolic family must promote a FRACTIONAL integer-underlying
+// dimensionless argument to floating point before the cmath call. A scaled dimensionless such as
+// percent<int>(50) has value 0.5 but an integer underlying of 50; converting to the raw underlying
+// truncated 0.5 -> 0, so asin/acos/atan (and the inverse hyperbolics) returned the wrong result for any
+// non-whole ratio. They must match std::* on the promoted value, exactly as the forward trig already does.
+TEST_F(UnitMath, inverseTrigPromotesFractionalIntegerUnderlying)
+{
+	const percent<int> half(50);    // value() == 0.5, underlying int == 50
+	EXPECT_NEAR(std::asin(0.5), asin(half).to<double>(), 5.0e-12);
+	EXPECT_NEAR(std::acos(0.5), acos(half).to<double>(), 5.0e-12);
+	EXPECT_NEAR(std::atan(0.5), atan(half).to<double>(), 5.0e-12);
+	EXPECT_NEAR(std::asinh(0.5), asinh(half).to<double>(), 5.0e-12);
+	EXPECT_NEAR(std::atanh(0.5), atanh(half).to<double>(), 5.0e-12);
+	// acosh needs an argument >= 1; use 150% = 1.5.
+	const percent<int> onePointFive(150);
+	EXPECT_NEAR(std::acosh(1.5), acosh(onePointFive).to<double>(), 5.0e-12);
+}
+
 TEST_F(UnitMath, atan)
 {
 	static_assert(std::is_same_v<angle::radians<double>, decltype(atan(dimensionless<double>(0)))>);
@@ -5211,12 +5278,37 @@ TEST_F(UnitMath, ceil)
 	double val = 101.1;
 	EXPECT_EQ(ceil(val), ceil(meters<double>(val)).to<double>());
 	static_assert(std::is_same_v<meters<double>, decltype(ceil(meters<double>(val)))>);
+
+	// ceil must match std::ceil across the WHOLE domain, including non-finite and magnitudes beyond the
+	// 2^63 range of a signed integer. A prior hand-rolled `static_cast<long long>` path returned garbage
+	// (~-9.22e18) for NaN, +/-Inf, and |x| >= 2^63; delegating to std::ceil fixes it.
+	const double nan = std::numeric_limits<double>::quiet_NaN();
+	const double inf = std::numeric_limits<double>::infinity();
+	EXPECT_TRUE(std::isnan(ceil(meters<double>(nan)).to<double>()));
+	EXPECT_EQ(inf, ceil(meters<double>(inf)).to<double>());
+	EXPECT_EQ(-inf, ceil(meters<double>(-inf)).to<double>());
+	EXPECT_EQ(std::ceil(1e19), ceil(meters<double>(1e19)).to<double>());
+	EXPECT_EQ(std::ceil(-1e19), ceil(meters<double>(-1e19)).to<double>());
+	// ordinary positive/negative rounding stays correct.
+	EXPECT_EQ(3.0, ceil(meters<double>(2.3)).to<double>());
+	EXPECT_EQ(-2.0, ceil(meters<double>(-2.3)).to<double>());
 }
 
 TEST_F(UnitMath, floor)
 {
 	double val = 101.1;
 	EXPECT_EQ(floor(val), floor(dimensionless<double>(val)));
+
+	// floor must match std::floor across the whole domain (see ceil above for the fixed regression).
+	const double nan = std::numeric_limits<double>::quiet_NaN();
+	const double inf = std::numeric_limits<double>::infinity();
+	EXPECT_TRUE(std::isnan(floor(meters<double>(nan)).to<double>()));
+	EXPECT_EQ(inf, floor(meters<double>(inf)).to<double>());
+	EXPECT_EQ(-inf, floor(meters<double>(-inf)).to<double>());
+	EXPECT_EQ(std::floor(1e19), floor(meters<double>(1e19)).to<double>());
+	EXPECT_EQ(std::floor(-1e19), floor(meters<double>(-1e19)).to<double>());
+	EXPECT_EQ(2.0, floor(meters<double>(2.3)).to<double>());
+	EXPECT_EQ(-3.0, floor(meters<double>(-2.3)).to<double>());
 }
 
 TEST_F(UnitMath, fmod)
@@ -5284,6 +5376,26 @@ TEST_F(UnitMath, fma)
 	meters<double>        y(3.0);
 	square_meters<double> z(1.0);
 	EXPECT_EQ(square_meters<double>(7.0), (units::fma(x, y, z)));
+
+	// Regression for #373: the three operands may be in DIFFERENT units of their dimensions, and each must
+	// be reconciled to the result unit before the fused multiply-add. Feeding each operand's own-unit raw
+	// value combined inconsistent bases (6 ft * 3 ft + 1 m^2 wrongly gave ~1.0 m^2 instead of 2.672255).
+	using units::literals::operator""_ft;
+	using units::literals::operator""_m2;
+	const auto crossUnit = units::fma(6.0_ft, 3.0_ft, 1.0_m2);
+	EXPECT_NEAR(2.67225472, square_meters<double>(crossUnit).to<double>(), 1.0e-6);
+
+	// Cross-DIMENSION product: (speed * time) + length, all reconciled to meters.
+	const auto crossDim = units::fma(10.0_mps, 2.0_s, 5.0_m);
+	EXPECT_NEAR(25.0, meters<double>(crossDim).to<double>(), 1.0e-9);
+
+	// Same-unit exact case stays exact.
+	EXPECT_EQ(square_meters<double>(10.0), (units::fma(meters<double>(2.0), meters<double>(3.0), square_meters<double>(4.0))));
+
+	// Integer-underlying operands promote (matching C's usual arithmetic conversions) and stay correct.
+	const auto intFma = units::fma(meters<int>(2), meters<int>(3), square_meters<int>(4));
+	EXPECT_NEAR(10.0, square_meters<double>(intFma).to<double>(), 1.0e-9);
+	static_assert(!std::is_integral_v<typename decltype(intFma)::underlying_type>, "fma result must be floating-point-promoted like C");
 }
 
 TEST_F(UnitMath, isnan)


### PR DESCRIPTION
## Fix fma (#373) and a cluster of unit-math correctness bugs

Closes #373.

The `fma` report pointed at a broader class of bug, so I ran an adversarial review across the cmath-analog functions, the conversion core, the arithmetic operators, and **all 48 dimension headers**. It found a cluster sharing two root causes — combining operands across **inconsistent unit bases**, and integer/float promotion diverging from the **usual arithmetic conversions**. Each fix matches the standard-library behavior (or is more accurate, never less) and carries a regression test.

Verified: **330/330** on g++ (C++23) **and** MSVC cl.exe.

### Fixes

| Function | Bug | Fix |
|---|---|---|
| **`fma`** (#373) | multiply + add done on each operand's own-unit raw → `fma(6_ft,3_ft,1_m2)` = ~1.0 m² (want 2.672255) | fold the product→result-unit scale into one multiplicand so a **single `std::fma`** runs in one basis (fused-op contract preserved) |
| **`ceil`/`floor`** | hand-rolled `static_cast<long long>` → garbage/UB for NaN, ±Inf, `\|x\|≥2^63` (`ceil(NaN)`→−9.2e18) | delegate to `std::ceil`/`std::floor` like `trunc`/`round`/`fabs` |
| **inverse trig** (`asin`/`acos`/`atan`/`asinh`/`acosh`/`atanh`) | converted a fractional integer-underlying dimensionless to the raw int first → `asin(percent<int>(50))` (0.5) = 0 | promote to floating point before the cmath call, like the forward trig |
| **fractional pi exponent** | pi-exponent computed with **integer** division → `sqrt(degrees(4))` truncated to 0 → divide-by-zero / missing-return **compile error** | compute in `long double` + a fractional-exponent branch |
| **affine (temperature) `+`/`-`** | linear op stored a difference into an affine common unit, re-applying the datum offset → `celsius(0)-kelvin(0)` = 546.30 K (want 273.15) | point − point → non-affine **delta** (offsets cancel); point `+=`/`-=` delta moves the point in place; point + point disabled at compile time |
| **`operator%`** (int, cross-unit) | result declared as lhs unit but computed in the finer common unit → `kilometers % meters` failed to compile (order-dependent) | return the common (finer) unit, mirroring `fmod` |

### Affine semantics (temperatures)

The library stays **point-centric** — the affine point/delta handling is a localized detail, not a pervasive calculus. `celsius(20) += celsius(5)` reads the rhs as a relative amount ("warm by 5") → `25 °C`; `celsius(100) - fahrenheit(32)` is a `100 K` **delta**; `celsius + celsius` (a meaningless absolute sum) is disabled. Documented in a new README "Temperatures and other affine units" section.

### Reviewed and found correct (no change)
The multi-operand functions (`hypot`/`fmod`/`fdim`/`fmax`/`fmin`/`copysign`), the `convert` core (integer path is *more* accurate than C), `min`/`max`/`signbit`/`numeric_limits`/`unit_cast`, and every dimension header's conversion factors (113 + 31 checked against authoritative values, incl. `data.h` binary/decimal prefixes and the pi-scaled angular units).

### Follow-ups filed
- #375 — explicit lossy integer conversion accessors (e.g. `bits<int>` → `bytes<int>`).
