### PR TITLE
Add opt-in absolute<>/delta<> point/delta wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,36 @@ Comparisons (`==`, `<`, …) and conversions between affine units are exact and 
 units (lengths, masses, everything without an offset) are unaffected — they add, subtract, and combine with
 no special cases.
 
+#### Making the point/delta distinction explicit: `absolute<>` and `delta<>`
+
+The rules above are enforced at run time by convention. When you want the compiler to enforce them, wrap a
+quantity in **`absolute<U>`** (a point on a scale — carries the datum) or **`delta<U>`** (an amount —
+offset-free). These are opt-in: plain unit types are unchanged, and you reach for the wrappers only where
+the safety matters (temperatures, epochs vs durations, absolute vs gauge pressure, positions vs
+displacements). They wrap *any* unit — for a non-affine unit the datum is zero, so `absolute` and `delta`
+coincide.
+
+```cpp
+using namespace units::temperature;
+
+absolute<celsius<double>> room(celsius<double>(20.0));
+delta<celsius<double>>    step(celsius<double>(5.0));
+
+auto d      = room - absolute<kelvin<double>>(kelvin<double>(273.15)); // delta<>  (20 K difference)
+auto warmer = room + step;                                            // absolute<> (25 degC)
+room       += step;                                                    // move the point in place
+
+// enforced at compile time:
+// auto bad = room + room;   // ill-formed — the sum of two points is meaningless
+// auto x   = room + 5.0_m;  // ill-formed — a plain unit is neither a point nor a delta here
+```
+
+The type algebra: `absolute − absolute → delta` (the datum cancels), `absolute ± delta → absolute` (move
+the point), `delta ± delta → delta`, `delta * scalar → delta`; `absolute + absolute` does not compile. An
+`absolute`'s `.to<V>()` applies the datum (a point conversion); a `delta`'s `.to<V>()` is scale-only (a
+10 °C delta converts to an 18 °F delta, not to 50 °F). The wrappers are trivially copyable and the same
+size as the wrapped unit — zero overhead.
+
 ---
 
 ## Type errors

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -5075,6 +5075,259 @@ namespace units
 	{
 		return std::isunordered(lhs.raw(), rhs.raw());
 	}
+
+	//----------------------------------------------------------------------------------------------------------------------
+	//	AFFINE POINT / DELTA WRAPPERS
+	//----------------------------------------------------------------------------------------------------------------------
+	// Opt-in wrappers that make the point-vs-delta distinction explicit in the type, for code that wants it
+	// enforced. `absolute<U>` is a POINT on a scale (it carries the unit's datum — 0 degC is 273.15 K).
+	// `delta<U>` is an AMOUNT (offset-free — a 10 degC delta is a 10 K delta, not 283.15 K). Plain unit types
+	// are unaffected; you reach for these only where the distinction matters (temperatures, epochs vs
+	// durations, absolute vs gauge pressure, positions vs displacements). For a non-affine unit the datum is
+	// zero, so `absolute` and `delta` coincide numerically. The type algebra the wrappers enforce:
+	//   absolute - absolute -> delta      (the datum offsets cancel)
+	//   absolute +/- delta   -> absolute  (move the point by a relative amount)
+	//   delta +/- delta      -> delta
+	//   absolute + absolute  -> ill-formed (the sum of two points has no meaning)
+
+	namespace detail
+	{
+		/// The offset-free counterpart of a unit: same dimension, scale, and pi factor, but translation
+		/// stripped. Converting a `delta` between units uses THIS (scale only, no datum), so a temperature
+		/// difference converts by degree size, not as an absolute point.
+		template<UnitType U>
+		using delta_unit_t = unit<traits::strong_t<conversion_factor<typename traits::conversion_factor_traits<typename traits::unit_traits<U>::conversion_factor>::conversion_ratio,
+											 typename traits::conversion_factor_traits<typename traits::unit_traits<U>::conversion_factor>::dimension_type,
+											 typename traits::conversion_factor_traits<typename traits::unit_traits<U>::conversion_factor>::pi_exponent_ratio, std::ratio<0>>>,
+			typename traits::unit_traits<U>::underlying_type, typename traits::unit_traits<U>::numerical_scale_type>;
+	} // namespace detail
+
+	template<UnitType U>
+	class delta;
+
+	//	----------------------------------------------------------------------------
+	//	CLASS		absolute
+	//  ----------------------------------------------------------------------------
+	///	@brief		A point on an (possibly affine) scale — carries the unit's datum.
+	///	@tparam		U	the wrapped unit type.
+	//  ----------------------------------------------------------------------------
+	template<UnitType U>
+	class absolute
+	{
+	public:
+		using unit_type       = U;
+		using underlying_type = typename traits::unit_traits<U>::underlying_type;
+
+		constexpr absolute() noexcept = default;
+		constexpr explicit absolute(const U& point) noexcept : m_point(point) {}
+
+		/// The wrapped point as a plain unit (still carrying its datum).
+		constexpr const U& quantity() const noexcept { return m_point; }
+		/// The point's numeric value in its own unit.
+		constexpr auto value() const noexcept { return m_point.value(); }
+		constexpr auto raw() const noexcept { return m_point.raw(); }
+
+		/// Convert this point to another unit of the same dimension — the datum offset IS applied.
+		template<UnitType V>
+			requires traits::is_same_dimension_unit_v<U, V>
+		constexpr absolute<V> to() const noexcept
+		{
+			return absolute<V>(V(m_point));
+		}
+
+	private:
+		U m_point{};
+	};
+
+	//	----------------------------------------------------------------------------
+	//	CLASS		delta
+	//  ----------------------------------------------------------------------------
+	///	@brief		An amount of a quantity — offset-free (no datum).
+	///	@tparam		U	the wrapped unit type (its datum is ignored; only its scale matters).
+	//  ----------------------------------------------------------------------------
+	template<UnitType U>
+	class delta
+	{
+	public:
+		using unit_type       = U;
+		using underlying_type = typename traits::unit_traits<U>::underlying_type;
+
+		constexpr delta() noexcept = default;
+		constexpr explicit delta(const U& amount) noexcept : m_amount(amount) {}
+
+		/// The wrapped amount as a plain unit.
+		constexpr const U& quantity() const noexcept { return m_amount; }
+		constexpr auto value() const noexcept { return m_amount.value(); }
+		constexpr auto raw() const noexcept { return m_amount.raw(); }
+
+		/// Convert this delta to another unit of the same dimension — SCALE ONLY, the datum is never applied
+		/// (a 10 degC delta becomes an 18 degF delta, not an absolute 50 degF).
+		template<UnitType V>
+			requires traits::is_same_dimension_unit_v<U, V>
+		constexpr delta<V> to() const noexcept
+		{
+			// Reinterpret both units as their offset-free counterparts, convert there, rewrap as V.
+			const detail::delta_unit_t<U> here(m_amount.raw());
+			const detail::delta_unit_t<V> there(here);    // scale-only conversion (no translation on either)
+			return delta<V>(V(there.raw()));
+		}
+
+	private:
+		U m_amount{};
+	};
+
+	//----------------------------------
+	//	ABSOLUTE / DELTA OPERATORS
+	//----------------------------------
+
+	// The wrapper operators reconcile the two operands to their COMMON unit (the finer of the two, via
+	// std::common_type) before combining — exactly as the plain-unit operators do. Reconciling to the lhs
+	// unit instead would narrow when the lhs is the coarser unit, which for an integer underlying is a
+	// lossy conversion the unit's constructor rejects — so `delta<kilometers<int>> - delta<meters<int>>`
+	// would be found by overload resolution yet hard-error deep in the conversion on instantiation. The
+	// common-unit reconciliation never narrows.
+
+	/// point - point -> delta (the datum offsets cancel), in the common (finer) unit.
+	template<UnitType U, UnitType V>
+		requires traits::is_same_dimension_unit_v<U, V>
+	constexpr delta<U> operator-(const absolute<U>& lhs, const absolute<V>& rhs) noexcept
+	{
+		// The rhs point is converted into the lhs unit AFFINELY (offset applied), then subtracted; the datum
+		// cancels, leaving an offset-free delta expressed in the lhs unit. (Converting a point is safe and
+		// intuitive — "celsius point - X" yields a difference in celsius-degrees.)
+		return delta<U>(U(lhs.quantity().raw() - U(rhs.quantity()).raw()));
+	}
+
+	/// point + delta -> point (move the point up by a relative amount). The point keeps its OWN unit — a
+	/// point has a datum, and reconciling two affine frames to a "common" unit mangles the datum; only the
+	/// delta (offset-free) is converted, scale-only, into the point's unit.
+	template<UnitType U, UnitType V>
+		requires traits::is_same_dimension_unit_v<U, V>
+	constexpr absolute<U> operator+(const absolute<U>& lhs, const delta<V>& rhs) noexcept
+	{
+		return absolute<U>(U(lhs.quantity().raw() + rhs.template to<U>().quantity().raw()));
+	}
+
+	/// delta + point -> point (commutative form).
+	template<UnitType U, UnitType V>
+		requires traits::is_same_dimension_unit_v<V, U>
+	constexpr absolute<U> operator+(const delta<V>& lhs, const absolute<U>& rhs) noexcept
+	{
+		return rhs + lhs;
+	}
+
+	/// point - delta -> point (move the point down by a relative amount), in the point's own unit.
+	template<UnitType U, UnitType V>
+		requires traits::is_same_dimension_unit_v<U, V>
+	constexpr absolute<U> operator-(const absolute<U>& lhs, const delta<V>& rhs) noexcept
+	{
+		return absolute<U>(U(lhs.quantity().raw() - rhs.template to<U>().quantity().raw()));
+	}
+
+	/// delta + delta -> delta, in the common unit.
+	template<UnitType U, UnitType V>
+		requires traits::is_same_dimension_unit_v<U, V>
+	constexpr auto operator+(const delta<U>& lhs, const delta<V>& rhs) noexcept
+	{
+		using C = std::common_type_t<U, V>;
+		return delta<C>(C(lhs.template to<C>().quantity().raw() + rhs.template to<C>().quantity().raw()));
+	}
+
+	/// delta - delta -> delta, in the common unit.
+	template<UnitType U, UnitType V>
+		requires traits::is_same_dimension_unit_v<U, V>
+	constexpr auto operator-(const delta<U>& lhs, const delta<V>& rhs) noexcept
+	{
+		using C = std::common_type_t<U, V>;
+		return delta<C>(C(lhs.template to<C>().quantity().raw() - rhs.template to<C>().quantity().raw()));
+	}
+
+	/// Unary negation of a delta (an amount can be negated; a point cannot).
+	template<UnitType U>
+	constexpr delta<U> operator-(const delta<U>& d) noexcept
+	{
+		return delta<U>(U(-d.quantity().raw()));
+	}
+
+	/// delta scaled by a bare number -> delta. The underlying type promotes exactly as the wrapped unit's own
+	/// `operator*` does (scaling an integer delta by a floating factor yields a floating delta — the wrapper
+	/// is never less precise than the unit it wraps).
+	template<UnitType U, ArithmeticType T>
+	constexpr auto operator*(const delta<U>& lhs, T rhs) noexcept
+	{
+		using ScaledUnit = decltype(lhs.quantity() * rhs);
+		return delta<ScaledUnit>(lhs.quantity() * rhs);
+	}
+	template<UnitType U, ArithmeticType T>
+	constexpr auto operator*(T lhs, const delta<U>& rhs) noexcept
+	{
+		return rhs * lhs;
+	}
+
+	/// delta divided by a bare number -> delta (promotes like the wrapped unit's own `operator/`).
+	template<UnitType U, ArithmeticType T>
+	constexpr auto operator/(const delta<U>& lhs, T rhs) noexcept
+	{
+		using ScaledUnit = decltype(lhs.quantity() / rhs);
+		return delta<ScaledUnit>(lhs.quantity() / rhs);
+	}
+
+	/// Compound move of a point by a delta. The point stays in its own unit (in-place semantics), so the rhs
+	/// delta is converted to the lhs unit; this is well-formed whenever that conversion is (a lossy integer
+	/// case is cleanly rejected by the delta conversion, as elsewhere in the library).
+	template<UnitType U, UnitType V>
+		requires traits::is_same_dimension_unit_v<U, V>
+	constexpr absolute<U>& operator+=(absolute<U>& lhs, const delta<V>& rhs) noexcept
+	{
+		lhs = absolute<U>(U(lhs.quantity().raw() + rhs.template to<U>().quantity().raw()));
+		return lhs;
+	}
+	template<UnitType U, UnitType V>
+		requires traits::is_same_dimension_unit_v<U, V>
+	constexpr absolute<U>& operator-=(absolute<U>& lhs, const delta<V>& rhs) noexcept
+	{
+		lhs = absolute<U>(U(lhs.quantity().raw() - rhs.template to<U>().quantity().raw()));
+		return lhs;
+	}
+
+	//----------------------------------
+	//	ABSOLUTE / DELTA COMPARISONS
+	//----------------------------------
+
+	// Comparisons reconcile to the common (finer) unit — never narrowing — so a mixed integer comparison
+	// (e.g. delta<kilometers<int>> vs delta<meters<int>>) is well-formed rather than hard-erroring.
+
+	/// Compare two points (reconciled to the common unit; the datum is applied on each side).
+	template<UnitType U, UnitType V>
+		requires traits::is_same_dimension_unit_v<U, V>
+	constexpr bool operator==(const absolute<U>& lhs, const absolute<V>& rhs) noexcept
+	{
+		using C = std::common_type_t<U, V>;
+		return C(lhs.quantity()).raw() == C(rhs.quantity()).raw();
+	}
+	template<UnitType U, UnitType V>
+		requires traits::is_same_dimension_unit_v<U, V>
+	constexpr auto operator<=>(const absolute<U>& lhs, const absolute<V>& rhs) noexcept
+	{
+		using C = std::common_type_t<U, V>;
+		return C(lhs.quantity()).raw() <=> C(rhs.quantity()).raw();
+	}
+
+	/// Compare two deltas (scale-only reconciliation to the common unit).
+	template<UnitType U, UnitType V>
+		requires traits::is_same_dimension_unit_v<U, V>
+	constexpr bool operator==(const delta<U>& lhs, const delta<V>& rhs) noexcept
+	{
+		using C = std::common_type_t<U, V>;
+		return lhs.template to<C>().quantity().raw() == rhs.template to<C>().quantity().raw();
+	}
+	template<UnitType U, UnitType V>
+		requires traits::is_same_dimension_unit_v<U, V>
+	constexpr auto operator<=>(const delta<U>& lhs, const delta<V>& rhs) noexcept
+	{
+		using C = std::common_type_t<U, V>;
+		return lhs.template to<C>().quantity().raw() <=> rhs.template to<C>().quantity().raw();
+	}
 } // end namespace units
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/test/errorMessages/cases/wrapper_absolute_plus_absolute.cpp
+++ b/test/errorMessages/cases/wrapper_absolute_plus_absolute.cpp
@@ -1,0 +1,23 @@
+// Case: summing two affine POINTS is meaningless (what is "20 degC + 5 degC" as a point?), so
+// `absolute<U> + absolute<V>` must be ill-formed. Only point - point (-> delta), point +/- delta,
+// and delta +/- delta are defined. The diagnostic must name the friendly absolute/celsius wrapper
+// types, never the raw conversion_factor<...> soup.
+//
+// The harness (run.py) normalizes the match directives to be portable across g++, clang, and MSVC
+// (it strips class/struct/enum keywords and collapses whitespace), so one directive covers every
+// compiler; the harness has no separate per-compiler directive.
+//
+// expect: fail
+// expect-match: operator+
+// expect-match: absolute
+// expect-match: celsius<double>
+// forbid-match: conversion_factor<std::ratio
+#include <units/temperature.h>
+using namespace units;
+using namespace units::temperature;
+auto bad = absolute<celsius<>>(celsius<>(20.0)) + absolute<celsius<>>(celsius<>(5.0)); // ill-formed: point + point
+int main()
+{
+	(void)bad;
+	return 0;
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -28,6 +28,13 @@
 using namespace units;
 using namespace units::literals;
 
+// Adversarial type-safety tests for the absolute<>/delta<> wrappers (self-contained: own usings + anonymous-namespace
+// helpers + WrapperSafety suite). Included as a header so it joins the single-TU suite.
+#include "wrapperTest_safety.h"
+
+// General (non-affine, cross-dimension) absolute<>/delta<> tests (GeneralWrapper suite).
+#include "wrapperTest_general.h"
+
 // A user-defined base dimension + unit, declared outside the library, to prove serialization is extensible to
 // dimensions the library has never seen (no central table, no fixed ceiling).
 namespace units
@@ -7164,6 +7171,216 @@ TEST_F(Serialization, typedFastPathPropagatesDecodeError)
 	const auto             r = units::deserialize<units::meters<double>>(garbage);
 	EXPECT_FALSE(r.has_value());
 	EXPECT_EQ(units::deserialize_error::bad_version, r.error());
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+//	AFFINE POINT / DELTA WRAPPER TESTS (absolute<>/delta<>) — the temperature (affine) slice.
+// ---------------------------------------------------------------------------------------------------------------------
+// These hammer the point-vs-delta distinction against physical truth: a POINT carries the scale's datum (0 degC =
+// 273.15 K), a DELTA is offset-free (a 10 degC change is a 10 K change, and an 18 degF change — SCALE only, never 50).
+namespace
+{
+	using units::absolute;
+	using units::delta;
+	using units::temperature::celsius;
+	using units::temperature::fahrenheit;
+	using units::temperature::kelvin;
+	using units::temperature::rankine;
+	using units::temperature::reaumur;
+
+	// Build wrappers tersely: aPoint<U>(v) / aDelta<U>(v) wrap a plain value in the point/delta wrapper.
+	template<class U>
+	constexpr absolute<U> aPoint(double v) noexcept
+	{
+		return absolute<U>(U(v));
+	}
+	template<class U>
+	constexpr delta<U> aDelta(double v) noexcept
+	{
+		return delta<U>(U(v));
+	}
+
+	constexpr double kTol = 1e-9; ///< tolerance for double temperature comparisons.
+} // namespace
+
+// point - point cancels the datum and yields a DELTA expressed in the lhs unit, across every temperature pair.
+TEST(AffineWrapper, pointMinusPointCancelsDatum)
+{
+	EXPECT_NEAR(273.15, (aPoint<celsius<>>(0.0) - aPoint<kelvin<>>(0.0)).value(), kTol);
+	EXPECT_NEAR(100.0, (aPoint<celsius<>>(100.0) - aPoint<fahrenheit<>>(32.0)).value(), kTol);
+
+	// 212 degF - 32 degF = 180 F-deg, which is exactly 100 K/C-deg once rescaled.
+	const auto fdiff = aPoint<fahrenheit<>>(212.0) - aPoint<fahrenheit<>>(32.0);
+	EXPECT_NEAR(180.0, fdiff.value(), kTol);
+	EXPECT_NEAR(100.0, fdiff.to<kelvin<>>().value(), kTol);
+	EXPECT_NEAR(100.0, fdiff.to<celsius<>>().value(), kTol);
+
+	// rankine and kelvin share the absolute-zero datum (491.67 R == 273.15 K), so their difference is ~0.
+	EXPECT_NEAR(0.0, (aPoint<rankine<>>(491.67) - aPoint<kelvin<>>(273.15)).value(), 1e-6);
+
+	// reaumur shares celsius's datum (0 Re = 0 C) but is 1.25x the degree size (100 C = 80 Re).
+	const auto rediff = aPoint<reaumur<>>(80.0) - aPoint<celsius<>>(0.0);
+	EXPECT_NEAR(80.0, rediff.value(), kTol);            // 80 Re-deg in the lhs (reaumur) unit
+	EXPECT_NEAR(100.0, rediff.to<celsius<>>().value(), kTol); // == 100 C-deg
+}
+
+// The result type of point - point is delta<lhs-unit>, and self-subtraction is an exact zero delta.
+TEST(AffineWrapper, pointMinusPointResultTypeAndSelf)
+{
+	// 0 C = 32 F, so 212 F - 32 F = 180 F-deg = 100 K. The difference is a delta wrapper in the common
+	// (finer) unit; compare via a conversion so the test is independent of that unit choice.
+	const auto diff = aPoint<fahrenheit<>>(212.0) - aPoint<celsius<>>(0.0);
+	EXPECT_NEAR(180.0, diff.template to<fahrenheit<>>().value(), kTol);
+	EXPECT_NEAR(100.0, diff.template to<kelvin<>>().value(), kTol);
+
+	const auto body = aPoint<celsius<>>(37.0);
+	EXPECT_NEAR(0.0, (body - body).template to<kelvin<>>().value(), kTol);
+}
+
+// point +/- delta moves the point and keeps the lhs unit; a cross-unit delta is added SCALE-only.
+TEST(AffineWrapper, pointPlusMinusDelta)
+{
+	EXPECT_NEAR(25.0, (aPoint<celsius<>>(20.0) + aDelta<celsius<>>(5.0)).value(), kTol);
+	EXPECT_NEAR(25.0, (aPoint<celsius<>>(20.0) + aDelta<kelvin<>>(5.0)).value(), kTol);
+	// 9 F-deg is 5 C-deg (SCALE only), so 20 C + delta(9 F) = 25 C — the delta never drags the 32-degree offset in.
+	EXPECT_NEAR(25.0, (aPoint<celsius<>>(20.0) + aDelta<fahrenheit<>>(9.0)).value(), kTol);
+	EXPECT_NEAR(15.0, (aPoint<celsius<>>(20.0) - aDelta<celsius<>>(5.0)).value(), kTol);
+	EXPECT_NEAR(273.0, (aPoint<kelvin<>>(300.0) - aDelta<celsius<>>(27.0)).value(), kTol);
+
+	// commuted form delta + point.
+	EXPECT_NEAR(25.0, (aDelta<kelvin<>>(5.0) + aPoint<celsius<>>(20.0)).value(), kTol);
+
+	// result keeps the lhs (point) unit.
+	const auto moved = aPoint<celsius<>>(20.0) + aDelta<fahrenheit<>>(9.0);
+	EXPECT_TRUE((std::is_same_v<std::remove_const_t<decltype(moved)>, absolute<celsius<>>>));
+}
+
+// A ZERO delta of an affine unit must NOT smuggle the datum in: celsius(20) + delta<celsius>(0) stays 20, not 293.15.
+// This is the core correctness property that distinguishes delta from absolute.
+TEST(AffineWrapper, zeroDeltaDoesNotCarryOffset)
+{
+	EXPECT_NEAR(20.0, (aPoint<celsius<>>(20.0) + aDelta<celsius<>>(0.0)).value(), kTol);
+	EXPECT_NEAR(20.0, (aPoint<celsius<>>(20.0) + aDelta<fahrenheit<>>(0.0)).value(), kTol);
+	EXPECT_NEAR(20.0, (aPoint<celsius<>>(20.0) - aDelta<kelvin<>>(0.0)).value(), kTol);
+	// a delta's wrapped quantity is the bare amount, never datum-shifted.
+	EXPECT_NEAR(10.0, aDelta<celsius<>>(10.0).quantity().raw(), kTol);
+	EXPECT_NEAR(10.0, aDelta<celsius<>>(10.0).value(), kTol);
+}
+
+// delta.to<V>() is SCALE-only: 10 C-deg == 18 F-deg == 10 K, never an absolute 50 degF.
+TEST(AffineWrapper, deltaConversionIsScaleOnly)
+{
+	EXPECT_NEAR(18.0, aDelta<celsius<>>(10.0).to<fahrenheit<>>().value(), kTol);
+	EXPECT_NEAR(10.0, aDelta<fahrenheit<>>(18.0).to<celsius<>>().value(), kTol);
+	EXPECT_NEAR(10.0, aDelta<celsius<>>(10.0).to<kelvin<>>().value(), kTol);
+	EXPECT_NEAR(5.0, aDelta<fahrenheit<>>(9.0).to<celsius<>>().value(), kTol);
+	EXPECT_NEAR(5.0, aDelta<rankine<>>(9.0).to<kelvin<>>().value(), kTol);
+	EXPECT_NEAR(10.0, aDelta<reaumur<>>(8.0).to<celsius<>>().value(), kTol); // 8 Re-deg == 10 C-deg
+}
+
+// delta +/- delta and delta * scalar, reconciled scale-only to the common (finer) unit. Results are
+// compared via a conversion to a fixed unit so the test is independent of which unit std::common_type picks.
+TEST(AffineWrapper, deltaArithmetic)
+{
+	// celsius-degree and kelvin-degree are the same size, so these are numerically clean either way.
+	EXPECT_NEAR(15.0, (aDelta<celsius<>>(10.0) + aDelta<kelvin<>>(5.0)).template to<kelvin<>>().value(), kTol);
+	EXPECT_NEAR(-3.0, (aDelta<celsius<>>(5.0) - aDelta<kelvin<>>(8.0)).template to<kelvin<>>().value(), kTol);
+	// cross-unit delta + delta reconciles scale-only: 10 F-deg + 5 C-deg (== 9 F-deg) = 19 F-deg.
+	EXPECT_NEAR(19.0, (aDelta<fahrenheit<>>(10.0) + aDelta<celsius<>>(5.0)).template to<fahrenheit<>>().value(), kTol);
+
+	EXPECT_NEAR(30.0, (aDelta<celsius<>>(10.0) * 3).value(), kTol);
+	EXPECT_NEAR(20.0, (2 * aDelta<celsius<>>(10.0)).value(), kTol);
+	EXPECT_NEAR(-25.0, (aDelta<celsius<>>(10.0) * -2.5).value(), kTol);
+
+	// The result of a cross-unit delta sum is a delta wrapper (of the common unit).
+	const auto sum = aDelta<celsius<>>(1.0) + aDelta<kelvin<>>(2.0);
+	EXPECT_NEAR(3.0, sum.template to<kelvin<>>().value(), kTol);
+}
+
+// += / -= compound-move a point by a (possibly cross-unit) delta, and chaining a + d1 + d2 accumulates correctly.
+TEST(AffineWrapper, compoundAssignAndChaining)
+{
+	auto p = aPoint<celsius<>>(20.0);
+	p += aDelta<kelvin<>>(5.0);
+	EXPECT_NEAR(25.0, p.value(), kTol);
+	p -= aDelta<fahrenheit<>>(9.0); // 9 F-deg == 5 C-deg
+	EXPECT_NEAR(20.0, p.value(), kTol);
+
+	const auto chained = aPoint<celsius<>>(20.0) + aDelta<celsius<>>(5.0) + aDelta<kelvin<>>(3.0);
+	EXPECT_NEAR(28.0, chained.value(), kTol);
+}
+
+// Point comparisons reconcile across the datum (celsius(0) == kelvin(273.15) == fahrenheit(32)); delta comparisons
+// are scale-only (10 C-deg == 18 F-deg).
+TEST(AffineWrapper, comparisons)
+{
+	EXPECT_TRUE(aPoint<celsius<>>(0.0) == aPoint<fahrenheit<>>(32.0));
+	EXPECT_TRUE(aPoint<celsius<>>(100.0) > aPoint<kelvin<>>(300.0)); // 100 C = 373.15 K
+	EXPECT_TRUE(aPoint<celsius<>>(0.0) < aPoint<fahrenheit<>>(33.0));
+	EXPECT_TRUE(aPoint<kelvin<>>(273.15) >= aPoint<celsius<>>(0.0));
+
+	EXPECT_TRUE(aDelta<celsius<>>(10.0) == aDelta<fahrenheit<>>(18.0));
+	EXPECT_TRUE(aDelta<fahrenheit<>>(9.0) == aDelta<celsius<>>(5.0));
+	EXPECT_TRUE(aDelta<celsius<>>(10.0) > aDelta<fahrenheit<>>(9.0));   // 18 F-deg > 9 F-deg
+	EXPECT_FALSE(aDelta<celsius<>>(5.0) == aDelta<fahrenheit<>>(10.0)); // 5 C = 9 F != 10 F
+}
+
+// absolute.to<V>() APPLIES the datum offset (20 C -> 293.15 K) and round-trips exactly.
+TEST(AffineWrapper, pointConversionAppliesOffsetAndRoundTrips)
+{
+	const auto k = aPoint<celsius<>>(20.0).to<kelvin<>>();
+	EXPECT_NEAR(293.15, k.value(), kTol);
+	EXPECT_NEAR(20.0, k.to<celsius<>>().value(), kTol);
+
+	// reaumur point -> celsius/kelvin applies both the scale and the offset.
+	EXPECT_NEAR(100.0, aPoint<reaumur<>>(80.0).to<celsius<>>().value(), kTol);
+	EXPECT_NEAR(373.15, aPoint<reaumur<>>(80.0).to<kelvin<>>().value(), kTol);
+
+	// fahrenheit point round-trips through kelvin.
+	const auto f = aPoint<fahrenheit<>>(98.6);
+	EXPECT_NEAR(98.6, f.to<kelvin<>>().to<fahrenheit<>>().value(), 1e-6);
+}
+
+// default-constructed wrappers are zero (a plain unit's zero), for both point and delta.
+TEST(AffineWrapper, defaultConstructedIsZero)
+{
+	EXPECT_NEAR(0.0, absolute<kelvin<>>{}.value(), kTol);
+	EXPECT_NEAR(0.0, delta<kelvin<>>{}.value(), kTol);
+	EXPECT_NEAR(0.0, absolute<celsius<>>{}.value(), kTol);
+}
+
+// Integer-underlying temperatures truncate C-style; lossless (same-datum, scale-1) conversions still compile.
+TEST(AffineWrapper, integerUnderlyingConversionAndScaling)
+{
+	// 20 C -> 293.15 K truncates toward zero to 293 (an integer-underlying point conversion).
+	EXPECT_EQ(293, absolute<celsius<int>>(celsius<int>(20)).to<kelvin<int>>().raw());
+	// delta same-datum scale-1 conversion is lossless.
+	EXPECT_EQ(10, delta<celsius<int>>(celsius<int>(10)).to<kelvin<int>>().raw());
+	// delta * fractional scalar promotes exactly as the wrapped unit's own operator* does: an int delta scaled by
+	// a floating factor yields a floating delta (the wrapper is never less precise than the unit it wraps).
+	const auto d = delta<celsius<int>>(celsius<int>(10)) * 1.19; // 11.9, promoted to double
+	EXPECT_TRUE((std::is_same_v<decltype(d)::underlying_type, double>));
+	EXPECT_NEAR(11.9, d.raw(), 5.0e-12);
+	// delta * integer keeps the integer underlying type.
+	const auto di = delta<celsius<int>>(celsius<int>(10)) * 2;
+	EXPECT_TRUE((std::is_same_v<decltype(di)::underlying_type, int>));
+	EXPECT_EQ(20, di.raw());
+}
+
+// Constant-evaluable math is provably correct at compile time (point-point, point+delta, scale-only delta, +=).
+TEST(AffineWrapper, constexprMath)
+{
+	static_assert((absolute<celsius<>>(celsius<>(100.0)) - absolute<celsius<>>(celsius<>(0.0))).value() == 100.0);
+	static_assert((absolute<celsius<>>(celsius<>(20.0)) + delta<kelvin<>>(kelvin<>(5.0))).value() == 25.0);
+	static_assert(delta<celsius<>>(celsius<>(10.0)).to<kelvin<>>().value() == 10.0);
+	static_assert(delta<fahrenheit<>>(fahrenheit<>(9.0)).to<celsius<>>().value() == 5.0);
+	static_assert(absolute<celsius<>>(celsius<>(0.0)) == absolute<fahrenheit<>>(fahrenheit<>(32.0)));
+	static_assert([] {
+		auto a = absolute<celsius<>>(celsius<>(20.0));
+		a += delta<celsius<>>(celsius<>(5.0));
+		return a.value();
+	}() == 25.0);
+	SUCCEED();
 }
 
 int main(int argc, char* argv[])

--- a/test/wrapperTest_general.h
+++ b/test/wrapperTest_general.h
@@ -1,0 +1,455 @@
+// ---------------------------------------------------------------------------------------------------------------------
+//			                 __
+//			               _/ /          /
+//			    __________/  /__ _______/
+//			   /  _______   ___//  ____/
+//			  /  /___   /  /   /  /   /   SYSTEMS
+//			  \____  \ /  /   /  /   /    & TECHNOLOGY
+//			 _____/  //  /___/  /   /     RESEARCH
+//			/_______/ \________/   /
+//			                      /
+//			                     /
+// ---------------------------------------------------------------------------------------------------------------------
+//
+/// @file       wrapperTest_general.h
+/// @brief      Adversarial tests for the `absolute<>` / `delta<>` wrappers over GENERAL (non-affine) units.
+/// @details    Exercises the point/amount wrappers on units whose datum is zero (length, time, mass, velocity,
+///             pressure, torque, angle, dimensionless), where `absolute` and `delta` coincide numerically. The
+///             angle cases prove the delta's scale-only conversion still carries the pi exponent. Warts found
+///             during authoring are captured as `Wart_*` cases that PIN the current behavior — a future fix
+///             flips the assertion deliberately.
+//
+// ---------------------------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <cmath>
+#include <compare>
+#include <gtest/gtest.h>
+#include <type_traits>
+#include <units.h>
+
+namespace
+{
+	using namespace units;
+	using namespace units::length;
+	using namespace units::time;
+	using namespace units::mass;
+	using namespace units::velocity;
+	using namespace units::pressure;
+	using namespace units::angle;
+	using namespace units::torque;
+
+	// A generous floating-point tolerance for the general-wrapper assertions (pi conversions, unit reconciliation).
+	constexpr double kGeneralWrapperTol = 1e-9;
+
+	// Detection idiom used to prove which wrapper operators are (SFINAE-)formable. NOTE: a `true` here means the
+	// operator PARTICIPATES in overload resolution — it does NOT prove the body instantiates (see Wart_LossyInt).
+	template<class A, class B, class = void>
+	struct genWrap_hasAdd : std::false_type
+	{
+	};
+	template<class A, class B>
+	struct genWrap_hasAdd<A, B, std::void_t<decltype(std::declval<A>() + std::declval<B>())>> : std::true_type
+	{
+	};
+
+	template<class A, class B, class = void>
+	struct genWrap_hasSub : std::false_type
+	{
+	};
+	template<class A, class B>
+	struct genWrap_hasSub<A, B, std::void_t<decltype(std::declval<A>() - std::declval<B>())>> : std::true_type
+	{
+	};
+
+	template<class A, class B, class = void>
+	struct genWrap_hasMul : std::false_type
+	{
+	};
+	template<class A, class B>
+	struct genWrap_hasMul<A, B, std::void_t<decltype(std::declval<A>() * std::declval<B>())>> : std::true_type
+	{
+	};
+} // namespace
+
+//======================================================================================================================
+//	POINT / DELTA ALGEBRA over a zero-datum unit (length)
+//======================================================================================================================
+
+TEST(GeneralWrapper, LengthPointMinusPointIsDelta)
+{
+	const auto d = absolute<meters<double>>(meters<double>(5)) - absolute<meters<double>>(meters<double>(3));
+	static_assert(std::is_same_v<std::remove_const_t<decltype(d)>, delta<meters<double>>>, "point - point -> delta");
+	EXPECT_DOUBLE_EQ(2.0, d.value());
+}
+
+TEST(GeneralWrapper, LengthPointPlusDeltaIsPoint)
+{
+	const auto p = absolute<meters<double>>(meters<double>(5)) + delta<meters<double>>(meters<double>(3));
+	static_assert(std::is_same_v<std::remove_const_t<decltype(p)>, absolute<meters<double>>>, "point + delta -> point");
+	// 5 m + 3 m = 8 m (a zero-datum unit: absolute and delta add like plain numbers).
+	EXPECT_DOUBLE_EQ(8.0, p.value());
+}
+
+TEST(GeneralWrapper, LengthPointMinusDeltaIsPoint)
+{
+	const auto p = absolute<meters<double>>(meters<double>(5)) - delta<meters<double>>(meters<double>(3));
+	static_assert(std::is_same_v<std::remove_const_t<decltype(p)>, absolute<meters<double>>>, "point - delta -> point");
+	EXPECT_DOUBLE_EQ(2.0, p.value());
+}
+
+TEST(GeneralWrapper, LengthDeltaPlusPointCommutes)
+{
+	const auto p = delta<meters<double>>(meters<double>(3)) + absolute<meters<double>>(meters<double>(5));
+	static_assert(std::is_same_v<std::remove_const_t<decltype(p)>, absolute<meters<double>>>, "delta + point -> point");
+	EXPECT_DOUBLE_EQ(8.0, p.value());
+}
+
+TEST(GeneralWrapper, LengthDeltaPlusDelta)
+{
+	const auto d = delta<meters<double>>(meters<double>(3)) + delta<meters<double>>(meters<double>(4));
+	static_assert(std::is_same_v<std::remove_const_t<decltype(d)>, delta<meters<double>>>, "delta + delta -> delta");
+	EXPECT_DOUBLE_EQ(7.0, d.value());
+}
+
+TEST(GeneralWrapper, LengthDeltaMinusDelta)
+{
+	const auto d = delta<meters<double>>(meters<double>(7)) - delta<meters<double>>(meters<double>(4));
+	static_assert(std::is_same_v<std::remove_const_t<decltype(d)>, delta<meters<double>>>, "delta - delta -> delta");
+	EXPECT_DOUBLE_EQ(3.0, d.value());
+}
+
+TEST(GeneralWrapper, LengthCompoundAssignMovesPoint)
+{
+	absolute<meters<double>> p(meters<double>(5));
+	p += delta<meters<double>>(meters<double>(3));
+	EXPECT_DOUBLE_EQ(8.0, p.value());
+	p -= delta<meters<double>>(meters<double>(1));
+	EXPECT_DOUBLE_EQ(7.0, p.value());
+}
+
+//======================================================================================================================
+//	CROSS-UNIT RECONCILIATION (scale only for zero-datum units)
+//======================================================================================================================
+
+TEST(GeneralWrapper, LengthCrossUnitPointDifference)
+{
+	// 5 m - 3 ft (= 0.9144 m) = 4.0856 m, expressed in the common (finer) unit. Compare via a conversion to a
+	// known unit so the test is independent of which unit std::common_type selects.
+	const auto d = absolute<meters<double>>(meters<double>(5)) - absolute<feet<double>>(feet<double>(3));
+	EXPECT_NEAR(4.0856, d.template to<meters<double>>().value(), kGeneralWrapperTol);
+}
+
+TEST(GeneralWrapper, LengthCrossUnitDeltaSumScaleReconciles)
+{
+	// 1 km delta + 500 m delta = 1500 m delta (scale reconciliation to the common/finer unit, no datum).
+	const auto d = delta<kilometers<double>>(kilometers<double>(1)) + delta<meters<double>>(meters<double>(500));
+	EXPECT_DOUBLE_EQ(1.5, d.template to<kilometers<double>>().value());
+}
+
+TEST(GeneralWrapper, ZeroDatumAbsoluteAndDeltaConversionsAgree)
+{
+	// For a non-affine (zero-datum) unit, `absolute::to` (offset applied) and `delta::to` (scale only) MUST agree,
+	// because the offset is zero. This is the property that separates general units from temperatures.
+	const auto ptFeet    = absolute<meters<double>>(meters<double>(2)).to<feet<double>>();
+	const auto deltaFeet = delta<meters<double>>(meters<double>(2)).to<feet<double>>();
+	static_assert(std::is_same_v<std::remove_const_t<decltype(ptFeet)>, absolute<feet<double>>>, "absolute::to -> absolute<V>");
+	static_assert(std::is_same_v<std::remove_const_t<decltype(deltaFeet)>, delta<feet<double>>>, "delta::to -> delta<V>");
+	EXPECT_DOUBLE_EQ(ptFeet.value(), deltaFeet.value());
+	EXPECT_NEAR(6.56167979, ptFeet.value(), 1e-6);
+}
+
+//======================================================================================================================
+//	ANGLE — the pi-carrying units (highest-value wart target)
+//======================================================================================================================
+
+TEST(GeneralWrapper, AngleDeltaDegreesToRadiansCarriesPi)
+{
+	// `delta::to` strips the datum but MUST keep the pi exponent: 90 deg delta = pi/2 rad delta.
+	const auto rad = delta<degrees<double>>(degrees<double>(90)).to<radians<double>>();
+	EXPECT_NEAR(units::detail::PI_VAL / 2.0, rad.value(), kGeneralWrapperTol);
+}
+
+TEST(GeneralWrapper, AngleAbsoluteDegreesToRadiansCarriesPi)
+{
+	const auto rad = absolute<degrees<double>>(degrees<double>(90)).to<radians<double>>();
+	EXPECT_NEAR(units::detail::PI_VAL / 2.0, rad.value(), kGeneralWrapperTol);
+}
+
+TEST(GeneralWrapper, AngleDeltaRadiansToDegrees)
+{
+	const auto deg = delta<radians<double>>(radians<double>(units::detail::PI_VAL)).to<degrees<double>>();
+	EXPECT_NEAR(180.0, deg.value(), kGeneralWrapperTol);
+}
+
+TEST(GeneralWrapper, AngleDeltaTurnsConvertBothWays)
+{
+	const auto deg = delta<turns<double>>(turns<double>(1)).to<degrees<double>>();
+	EXPECT_NEAR(360.0, deg.value(), kGeneralWrapperTol);
+	const auto rad = delta<turns<double>>(turns<double>(1)).to<radians<double>>();
+	EXPECT_NEAR(2.0 * units::detail::PI_VAL, rad.value(), kGeneralWrapperTol);
+}
+
+TEST(GeneralWrapper, AngleDeltaGradiansAndArcminutes)
+{
+	// 100 gradians = 90 degrees; 60 arcminutes = 1 degree (pure ratio units, no pi of their own beyond degrees').
+	EXPECT_NEAR(90.0, delta<gradians<double>>(gradians<double>(100)).to<degrees<double>>().value(), kGeneralWrapperTol);
+	EXPECT_NEAR(1.0, delta<arcminutes<double>>(arcminutes<double>(60)).to<degrees<double>>().value(), kGeneralWrapperTol);
+}
+
+TEST(GeneralWrapper, AngleMixedPiDeltaSumReconciles)
+{
+	// delta 90 deg + delta pi/2 rad = 180 deg (pi reconciliation through the scale-only delta path).
+	const auto d = delta<degrees<double>>(degrees<double>(90)) + delta<radians<double>>(radians<double>(units::detail::PI_VAL / 2.0));
+	EXPECT_NEAR(180.0, d.value(), kGeneralWrapperTol);
+}
+
+TEST(GeneralWrapper, AngleAbsoluteCrossUnitDifferenceReconcilesPi)
+{
+	const auto d = absolute<degrees<double>>(degrees<double>(180)) - absolute<radians<double>>(radians<double>(units::detail::PI_VAL));
+	EXPECT_NEAR(0.0, d.value(), kGeneralWrapperTol);
+}
+
+TEST(GeneralWrapper, AngleAbsolutePointMovedByAngularDelta)
+{
+	// pi rad point moved +90 deg = 3pi/2 rad.
+	const auto p = absolute<radians<double>>(radians<double>(units::detail::PI_VAL)) + delta<degrees<double>>(degrees<double>(90));
+	EXPECT_NEAR(3.0 * units::detail::PI_VAL / 2.0, p.value(), kGeneralWrapperTol);
+}
+
+//======================================================================================================================
+//	OTHER DIMENSIONS — proving "general" is genuinely general
+//======================================================================================================================
+
+TEST(GeneralWrapper, TimeEpochMinusEpochIsDuration)
+{
+	const auto d = absolute<seconds<double>>(seconds<double>(100)) - absolute<seconds<double>>(seconds<double>(40));
+	EXPECT_DOUBLE_EQ(60.0, d.value());
+	// cross-unit: 2 minutes epoch - 30 s epoch = 90 s, expressed in minutes.
+	const auto d2 = absolute<minutes<double>>(minutes<double>(2)) - absolute<seconds<double>>(seconds<double>(30));
+	EXPECT_NEAR(1.5, d2.value(), kGeneralWrapperTol);
+}
+
+TEST(GeneralWrapper, MassPointArithmetic)
+{
+	const auto d = absolute<kilograms<double>>(kilograms<double>(5)) - absolute<grams<double>>(grams<double>(500));
+	EXPECT_NEAR(4.5, d.value(), kGeneralWrapperTol);
+}
+
+TEST(GeneralWrapper, VelocityCompoundUnitWraps)
+{
+	const auto d = absolute<meters_per_second<double>>(meters_per_second<double>(10)) - absolute<meters_per_second<double>>(meters_per_second<double>(4));
+	EXPECT_DOUBLE_EQ(6.0, d.value());
+	const auto dv = delta<meters_per_second<double>>(meters_per_second<double>(10)).to<kilometers_per_hour<double>>();
+	EXPECT_NEAR(36.0, dv.value(), kGeneralWrapperTol);
+}
+
+TEST(GeneralWrapper, PressureGaugeStyleDifference)
+{
+	// absolute (bar) minus reference (bar) = gauge-style delta.
+	const auto d = absolute<pascals<double>>(pascals<double>(101325)) - absolute<pascals<double>>(pascals<double>(101000));
+	EXPECT_DOUBLE_EQ(325.0, d.value());
+}
+
+TEST(GeneralWrapper, TorqueDerivedNamedUnitWraps)
+{
+	const auto d = absolute<newton_meters<double>>(newton_meters<double>(10)) - absolute<newton_meters<double>>(newton_meters<double>(4));
+	EXPECT_DOUBLE_EQ(6.0, d.value());
+}
+
+TEST(GeneralWrapper, DimensionlessWrappersAreSane)
+{
+	const auto sum = absolute<dimensionless<double>>(dimensionless<double>(5)) + delta<dimensionless<double>>(dimensionless<double>(3));
+	EXPECT_DOUBLE_EQ(8.0, sum.value());
+	const auto diff = absolute<dimensionless<double>>(dimensionless<double>(5)) - absolute<dimensionless<double>>(dimensionless<double>(2));
+	EXPECT_DOUBLE_EQ(3.0, diff.value());
+}
+
+//======================================================================================================================
+//	SCALAR MULTIPLICATION
+//======================================================================================================================
+
+TEST(GeneralWrapper, DeltaScaledByScalar)
+{
+	const auto a = delta<meters<double>>(meters<double>(4)) * 3;
+	static_assert(std::is_same_v<std::remove_const_t<decltype(a)>, delta<meters<double>>>, "delta * scalar -> delta");
+	EXPECT_DOUBLE_EQ(12.0, a.value());
+	// commutative form.
+	const auto b = 2.5 * delta<meters<double>>(meters<double>(4));
+	EXPECT_DOUBLE_EQ(10.0, b.value());
+}
+
+//======================================================================================================================
+//	INTEGER UNDERLYING
+//======================================================================================================================
+
+TEST(GeneralWrapper, IntegerPointArithmetic)
+{
+	const auto d = absolute<meters<int>>(meters<int>(5)) - absolute<meters<int>>(meters<int>(3));
+	static_assert(std::is_same_v<std::remove_const_t<decltype(d)>, delta<meters<int>>>, "int point diff -> int delta");
+	EXPECT_EQ(2, d.value());
+	const auto p = absolute<meters<int>>(meters<int>(5)) + delta<meters<int>>(meters<int>(3));
+	EXPECT_EQ(8, p.value());
+}
+
+TEST(GeneralWrapper, IntegerLosslessCrossUnitDeltaConversion)
+{
+	// km -> m is lossless (x1000), so this compiles and is exact.
+	const auto m = delta<kilometers<int>>(kilometers<int>(2)).to<meters<int>>();
+	static_assert(std::is_same_v<std::remove_const_t<decltype(m)>, delta<meters<int>>>, "int delta km->m");
+	EXPECT_EQ(2000, m.value());
+}
+
+TEST(GeneralWrapper, IntegerDeltaScaledByInteger)
+{
+	const auto a = delta<meters<int>>(meters<int>(7)) * 3;
+	static_assert(std::is_same_v<std::remove_const_t<decltype(a)>, delta<meters<int>>>, "int delta * int -> int delta");
+	EXPECT_EQ(21, a.value());
+}
+
+//======================================================================================================================
+//	MIXED UNDERLYING — result carries the LHS unit type
+//======================================================================================================================
+
+TEST(GeneralWrapper, MixedUnderlyingPointDifferenceWidening)
+{
+	// lhs is double, rhs int: rhs widens losslessly into double; result carries the lhs unit (delta<meters<double>>).
+	const auto d = absolute<meters<double>>(meters<double>(5.5)) - absolute<meters<int>>(meters<int>(2));
+	static_assert(std::is_same_v<std::remove_const_t<decltype(d)>, delta<meters<double>>>, "mixed -> lhs unit (double)");
+	EXPECT_DOUBLE_EQ(3.5, d.value());
+}
+
+//======================================================================================================================
+//	COMPARISONS
+//======================================================================================================================
+
+TEST(GeneralWrapper, PointComparisonsCrossUnit)
+{
+	EXPECT_TRUE(absolute<meters<double>>(meters<double>(1)) < absolute<feet<double>>(feet<double>(10)));
+	EXPECT_TRUE(absolute<meters<double>>(meters<double>(1)) == absolute<centimeters<double>>(centimeters<double>(100)));
+	EXPECT_FALSE(absolute<meters<double>>(meters<double>(2)) == absolute<meters<double>>(meters<double>(3)));
+}
+
+TEST(GeneralWrapper, DeltaComparisonsCrossUnitScaleOnly)
+{
+	EXPECT_TRUE(delta<kilometers<double>>(kilometers<double>(1)) == delta<meters<double>>(meters<double>(1000)));
+	EXPECT_TRUE(delta<meters<double>>(meters<double>(1)) < delta<kilometers<double>>(kilometers<double>(1)));
+}
+
+TEST(GeneralWrapper, ComparisonOrderingCategories)
+{
+	// floating point -> partial_ordering; integer -> strong_ordering.
+	const auto ordf = absolute<meters<double>>(meters<double>(1)) <=> absolute<meters<double>>(meters<double>(2));
+	static_assert(std::is_same_v<std::remove_const_t<decltype(ordf)>, std::partial_ordering>, "double point -> partial_ordering");
+	EXPECT_EQ(std::partial_ordering::less, ordf);
+
+	const auto ordi = delta<meters<int>>(meters<int>(2)) <=> delta<meters<int>>(meters<int>(1));
+	static_assert(std::is_same_v<std::remove_const_t<decltype(ordi)>, std::strong_ordering>, "int delta -> strong_ordering");
+	EXPECT_EQ(std::strong_ordering::greater, ordi);
+}
+
+TEST(GeneralWrapper, NanPointComparesUnordered)
+{
+	const auto ord = absolute<meters<double>>(meters<double>(std::nan(""))) <=> absolute<meters<double>>(meters<double>(1));
+	EXPECT_EQ(std::partial_ordering::unordered, ord);
+}
+
+//======================================================================================================================
+//	TYPE ALGEBRA — what MUST be ill-formed (via the detection idiom)
+//======================================================================================================================
+
+TEST(GeneralWrapper, ForbiddenOperationsAreIllFormed)
+{
+	using Abs = absolute<meters<double>>;
+	using Del = delta<meters<double>>;
+
+	// point + point has no meaning (sum of two datums) — MUST be ill-formed.
+	static_assert(!genWrap_hasAdd<Abs, Abs>::value, "absolute + absolute is ill-formed");
+	// a point does not scale — only a delta does.
+	static_assert(!genWrap_hasMul<Abs, double>::value, "absolute * scalar is ill-formed");
+	// delta * delta is not a length (would be an area); no such operator.
+	static_assert(!genWrap_hasMul<Del, Del>::value, "delta * delta is ill-formed");
+	// delta - point is not defined (point - delta is; delta - point is not).
+	static_assert(!genWrap_hasSub<Del, Abs>::value, "delta - absolute is ill-formed");
+
+	// the sanctioned operations ARE formable.
+	static_assert(genWrap_hasSub<Abs, Abs>::value, "absolute - absolute is well-formed");
+	static_assert(genWrap_hasAdd<Abs, Del>::value, "absolute + delta is well-formed");
+	static_assert(genWrap_hasAdd<Del, Abs>::value, "delta + absolute is well-formed");
+	static_assert(genWrap_hasAdd<Del, Del>::value, "delta + delta is well-formed");
+	static_assert(genWrap_hasSub<Del, Del>::value, "delta - delta is well-formed");
+	static_assert(genWrap_hasMul<Del, double>::value, "delta * scalar is well-formed");
+	SUCCEED();
+}
+
+//======================================================================================================================
+//	CONSTEXPR — the wrappers are fully usable at compile time
+//======================================================================================================================
+
+TEST(GeneralWrapper, ConstexprAlgebra)
+{
+	constexpr auto d = absolute<meters<double>>(meters<double>(5)) - absolute<meters<double>>(meters<double>(3));
+	static_assert(d.value() == 2.0, "constexpr point - point");
+	constexpr auto p = absolute<meters<double>>(meters<double>(5)) + delta<meters<double>>(meters<double>(3));
+	static_assert(p.value() == 8.0, "constexpr point + delta");
+	constexpr auto s = delta<meters<double>>(meters<double>(4)) * 3;
+	static_assert(s.value() == 12.0, "constexpr delta * scalar");
+	constexpr bool eq = delta<kilometers<double>>(kilometers<double>(1)) == delta<meters<double>>(meters<double>(1000));
+	static_assert(eq, "constexpr delta comparison");
+	constexpr auto conv = delta<meters<int>>(meters<int>(2)).to<centimeters<int>>();
+	static_assert(conv.value() == 200, "constexpr int delta conversion");
+	SUCCEED();
+}
+
+//======================================================================================================================
+//	WARTS — cases that PIN the current (surprising) behavior. A future fix flips these deliberately.
+//======================================================================================================================
+
+TEST(GeneralWrapper, IntegerDeltaScaledByFractionPromotes)
+{
+	// A `delta<U<int>> * <double>` PROMOTES exactly as the wrapped plain unit does — the wrapper is never less
+	// precise than the type it wraps. (This previously truncated to an int; the delta scalar operator now
+	// delegates to the wrapped unit's own promoting `operator*`.)
+	const auto scaled = delta<meters<int>>(meters<int>(3)) * 2.5;
+	static_assert(std::is_same_v<std::remove_cvref_t<decltype(scaled.raw())>, double>, "delta<int> * double promotes to double");
+	EXPECT_DOUBLE_EQ(7.5, static_cast<double>(scaled.value()));
+
+	// It matches the wrapped plain unit exactly.
+	const auto promoted = meters<int>(3) * 2.5;
+	EXPECT_DOUBLE_EQ(static_cast<double>(promoted.value()), static_cast<double>(scaled.value()));
+
+	// An integer factor keeps the integer underlying (like the plain unit).
+	const auto intScaled = delta<meters<int>>(meters<int>(3)) * 4;
+	static_assert(std::is_same_v<std::remove_cvref_t<decltype(intScaled.raw())>, int>, "delta<int> * int stays int");
+	EXPECT_EQ(12, intScaled.value());
+}
+
+TEST(GeneralWrapper, CrossUnitIntegerReconcilesToFinerUnit)
+{
+	// Cross-unit wrapper operators reconcile to the COMMON (finer) unit, so neither operand order narrows an
+	// integer — both directions compile and compute correctly. (This previously hard-errored in one order,
+	// where the result was forced into the coarser lhs unit.)
+	static_assert(genWrap_hasAdd<delta<meters<int>>, delta<kilometers<int>>>::value, "m + km delta add");
+	static_assert(genWrap_hasAdd<delta<kilometers<int>>, delta<meters<int>>>::value, "km + m delta add");
+
+	const auto a = delta<meters<int>>(meters<int>(500)) + delta<kilometers<int>>(kilometers<int>(1));
+	EXPECT_EQ(1500, a.value());    // in meters (the finer common unit)
+
+	const auto b = delta<kilometers<int>>(kilometers<int>(1)) + delta<meters<int>>(meters<int>(500));
+	EXPECT_EQ(1500, b.value());    // same result regardless of operand order
+
+	// Comparison across the two integer units is likewise well-formed both ways.
+	EXPECT_TRUE((delta<kilometers<int>>(kilometers<int>(1)) == delta<meters<int>>(meters<int>(1000))));
+	EXPECT_TRUE((delta<meters<int>>(meters<int>(1000)) == delta<kilometers<int>>(kilometers<int>(1))));
+}
+
+TEST(GeneralWrapper, OffsetFreeUnitBehavesIdenticallyUnderAbsoluteAndDelta)
+{
+	// For a unit that is ALREADY offset-free (meters), wrapping it as absolute vs delta yields identical numeric
+	// conversion results — the whole premise of the "general" (zero-datum) slice. (Contrast: temperatures differ.)
+	constexpr double meterValue = 12.0;
+	const auto asPoint = absolute<meters<double>>(meters<double>(meterValue)).to<feet<double>>();
+	const auto asDelta = delta<meters<double>>(meters<double>(meterValue)).to<feet<double>>();
+	EXPECT_DOUBLE_EQ(asPoint.value(), asDelta.value());
+}

--- a/test/wrapperTest_safety.h
+++ b/test/wrapperTest_safety.h
@@ -1,0 +1,408 @@
+// ---------------------------------------------------------------------------------------------------------------------
+//			                 __
+//			               _/ /          /
+//			    __________/  /__ _______/
+//			   /  _______   ___//  ____/
+//			  /  /___   /  /   /  /   /   SYSTEMS
+//			  \____  \ /  /   /  /   /    & TECHNOLOGY
+//			 _____/  //  /___/  /   /     RESEARCH
+//			/_______/ \________/   /
+//			                      /
+//			                     /
+// ---------------------------------------------------------------------------------------------------------------------
+//
+/// @file       wrapperTest_safety.h
+/// @author     Nic Holthaus
+/// @date       8/16/2026
+/// @copyright  (c) 2026 STR. The use of this software is subject to the terms and conditions outlined
+///             in the LICENSE file. By using this software, the user agrees to be bound by the terms and
+///             conditions set forth in the LICENSE file.
+//
+// ---------------------------------------------------------------------------------------------------------------------
+//
+/// @brief      Adversarial type-safety tests for the `absolute<U>` / `delta<U>` affine wrappers.
+/// @details    Covers the safety boundaries where warts hide: point+point and wrong-dimension rejection,
+///             plain/wrapper mixing, implicit-conversion rejection, trivial-copyability (the zero-cost claim),
+///             common_type / hashing / cmath / formatting behavior, and constexpr usability. Rejection cases are
+///             proven WITHOUT a compile-fail file by asserting the operation is SFINAE-undetectable, so the whole
+///             surface is exercised in one compiling translation unit.
+//
+// ---------------------------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <functional>
+#include <gtest/gtest.h>
+#include <sstream>
+#include <string>
+#include <type_traits>
+#include <units.h>
+
+using namespace units;
+
+namespace
+{
+	// Concrete unit types under test. Fully qualified and prefixed to sidestep the single-letter globals that
+	// UNIT_ADD_CONSTANT injects into `units` (e.g. `C` = coulombs, `ct` = carats), which a `using namespace units`
+	// makes ambiguous with a short alias.
+	using Meter     = units::length::meters<double>;
+	using Foot      = units::length::feet<double>;
+	using MeterInt  = units::length::meters<int>;
+	using Second    = units::time::seconds<double>;
+	using Cel       = units::temperature::celsius<double>;
+	using Fah       = units::temperature::fahrenheit<double>;
+	using Kel       = units::temperature::kelvin<double>;
+
+	//------------------------------------------------------------------------------------------------------------------
+	//	SFINAE detection idiom
+	//------------------------------------------------------------------------------------------------------------------
+	// A generic "is this expression well-formed?" probe: `Detected<Op, Args...>` is true iff `Op<Args...>` names a
+	// type. Applying it to `decltype`-based aliases lets a negative (should-not-compile) case be asserted as a
+	// COMPILING `static_assert(!Detected<...>)`, so no separate compile-fail harness is needed.
+
+	template<class, template<class...> class Op, class... Args>
+	struct detector : std::false_type
+	{
+	};
+	template<template<class...> class Op, class... Args>
+	struct detector<std::void_t<Op<Args...>>, Op, Args...> : std::true_type
+	{
+	};
+	template<template<class...> class Op, class... Args>
+	inline constexpr bool Detected = detector<void, Op, Args...>::value;
+
+	// Expression aliases (each is well-formed only if the operator/function resolves).
+	template<class A, class B> using AddExpr    = decltype(std::declval<A>() + std::declval<B>());
+	template<class A, class B> using SubExpr    = decltype(std::declval<A>() - std::declval<B>());
+	template<class A, class B> using MulExpr    = decltype(std::declval<A>() * std::declval<B>());
+	template<class A, class B> using DivExpr    = decltype(std::declval<A>() / std::declval<B>());
+	template<class A, class B> using EqExpr     = decltype(std::declval<A>() == std::declval<B>());
+	template<class A, class B> using PlusEqExpr = decltype(std::declval<A&>() += std::declval<B>());
+	template<class A>          using NegExpr    = decltype(-std::declval<A>());
+	template<class A>          using StreamExpr = decltype(std::declval<std::ostringstream&>() << std::declval<A>());
+	template<class A>          using ToStringExpr = decltype(units::to_string(std::declval<A>()));
+	template<class A>          using AbsExpr    = decltype(units::abs(std::declval<A>()));
+	template<class A>          using SqrtExpr   = decltype(units::sqrt(std::declval<A>()));
+	template<class A, class B> using FmaxExpr   = decltype(units::fmax(std::declval<A>(), std::declval<B>()));
+	template<class A>          using HashExpr   = decltype(std::hash<A>{}(std::declval<A>()));
+	template<class A, class B> using CommonType = std::common_type_t<A, B>;
+} // namespace
+
+//======================================================================================================================
+//	TRIVIAL-COPYABILITY & LAYOUT  (the zero-cost claim)
+//======================================================================================================================
+// The wrappers must add ZERO representation overhead: same size as the wrapped unit, trivially copyable, standard
+// layout. A regression here silently defeats the library's zero-cost promise, so these are compile-time invariants.
+
+static_assert(std::is_trivially_copyable_v<absolute<Cel>>, "absolute<affine> must stay trivially copyable");
+static_assert(std::is_trivially_copyable_v<delta<Cel>>, "delta<affine> must stay trivially copyable");
+static_assert(std::is_trivially_copyable_v<absolute<Meter>>, "absolute<linear> must stay trivially copyable");
+static_assert(std::is_trivially_copyable_v<delta<Meter>>, "delta<linear> must stay trivially copyable");
+static_assert(std::is_standard_layout_v<absolute<Cel>>, "absolute must stay standard layout");
+static_assert(std::is_standard_layout_v<delta<Cel>>, "delta must stay standard layout");
+static_assert(sizeof(absolute<Cel>) == sizeof(Cel), "absolute must be the size of its wrapped unit");
+static_assert(sizeof(delta<Cel>) == sizeof(Cel), "delta must be the size of its wrapped unit");
+static_assert(std::is_trivially_destructible_v<absolute<Cel>>, "absolute must be trivially destructible");
+static_assert(std::is_nothrow_default_constructible_v<absolute<Cel>>, "absolute default-ctor must be noexcept");
+static_assert(std::is_nothrow_move_constructible_v<absolute<Cel>>, "absolute move-ctor must be noexcept");
+
+//======================================================================================================================
+//	EXPLICIT CONSTRUCTION / NO IMPLICIT CONVERSION
+//======================================================================================================================
+// The unit->wrapper constructor is `explicit`: a bare unit must NOT silently become a point or a delta (that is the
+// exact point-vs-delta ambiguity the wrappers exist to prevent), and a wrapper must not silently decay to a unit.
+
+static_assert(std::is_constructible_v<absolute<Cel>, Cel>, "absolute must be explicitly constructible from its unit");
+static_assert(std::is_constructible_v<delta<Cel>, Cel>, "delta must be explicitly constructible from its unit");
+static_assert(!std::is_convertible_v<Cel, absolute<Cel>>, "unit must NOT implicitly convert to a point");
+static_assert(!std::is_convertible_v<Cel, delta<Cel>>, "unit must NOT implicitly convert to a delta");
+static_assert(!std::is_convertible_v<absolute<Cel>, Cel>, "a point must NOT implicitly decay to a bare unit");
+static_assert(!std::is_convertible_v<delta<Cel>, Cel>, "a delta must NOT implicitly decay to a bare unit");
+// A point and a delta of the same unit are DISTINCT types with no cross-conversion (the whole reason they exist).
+static_assert(!std::is_convertible_v<absolute<Cel>, delta<Cel>>, "point must NOT convert to delta");
+static_assert(!std::is_convertible_v<delta<Cel>, absolute<Cel>>, "delta must NOT convert to point");
+static_assert(!std::is_constructible_v<absolute<Cel>, delta<Cel>>, "point must NOT be constructible from a delta");
+static_assert(!std::is_constructible_v<delta<Cel>, absolute<Cel>>, "delta must NOT be constructible from a point");
+
+//======================================================================================================================
+//	POINT + POINT AND WRONG-DIMENSION ARITHMETIC ARE REJECTED
+//======================================================================================================================
+// The affine algebra: absolute+absolute is meaningless, and any cross-dimension operation is a category error. All of
+// these must be SFINAE-undetectable (soft-fail), which keeps the operators well-behaved in overload resolution AND
+// proves the compile-time rejection without a compile-fail file.
+
+static_assert(!Detected<AddExpr, absolute<Cel>, absolute<Cel>>, "absolute + absolute (point + point) must not compile");
+static_assert(!Detected<AddExpr, absolute<Fah>, absolute<Cel>>, "point + point must be rejected even cross-unit");
+static_assert(!Detected<AddExpr, absolute<Meter>, delta<Second>>, "point + delta of wrong dimension must not compile");
+static_assert(!Detected<SubExpr, absolute<Meter>, absolute<Second>>, "point - point of wrong dimension must not compile");
+static_assert(!Detected<AddExpr, delta<Meter>, delta<Second>>, "delta + delta of wrong dimension must not compile");
+static_assert(!Detected<SubExpr, delta<Meter>, delta<Second>>, "delta - delta of wrong dimension must not compile");
+static_assert(!Detected<AddExpr, absolute<Cel>, delta<Meter>>, "point + delta of wrong dimension must not compile");
+static_assert(!Detected<SubExpr, absolute<Cel>, delta<Second>>, "point - delta of wrong dimension must not compile");
+// Comparisons: cross-dimension compare is a category error and must be a SOFT fail (SFINAE), not a hard error.
+static_assert(!Detected<EqExpr, absolute<Meter>, absolute<Second>>, "cross-dimension point compare must not compile");
+static_assert(!Detected<EqExpr, delta<Meter>, delta<Second>>, "cross-dimension delta compare must not compile");
+// A point and a delta never compare or add to each other directly (they are different roles).
+static_assert(!Detected<EqExpr, absolute<Cel>, delta<Cel>>, "point vs delta comparison must not compile");
+// += / -= only accept a delta on the rhs, never another point.
+static_assert(!Detected<PlusEqExpr, absolute<Cel>, absolute<Cel>>, "absolute += absolute must not compile");
+static_assert(Detected<PlusEqExpr, absolute<Cel>, delta<Cel>>, "absolute += delta MUST compile");
+
+//======================================================================================================================
+//	PLAIN-UNIT / WRAPPER MIXING IS REJECTED  (a plain unit is role-ambiguous)
+//======================================================================================================================
+// A bare `meters` is ambiguous — is it a point or an amount? Mixing it with a wrapper must NOT compile in either
+// order; the user must state the role by wrapping. This is the correct, non-footgun behavior.
+
+static_assert(!Detected<AddExpr, absolute<Meter>, Meter>, "point + plain-unit must not compile (role-ambiguous)");
+static_assert(!Detected<AddExpr, Meter, absolute<Meter>>, "plain-unit + point must not compile (role-ambiguous)");
+static_assert(!Detected<SubExpr, absolute<Meter>, Meter>, "point - plain-unit must not compile (role-ambiguous)");
+static_assert(!Detected<AddExpr, delta<Meter>, Meter>, "delta + plain-unit must not compile (role-ambiguous)");
+static_assert(!Detected<AddExpr, Meter, delta<Meter>>, "plain-unit + delta must not compile (role-ambiguous)");
+static_assert(!Detected<EqExpr, absolute<Meter>, Meter>, "point == plain-unit must not compile (role-ambiguous)");
+static_assert(!Detected<PlusEqExpr, absolute<Meter>, Meter>, "point += plain-unit must not compile (role-ambiguous)");
+
+//======================================================================================================================
+//	MULTIPLICATION / DIVISION / NEGATION SURFACE  (documented gaps)
+//======================================================================================================================
+// A delta scales by a bare scalar (both orders). It intentionally does NOT multiply by another delta (a delta*delta
+// would change dimension and lose the affine role), and — a usability GAP flagged for the author — there is no
+// `delta / scalar` and no unary `-delta`. These asserts pin the CURRENT surface so a future addition is a conscious
+// change, not an accident.
+static_assert(Detected<MulExpr, delta<Meter>, double>, "delta * scalar MUST compile");
+static_assert(Detected<MulExpr, double, delta<Meter>>, "scalar * delta MUST compile");
+static_assert(!Detected<MulExpr, delta<Meter>, delta<Meter>>, "delta * delta must not compile");
+static_assert(Detected<DivExpr, delta<Meter>, double>, "delta / scalar MUST compile");
+static_assert(Detected<NegExpr, delta<Meter>>, "unary -delta MUST compile");
+static_assert(!Detected<SubExpr, delta<Meter>, absolute<Meter>>, "delta - point is not provided (only point - delta)");
+
+//======================================================================================================================
+//	LIBRARY-FUNCTION / FORMATTING BEHAVIOR  (documented non-support)
+//======================================================================================================================
+// The wrappers are unformatted and outside the cmath/hash surface. These are pinned as CURRENT behavior; a user who
+// expects `std::cout << point` or `units::abs(delta)` to work should reach through `.quantity()`.
+static_assert(!Detected<StreamExpr, absolute<Cel>>, "operator<< on a wrapper is not provided (unformatted)");
+static_assert(!Detected<StreamExpr, delta<Cel>>, "operator<< on a wrapper is not provided (unformatted)");
+static_assert(!Detected<ToStringExpr, absolute<Cel>>, "units::to_string on a wrapper is not provided");
+static_assert(!Detected<AbsExpr, delta<Meter>>, "units::abs on a wrapper is not provided");
+static_assert(!Detected<SqrtExpr, delta<Meter>>, "units::sqrt on a wrapper is not provided");
+static_assert(!Detected<FmaxExpr, delta<Meter>, delta<Meter>>, "units::fmax on a wrapper is not provided");
+static_assert(!Detected<HashExpr, absolute<Cel>>, "std::hash on a wrapper is not provided");
+// common_type of two DIFFERENT wrappers is SFINAE-empty (no common type), even for same-dimension units. The
+// identity case (same type) is defined by the standard and is the type itself.
+static_assert(std::is_same_v<CommonType<absolute<Cel>, absolute<Cel>>, absolute<Cel>>, "common_type of identical wrappers is the type");
+static_assert(!Detected<CommonType, absolute<Cel>, absolute<Fah>>, "common_type across differing units is undefined (SFINAE-empty)");
+static_assert(!Detected<CommonType, delta<Cel>, delta<Fah>>, "common_type across differing delta units is undefined");
+static_assert(!Detected<CommonType, absolute<Cel>, delta<Cel>>, "common_type of point vs delta is undefined");
+
+//======================================================================================================================
+//	CONSTEXPR USABILITY
+//======================================================================================================================
+// Every wrapper operation is usable in a constant expression (the operators and .to<> are constexpr).
+constexpr absolute<Cel> kConstA{Cel(20.0)};
+constexpr absolute<Cel> kConstB{Cel(5.0)};
+constexpr delta<Cel>    kConstDiff = kConstA - kConstB;
+static_assert(kConstDiff.value() == 15.0, "point - point is constexpr");
+constexpr absolute<Cel> kConstMoved = kConstA + delta<Cel>{Cel(10.0)};
+static_assert(kConstMoved.value() == 30.0, "point + delta is constexpr");
+constexpr absolute<Cel> kConstMovedDown = kConstA - delta<Cel>{Cel(10.0)};
+static_assert(kConstMovedDown.value() == 10.0, "point - delta is constexpr");
+constexpr delta<Cel> kConstScaled = kConstDiff * 2.0;
+static_assert(kConstScaled.value() == 30.0, "delta * scalar is constexpr");
+static_assert(kConstA == kConstA, "point == point is constexpr");
+static_assert(kConstB < kConstA, "point <=> point is constexpr");
+static_assert(kConstDiff == delta<Cel>{Cel(15.0)}, "delta == delta is constexpr");
+
+//======================================================================================================================
+//	RUNTIME BEHAVIOR
+//======================================================================================================================
+
+//----------------------------------------------------------------------------------------------------------------------
+//	TEST: pointMinusPointIsADelta
+//----------------------------------------------------------------------------------------------------------------------
+TEST(WrapperSafety, pointMinusPointIsADelta)
+{
+	const absolute<Cel> a{Cel(20.0)};
+	const absolute<Cel> b{Cel(5.0)};
+	const delta<Cel>    d = a - b;
+	EXPECT_NEAR(15.0, d.value(), 5.0e-12);
+	// The delta is truly a delta type (no datum re-applied on conversion).
+	static_assert(std::is_same_v<decltype(d), const delta<Cel>>, "point - point yields a delta");
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+//	TEST: crossUnitPointSubtractionAppliesDatum
+//----------------------------------------------------------------------------------------------------------------------
+TEST(WrapperSafety, crossUnitPointSubtractionAppliesDatum)
+{
+	// 100 degC and 373.15 K are the same point; their difference is exactly zero.
+	const absolute<Cel> c{Cel(100.0)};
+	const absolute<Kel> k{Kel(373.15)};
+	const auto          d = c - k;    // delta in the common unit
+	EXPECT_NEAR(0.0, d.value(), 5.0e-11);
+	// 100 degC point minus 32 degF point (= 0 degC) is a 100 degC delta.
+	const absolute<Fah> f{Fah(32.0)};
+	EXPECT_NEAR(100.0, (c - f).value(), 5.0e-11);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+//	TEST: pointPlusDeltaMovesThepoint
+//----------------------------------------------------------------------------------------------------------------------
+TEST(WrapperSafety, pointPlusDeltaMovesThePoint)
+{
+	const absolute<Cel> a{Cel(20.0)};
+	EXPECT_NEAR(30.0, (a + delta<Cel>{Cel(10.0)}).value(), 5.0e-12);
+	EXPECT_NEAR(10.0, (a - delta<Cel>{Cel(10.0)}).value(), 5.0e-12);
+	// delta + point is the commutative form and yields the SAME point (not a wart).
+	EXPECT_NEAR(30.0, (delta<Cel>{Cel(10.0)} + a).value(), 5.0e-12);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+//	TEST: pointPlusMixedUnitDeltaScalesOnly
+//----------------------------------------------------------------------------------------------------------------------
+TEST(WrapperSafety, pointPlusMixedUnitDeltaScalesOnly)
+{
+	// An 18 degF delta is a 10 degC delta (degree SIZE, no datum). Adding it to 20 degC yields 30 degC.
+	const absolute<Cel> a{Cel(20.0)};
+	const delta<Fah>    dF{Fah(18.0)};
+	EXPECT_NEAR(30.0, (a + dF).value(), 5.0e-11);
+	// A length example with feet: 10 m minus ~1 m expressed in feet.
+	const absolute<Meter> pm{Meter(10.0)};
+	const absolute<Foot>  pf{Foot(3.280839895013123)};    // 1 m
+	EXPECT_NEAR(9.0, (pm - pf).value(), 5.0e-9);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+//	TEST: deltaConversionIsScaleOnly
+//----------------------------------------------------------------------------------------------------------------------
+TEST(WrapperSafety, deltaConversionIsScaleOnly)
+{
+	// A 10 degC delta is an 18 degF delta (degree size), NOT an absolute 50 degF.
+	const delta<Cel> d{Cel(10.0)};
+	EXPECT_NEAR(18.0, d.to<Fah>().value(), 5.0e-11);
+	// Round-trips back to itself.
+	EXPECT_NEAR(10.0, d.to<Fah>().to<Cel>().value(), 5.0e-11);
+	// Self-conversion is the identity.
+	EXPECT_NEAR(10.0, d.to<Cel>().value(), 5.0e-12);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+//	TEST: absoluteConversionAppliesDatum
+//----------------------------------------------------------------------------------------------------------------------
+TEST(WrapperSafety, absoluteConversionAppliesDatum)
+{
+	// 0 degC as an absolute point is 32 degF (the datum IS applied on a point conversion).
+	const absolute<Cel> a{Cel(0.0)};
+	EXPECT_NEAR(32.0, a.to<Fah>().value(), 5.0e-11);
+	EXPECT_NEAR(273.15, a.to<Kel>().value(), 5.0e-11);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+//	TEST: deltaArithmeticAndScaling
+//----------------------------------------------------------------------------------------------------------------------
+TEST(WrapperSafety, deltaArithmeticAndScaling)
+{
+	const delta<Cel> a{Cel(10.0)};
+	const delta<Cel> b{Cel(4.0)};
+	EXPECT_NEAR(14.0, (a + b).value(), 5.0e-12);
+	EXPECT_NEAR(6.0, (a - b).value(), 5.0e-12);
+	EXPECT_NEAR(30.0, (a * 3.0).value(), 5.0e-12);
+	EXPECT_NEAR(20.0, (2.0 * a).value(), 5.0e-12);
+	// A cross-unit delta sum reconciles by scale (5 degC delta + 9 degF delta[=5 degC] = 10 degC delta),
+	// expressed in the common (finer) unit; compare via a conversion to celsius-degrees.
+	const delta<Fah> f{Fah(9.0)};
+	EXPECT_NEAR(10.0, (delta<Cel>{Cel(5.0)} + f).template to<Cel>().value(), 5.0e-11);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+//	TEST: compoundAssignmentMovesInPlace
+//----------------------------------------------------------------------------------------------------------------------
+TEST(WrapperSafety, compoundAssignmentMovesInPlace)
+{
+	absolute<Cel> a{Cel(0.0)};
+	a += delta<Cel>{Cel(5.0)};
+	EXPECT_NEAR(5.0, a.value(), 5.0e-12);
+	a -= delta<Cel>{Cel(2.0)};
+	EXPECT_NEAR(3.0, a.value(), 5.0e-12);
+	// += with a mixed-unit delta reconciles by scale (18 degF delta == 10 degC delta).
+	a += delta<Fah>{Fah(18.0)};
+	EXPECT_NEAR(13.0, a.value(), 5.0e-11);
+	// The type stays an absolute point.
+	static_assert(std::is_same_v<decltype(a), absolute<Cel>>, "compound assignment keeps the point type");
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+//	TEST: comparisonsReconcileUnits
+//----------------------------------------------------------------------------------------------------------------------
+TEST(WrapperSafety, comparisonsReconcileUnits)
+{
+	const absolute<Cel> a{Cel(20.0)};
+	const absolute<Cel> b{Cel(5.0)};
+	EXPECT_TRUE(a == a);
+	EXPECT_FALSE(a == b);
+	EXPECT_TRUE(b < a);
+	EXPECT_TRUE(a > b);
+	// Cross-unit point comparison reconciles: 0 degC == 32 degF as points.
+	EXPECT_TRUE((absolute<Cel>{Cel(0.0)} == absolute<Fah>{Fah(32.0)}));
+	// Cross-unit delta comparison reconciles by scale: 10 degC delta == 18 degF delta.
+	EXPECT_TRUE((delta<Cel>{Cel(10.0)} == delta<Fah>{Fah(18.0)}));
+	EXPECT_FALSE((delta<Cel>{Cel(10.0)} == delta<Fah>{Fah(10.0)}));
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+//	TEST: accessorsExposeUnderlying
+//----------------------------------------------------------------------------------------------------------------------
+TEST(WrapperSafety, accessorsExposeUnderlying)
+{
+	const absolute<Cel> a{Cel(25.0)};
+	EXPECT_NEAR(25.0, a.value(), 5.0e-12);
+	EXPECT_NEAR(25.0, a.raw(), 5.0e-12);
+	EXPECT_NEAR(25.0, a.quantity().value(), 5.0e-12);
+	static_assert(std::is_same_v<decltype(a.quantity()), const Cel&>, "quantity() returns the wrapped unit by const-ref");
+	// A user reaches the formatted/cmath surface THROUGH quantity() (the wrappers themselves are unformatted).
+	std::ostringstream os;
+	os << a.quantity();
+	EXPECT_FALSE(os.str().empty());
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+//	TEST: linearUnitPointAndDeltaCoincideNumerically
+//----------------------------------------------------------------------------------------------------------------------
+TEST(WrapperSafety, linearUnitPointAndDeltaCoincideNumerically)
+{
+	// For a non-affine unit the datum is zero, so a point and a delta convert identically.
+	const absolute<Meter> ap{Meter(5.0)};
+	const delta<Meter>    dp{Meter(5.0)};
+	EXPECT_NEAR(ap.to<Foot>().value(), dp.to<Foot>().value(), 5.0e-9);
+	EXPECT_NEAR(16.4041994750656, ap.to<Foot>().value(), 5.0e-9);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+//	TEST: integerDeltaScalingPromotesLikeThePlainUnit
+//----------------------------------------------------------------------------------------------------------------------
+TEST(WrapperSafety, integerDeltaScalingPromotesLikeThePlainUnit)
+{
+	// A delta scales EXACTLY as its wrapped unit does: `meters<int>(7) * 2.5` promotes to `meters<double>(17.5)`,
+	// so `delta<meters<int>> * 2.5` promotes to `delta<meters<double>>(17.5)` — the wrapper never loses precision
+	// the plain unit would keep. Scaling by an integer keeps the integer underlying type.
+	const delta<MeterInt> d{MeterInt(7)};
+	const auto            byInt = d * 2;
+	EXPECT_EQ(14, byInt.value());
+	static_assert(std::is_same_v<decltype(byInt), const delta<MeterInt>>, "int * int delta stays integer-underlying");
+
+	const auto byDouble = d * 2.5;
+	EXPECT_NEAR(17.5, byDouble.value(), 5.0e-12);
+	static_assert(std::is_same_v<decltype(byDouble), const delta<units::length::meters<double>>>,
+		"a fractional scale promotes the delta's underlying type to the wrapped unit's promoted type");
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+//	TEST: defaultConstructedIsZero
+//----------------------------------------------------------------------------------------------------------------------
+TEST(WrapperSafety, defaultConstructedIsZero)
+{
+	const absolute<Cel> a{};
+	const delta<Cel>    d{};
+	EXPECT_NEAR(0.0, a.value(), 5.0e-12);
+	EXPECT_NEAR(0.0, d.value(), 5.0e-12);
+}


### PR DESCRIPTION
## Opt-in `absolute<>` / `delta<>` point/delta wrappers

Two thin, opt-in class templates that make the affine **point vs delta** distinction explicit in the type — the inverse of a point/delta-centric library. Plain unit types are **completely unchanged**; you reach for the wrappers only where you want the compiler to enforce the distinction (temperatures, epochs vs durations, absolute vs gauge pressure, positions vs displacements).

Stacked on #376 (uses its affine-correctness work + `is_affine_unit_v`). Merge #376 first.

### The types
- **`absolute<U>`** — a POINT (carries the unit's datum). `.to<V>()` is a point conversion, offset applied (`0 °C → 273.15 K`).
- **`delta<U>`** — an AMOUNT (offset-free). `.to<V>()` is scale-only (`10 °C delta → 18 °F delta`, never `50 °F`).

They wrap **any** unit; for a non-affine unit the datum is zero, so `absolute` and `delta` coincide.

### Type algebra (compile-time enforced)
| Expression | Result |
|---|---|
| `absolute − absolute` | `delta` (datum cancels) |
| `absolute ± delta` | `absolute` (move the point) |
| `delta ± delta` | `delta` |
| `delta * / scalar`, `-delta` | `delta` |
| `absolute + absolute` | **ill-formed** (sum of two points is meaningless) |
| wrapper `±`/`==` plain unit | **ill-formed** (a plain unit is neither point nor delta here) |

Constructors are `explicit` (no implicit unit↔wrapper conversion). Wrappers are **trivially copyable and `sizeof == sizeof(U)`** — zero overhead.

### Correctness detail
Per-operation unit choice is deliberate: a **point stays in its own unit** (reconciling two affine frames to a "common" unit mangles the datum), while offset-free **delta arithmetic reconciles to the common/finer unit** so a mixed integer delta never narrows.

### Testing — an adversarial wart hunt
Three suites authored by fanning adversarial reviewers across the factorial, per "test the hell out of it, find warts preemptively":
- **AffineWrapper** — temperature point/delta algebra, scale-only delta conversion, no-datum-leak, constexpr.
- **GeneralWrapper** — non-affine + the pi-carrying angular units (verified the delta scale-only path preserves the pi exponent), integer underlying, cross-dimension.
- **WrapperSafety** — 70+ `static_assert`s: trivial-copyability, explicit ctors, plain/wrapper and wrong-dimension and point+point rejection via SFINAE, cmath/format/hash non-support, constexpr.
- A compile-fail `errorMessages` case for `absolute + absolute`.

The hunt found and fixed three real warts (int-delta×fraction truncation → now promotes; lossy cross-unit reconciliation → finer-common-unit; affine-point datum mangling → point stays in its own unit).

**Full suite green: 393/393 on g++ (C++23) and MSVC cl.exe** (verified via WSL interop). Documented in a new README section.
