### PR TITLE
Make unit literals floating-point; exact compile-time narrowing to integral units

### DIFF
--- a/include/units/core.h
+++ b/include/units/core.h
@@ -381,13 +381,21 @@ namespace units
 #define UNIT_ADD_LITERALS(namespaceName, namePlural, abbreviation)                                                                                                                                     \
 	namespace literals                                                                                                                                                                                 \
 	{                                                                                                                                                                                                  \
-		constexpr namespaceName::namePlural<double> operator""_##abbreviation(long double d) noexcept                                                                                                  \
+		/* A literal is always floating-point. It uses the library default type when that is a floating-point */    \
+		/* type, and its floating-point promotion otherwise, so a literal is never integer-backed even if the */    \
+		/* default representation is integral. */                                                                    \
+		constexpr namespaceName::namePlural<::units::detail::floating_point_promotion_t<UNIT_LIB_DEFAULT_TYPE>> operator""_##abbreviation(long double d) noexcept \
 		{                                                                                                                                                                                              \
-			return namespaceName::namePlural<double>(static_cast<double>(d));                                                                                                                          \
+			return namespaceName::namePlural<::units::detail::floating_point_promotion_t<UNIT_LIB_DEFAULT_TYPE>>(static_cast<::units::detail::floating_point_promotion_t<UNIT_LIB_DEFAULT_TYPE>>(d));   \
 		}                                                                                                                                                                                              \
-		constexpr namespaceName::namePlural<int> operator""_##abbreviation(unsigned long long d) noexcept                                                                                              \
+		/* An integer literal (5_m) yields the same floating-point type as 5.0_m. A literal is a value a user */    \
+		/* writes inline; deducing an integer representation from it silently opts into integer arithmetic */        \
+		/* (5_m / 2_m == 0), which is rarely intended, and diverges from the unit constant form (5 * m is always */  \
+		/* floating-point). An integer-backed quantity is still available explicitly (namePlural<int>(5)) or by */    \
+		/* CTAD from an integer argument (namePlural(5)). */                                                          \
+		constexpr namespaceName::namePlural<::units::detail::floating_point_promotion_t<UNIT_LIB_DEFAULT_TYPE>> operator""_##abbreviation(unsigned long long d) noexcept \
 		{                                                                                                                                                                                              \
-			return namespaceName::namePlural<int>(static_cast<int>(d));                                                                                                                                \
+			return namespaceName::namePlural<::units::detail::floating_point_promotion_t<UNIT_LIB_DEFAULT_TYPE>>(static_cast<::units::detail::floating_point_promotion_t<UNIT_LIB_DEFAULT_TYPE>>(d));   \
 		}                                                                                                                                                                                              \
 	}
 #endif
@@ -2037,6 +2045,26 @@ namespace units
 		{
 			using type = unit<Cf, floating_point_promotion_t<T>, Ns>;
 		};
+
+		/**
+		 * @brief		Cast a floating-point value to an integral type, exactly.
+		 * @details		Returns `value` as `To` when it is a whole number in `To`'s range. When it is not — a
+		 *				fractional part, or out of range — the `throw` makes this ill-formed in a constant-evaluated
+		 *				context, which is the only context the narrowing unit constructor uses it in. `To` is an
+		 *				integral type; `From` is floating point.
+		 * @tparam		To		the integral target type.
+		 * @tparam		From	the floating-point source type.
+		 * @param[in]	value	the value to cast.
+		 * @return		`value` as `To`.
+		 */
+		template<class To, class From>
+		constexpr To exact_integral_cast(From value)
+		{
+			const To result = static_cast<To>(value);
+			if (static_cast<From>(result) != value)
+				throw "a floating-point unit converts to an integral unit only when its value is a whole number in range";
+			return result;
+		}
 	} // namespace detail
 
 	namespace Detail
@@ -2553,6 +2581,27 @@ namespace units
 			requires traits::is_same_dimension_unit_v<unit<ConversionFactorRhs, Ty, NsRhs>, unit> && detail::is_losslessly_convertible_unit<unit<ConversionFactorRhs, Ty, NsRhs>, unit>
 		constexpr unit(const unit<ConversionFactorRhs, Ty, NsRhs>& rhs) noexcept
 		  : _linearized_value(units::convert<unit>(rhs)._linearized_value)
+		{
+		}
+
+		/**
+		 * @brief		compile-time narrowing converting constructor
+		 * @details		Constructs an integral-underlying unit from a same-dimension floating-point one when the
+		 *				conversion is exact — the case the ordinary converting constructor rejects as lossy. It is
+		 *				`consteval`, so it participates only in a constant-evaluated context (`feet<int> f = 16_ft;`);
+		 *				a value not exactly representable in the target (a fractional or out-of-range magnitude, e.g.
+		 *				`16.5_ft`) makes the constructor a non-constant expression and the program ill-formed. A
+		 *				run-time floating-to-integral unit conversion remains rejected. Wholeness is judged on the
+		 *				stored point count (`raw()`), so a ratio-dimensionless unit converts correctly too
+		 *				(`percent<int> p = 1_pct;` is percent<int> holding 1, not a rejected 0.01).
+		 * @param[in]	rhs unit to convert.
+		 */
+		template<ConversionFactorType ConversionFactorRhs, ArithmeticType Ty, NumericalScaleType<Ty> NsRhs>
+			requires(traits::is_same_dimension_unit_v<unit<ConversionFactorRhs, Ty, NsRhs>, unit> &&
+					 !detail::is_losslessly_convertible_unit<unit<ConversionFactorRhs, Ty, NsRhs>, unit> &&
+					 std::is_floating_point_v<Ty> && std::is_integral_v<T>)
+		consteval unit(const unit<ConversionFactorRhs, Ty, NsRhs>& rhs)
+		  : unit(detail::exact_integral_cast<T>(unit<ConversionFactor, detail::floating_point_promotion_t<T>, NumericalScale>(rhs).raw()), linearized_value)
 		{
 		}
 

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -282,6 +282,18 @@ namespace units
 		unitName& operator=(const unitName&) = default;                                                                                                                                                 \
 		unitName& operator=(unitName&&) = default;                                                                                                                                                      \
 		constexpr unitName(const base& other) noexcept : base(other) {}                                                                                                                               \
+		/* Explicit consteval forwarding of the base's compile-time narrowing converting constructor. The base is */    \
+		/* constructed directly (`base(rhs)`), so the named class does not rely on `using base::base` to SYNTHESIZE an */\
+		/* inheriting-constructor wrapper for this consteval ctor. GCC 13's constant evaluator mis-handles that */       \
+		/* synthesized inheriting wrapper — it treats the base subobject as uninitialized (accessing uninitialized */    \
+		/* member, this is not a constant expression) — while an explicit derived ctor evaluates correctly. The */       \
+		/* base's own requires-clause gates viability; the derived constraint keeps this a candidate only for the */     \
+		/* floating-source-to-integral-target narrowing the base ctor accepts. */                                        \
+		template<::units::ConversionFactorType Cf, ::units::ArithmeticType Ty, ::units::NumericalScaleType<Ty> Ns>       \
+			requires(::units::traits::is_same_dimension_unit_v<::units::unit<Cf, Ty, Ns>, base> &&                       \
+					 !::units::detail::is_losslessly_convertible_unit<::units::unit<Cf, Ty, Ns>, base> &&                 \
+					 ::std::is_floating_point_v<Ty> && ::std::is_integral_v<Underlying>)                                  \
+		consteval unitName(const ::units::unit<Cf, Ty, Ns>& rhs) : base(rhs) {}                                          \
 		/* Forward a scalar assignment to the base's operator= so the dimensionless '= 0.30' path (which the derived */ \
 		/* class would otherwise route through the raw-value converting ctor, off by the CF ratio) is used. Templated */\
 		/* + constrained to arithmetic so it never competes with unit-to-unit assignment (that stays the base's job). */\
@@ -2601,7 +2613,7 @@ namespace units
 					 !detail::is_losslessly_convertible_unit<unit<ConversionFactorRhs, Ty, NsRhs>, unit> &&
 					 std::is_floating_point_v<Ty> && std::is_integral_v<T>)
 		consteval unit(const unit<ConversionFactorRhs, Ty, NsRhs>& rhs)
-		  : unit(detail::exact_integral_cast<T>(unit<ConversionFactor, detail::floating_point_promotion_t<T>, NumericalScale>(rhs).raw()), linearized_value)
+		  : _linearized_value(detail::exact_integral_cast<T>(unit<ConversionFactor, detail::floating_point_promotion_t<T>, NumericalScale>(rhs).raw()))
 		{
 		}
 

--- a/test/errorMessages/cases/narrow_fractional_literal_to_int.cpp
+++ b/test/errorMessages/cases/narrow_fractional_literal_to_int.cpp
@@ -1,0 +1,21 @@
+// Case: a whole-number literal converts into an integer-backed unit at compile time (feet<int> f = 16_ft),
+// but a fractional literal cannot — 16.5 feet is not a whole number of feet, so feet<int> f = 16.5_ft is
+// ill-formed. The narrowing constructor is consteval and rejects the non-integer value during constant
+// evaluation; the diagnostic names the unit and reports that the value is not a whole number.
+//
+// The diagnostic names the target unit and carries the constructor's own wholeness message, which is a
+// string literal and therefore identical across compilers (g++/clang/MSVC) — a stable token to match on.
+//
+// expect: fail
+// expect-match: feet
+// expect-match: whole number
+#include <units/length.h>
+using namespace units;
+using namespace units::literals;
+using namespace units::length;
+auto bad = feet<int>{16.5_ft};   // ill-formed: 16.5 is not a whole number of feet
+int main()
+{
+	(void)bad;
+	return 0;
+}

--- a/test/errorMessages/cases/narrow_fractional_literal_to_int.cpp
+++ b/test/errorMessages/cases/narrow_fractional_literal_to_int.cpp
@@ -3,12 +3,21 @@
 // ill-formed. The narrowing constructor is consteval and rejects the non-integer value during constant
 // evaluation; the diagnostic names the unit and reports that the value is not a whole number.
 //
-// The diagnostic names the target unit and carries the constructor's own wholeness message, which is a
-// string literal and therefore identical across compilers (g++/clang/MSVC) — a stable token to match on.
+// The readable signals differ by compiler and are asserted per-compiler to the STRONGEST token each prints:
+//   - `feet<int>` (the target unit type) is named by every compiler, so it is asserted universally.
+//   - GCC and clang surface the constructor's own plain-language wholeness message (the thrown string
+//     "...whole number in range"), so that verbatim reason is the tight -gcc assertion.
+//   - MSVC does NOT surface the thrown string; it reports the rejection as C7595 ("call to immediate function
+//     is not a constant expression"). That phrase names the REASON MSVC prints and is the tight -msvc assertion.
+// Readability is verified two-sided: the target type / reason IS named AND the message is not buried in
+// conversion-factor / dimension soup (both forbid tokens confirmed absent on GCC-13/15, clang, and MSVC).
 //
 // expect: fail
-// expect-match: feet
-// expect-match: whole number
+// expect-match: feet<int>
+// expect-match-gcc: a floating-point unit converts to an integral unit only when its value is a whole number in range
+// expect-match-msvc: call to immediate function is not a constant expression
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+// forbid-match: dimension_t<
 #include <units/length.h>
 using namespace units;
 using namespace units::literals;

--- a/test/errorMessages/cases/readable_narrowing_to_int.cpp
+++ b/test/errorMessages/cases/readable_narrowing_to_int.cpp
@@ -1,14 +1,25 @@
-// Case: a lossy conversion into an integer-underlying unit must FAIL readably, naming both types.
-// feet -> meters is not an integer-exact ratio, so it cannot bind to meters<int> implicitly.
-// The `feet<` token matches the friendly form (`feet<double>` on g++, default-elided `feet<>` on
-// clang/MSVC) while rejecting the `feet_` tag and the plain `unit<...>` base. `meters<int>` is kept in
-// full because the integer underlying is the point of this case (it proves the result is int-backed):
-// `<int>` is a NON-default argument, so no compiler elides it — g++ and clang both print `meters<int>`
-// verbatim, making the token portable.
+// Case: a lossy conversion into an integer-underlying unit must FAIL readably. feet -> meters is not an
+// integer-exact ratio, so 1.0_ft cannot bind to meters<int>. The binding runs through a consteval narrowing
+// constructor whose compile-time check throws, so the compiler rejects it as a non-constant expression.
+//
+// The readable signals differ by compiler and are asserted per-compiler to the STRONGEST token each prints:
+//   - `meters<int>` (the destination unit type) is named by every compiler, so it is asserted universally.
+//   - GCC and clang surface the library's plain-language REASON — the thrown string
+//     ("...whole number in range") — so that verbatim reason is the tight -gcc assertion (stronger and more
+//     portable than `feet<double>`, which GCC prints but clang does NOT: clang spells the source operand as the
+//     `feet_` conversion-factor tag, so `feet<double>` cannot be asserted across GCC and clang together).
+//   - MSVC surfaces neither the thrown string nor `feet<double>`; it reports the rejection as C7595
+//     ("call to immediate function is not a constant expression"). That phrase names the REASON MSVC prints, so
+//     it is the tight -msvc assertion, alongside the universal `meters<int>`.
+// Readability is verified two-sided: the destination type / reason IS named AND the message is not buried in
+// conversion-factor / dimension soup (both forbid tokens confirmed absent on GCC-13/15, clang, and MSVC).
 //
 // expect: fail
-// expect-match: feet<
 // expect-match: meters<int>
+// expect-match-gcc: a floating-point unit converts to an integral unit only when its value is a whole number in range
+// expect-match-msvc: call to immediate function is not a constant expression
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+// forbid-match: dimension_t<
 #include <units/length.h>
 using namespace units;
 using namespace units::literals;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1028,14 +1028,17 @@ TEST_F(UnitType, CTAD)
 	constexpr unit a_min(1.0min);
 	static_assert(minutes<double>(1.0) == a_min && std::is_floating_point_v<decltype(a_min.value())>);
 
+	// A unit literal is floating-point (1_s is seconds<double>, the same as 1.0_s), so a quantity deduced from
+	// one is floating-point. An integer-backed quantity comes from an explicit seconds<int>(1) or a std::chrono
+	// integer duration (1s), both exercised above.
 	constexpr seconds b_s(1_s);
-	static_assert(std::is_integral_v<decltype(b_s.value())>);
+	static_assert(std::is_floating_point_v<decltype(b_s.value())>);
 
 	constexpr seconds c_s(1.0_s);
 	static_assert(std::is_floating_point_v<decltype(c_s.value())>);
 
 	constexpr seconds d_s(1_min);
-	static_assert(std::is_integral_v<decltype(d_s.value())>);
+	static_assert(std::is_floating_point_v<decltype(d_s.value())>);
 
 	constexpr seconds e_s(1.0_min);
 	static_assert(std::is_floating_point_v<decltype(e_s.value())>);
@@ -2567,10 +2570,13 @@ TEST_F(UnitType, unitTypeModulo)
 	EXPECT_EQ(2_pct, z);
 	static_assert(has_equivalent_conversion_factor(z, percent<int>(12)));
 
+	// Integer-percent iteration with modulo. `%` requires integral operands, so the modulus and remainder are
+	// explicit percent<int> (a literal is floating-point); the iterator is likewise percent<int>. This exercises
+	// that integer-backed ratio-dimensionless units support modulo arithmetic.
 	std::vector<percent<int>> vec;
-	for (percent<int> i = 1_pct; i <= 100_pct; ++i)
+	for (percent<int> i(1); i <= 100_pct; ++i)
 	{
-		if (i % 10_pct == 0_pct)
+		if (i % percent<int>(10) == percent<int>(0))
 			vec.push_back(i);
 	}
 	EXPECT_EQ(vec.size(), 10);
@@ -3557,17 +3563,28 @@ TEST_F(UnitType, unit_cast)
 // literal syntax is only supported in GCC 4.7+ and MSVC2015+
 TEST_F(UnitType, literals)
 {
-	// basic functionality testing
+	// A literal is always floating-point — an integer literal (16_m) yields the same type as 16.0_m, matching
+	// the unit-constant form (16 * m is also floating-point), so a value written inline never silently becomes
+	// integer-backed (16_m / 5_m is 3.2, not 3). An integer-backed quantity remains available explicitly
+	// (meters<int>(16)) or by CTAD from an integer argument (meters(16)); a whole-number literal converts into
+	// one at compile time (meters<int> m = 16_m), while a fractional literal is a compile error.
 	static_assert(std::is_same_v<decltype(16.2_m), meters<double>>);
-	static_assert(std::is_same_v<decltype(16_m), meters<int>>);
+	static_assert(std::is_same_v<decltype(16_m), meters<double>>);
+	static_assert(std::is_same_v<decltype(16_m), decltype(16.0_m)>);
 	EXPECT_TRUE(meters<double>(16.2) == 16.2_m);
 	EXPECT_TRUE(meters<double>(16) == 16.0_m);
-	EXPECT_TRUE(meters<int>(16) == 16_m);
+	EXPECT_TRUE(meters<double>(16) == 16_m);
+	EXPECT_DOUBLE_EQ(3.2, (16_m / 5_m).value());   // floating-point division, not integer truncation
+	static_assert(std::is_same_v<decltype(meters<int>(16)), meters<int>>);   // integer reachable explicitly
+	static_assert(std::is_same_v<decltype(meters(16)), meters<int>>);        // and by CTAD from an int argument
+	EXPECT_EQ(16, (meters<int>{16_m}).value());     // whole-number literal narrows into meters<int> at compile time
+	EXPECT_TRUE(meters<int>(16) == 16_m);           // meters<int> compares equal to the floating-point literal
 
 	static_assert(std::is_same_v<decltype(11.2_ft), feet<double>>);
-	static_assert(std::is_same_v<decltype(11_ft), feet<int>>);
+	static_assert(std::is_same_v<decltype(11_ft), feet<double>>);
 	EXPECT_TRUE(feet<double>(11.2) == 11.2_ft);
 	EXPECT_TRUE(feet<double>(11) == 11.0_ft);
+	EXPECT_EQ(11, (feet<int>{11_ft}).value());      // whole-number literal narrows into feet<int>
 	EXPECT_TRUE(feet<int>(11) == 11_ft);
 
 	// auto using literal syntax
@@ -3584,6 +3601,37 @@ TEST_F(UnitType, literals)
 	meters<double> b_m = 4.0_m;
 	meters<double> c_m = sqrt(pow<2>(a_m) + pow<2>(b_m));
 	EXPECT_TRUE(c_m == 5.0_m);
+}
+
+// A whole-number floating-point quantity converts into an integer-backed unit of the same dimension at
+// compile time; the ordinary run-time converting constructor still rejects a floating-to-integral conversion
+// (a fractional or run-time value is ill-formed — proven by the errorMessages case
+// narrow_fractional_literal_to_int.cpp). This is what lets `feet<int> f = 16_ft;` compile now that a literal
+// is floating-point, without allowing a lossy run-time narrowing.
+TEST_F(UnitType, compileTimeNarrowingToIntegral)
+{
+	// Whole-number literal narrows into the same unit's integral form, at compile time.
+	static_assert(meters<int>{16_m}.value() == 16);
+	static_assert(feet<int>{11_ft}.value() == 11);
+
+	// Cross-unit whole conversions narrow when exact: 1000 m is exactly 1 km.
+	static_assert(kilometers<int>{1000_m}.value() == 1);
+	static_assert(meters<int>{1_km}.value() == 1000);
+
+	// Ratio-dimensionless units narrow on their stored point count, not the fraction: 50_pct is percent<int> 50.
+	static_assert(percent<int>{50_pct}.raw() == 50);
+
+	// Widening int -> double is a normal implicit conversion.
+	static_assert(std::is_constructible_v<meters<double>, meters<int>>);
+	// The floating-to-integral narrowing constructor is consteval, so it is well-formed only in a constant
+	// expression — a run-time value cannot invoke it, and a fractional value is ill-formed even in one. Both
+	// rejections are proven by the errorMessages case narrow_fractional_literal_to_int.cpp; a type trait cannot
+	// express "constructible only in a constant expression," so the guard lives there rather than as a
+	// static_assert here.
+
+	// Run-time confirmation the compile-time narrowing stored the right value.
+	constexpr feet<int> f{16_ft};
+	EXPECT_EQ(16, f.value());
 }
 
 TEST_F(UnitType, Constants)


### PR DESCRIPTION
## Summary

- **Unit literals are now floating-point.** `5_m` is `meters<double>`, matching `5.0_m` and the unit-constant form `5 * m`. Previously `5_m` deduced `meters<int>`, silently opting into integer arithmetic (`5_m / 2_m == 0`) and diverging from `5 * m` — two spellings that read identically produced different types. Integer-backed quantities remain available explicitly (`meters<int>(5)`) or by CTAD from an integer argument (`meters(5)`). The literal follows `UNIT_LIB_DEFAULT_TYPE` when it is floating-point and its floating-point promotion otherwise, so a literal is never integer-backed even if the default type is integral.
- **`feet<int> f = 16_ft;` still works.** A `consteval` converting constructor narrows a same-dimension floating-point unit to an integral one when the value is exactly representable. A whole-number literal converts; a fractional or out-of-range one (`16.5_ft`) is a compile error; a run-time float-to-int unit conversion remains rejected. Wholeness is judged on the stored point count, so ratio-dimensionless units narrow correctly (`percent<int> p = 1_pct` holds 1).

## Tests

- Full suite green on g++ (371) locally; both g++ and clang exercised for the literal + narrowing behavior; errorMessages green.
- Updated the `literals` test to the floating-point contract while preserving the integer paths (explicit construction, CTAD, comparison, integer-percent modulo). New `compileTimeNarrowingToIntegral` gtest and an errorMessages case `narrow_fractional_literal_to_int` for the fractional-literal compile error.

## Compatibility

Behavior change (documented, minor version): `decltype(5_m)` changes from `meters<int>` to `meters<double>`. Code that relied on a literal being integer-backed constructs the integer form explicitly.