### PR TITLE
ci: parallelize the cmake build and ctest run

### DIFF
--- a/.github/workflows/clang-19.yaml
+++ b/.github/workflows/clang-19.yaml
@@ -44,11 +44,11 @@ jobs:
 
       - name: Build
         run: |
-          cmake --build build --config Release
+          cmake --build build --config Release --parallel
 
       - name: Run Tests
         working-directory: build
-        run: ctest --output-on-failure
+        run: ctest --output-on-failure --parallel 4
 
       - name: Error-message tests
         run: |

--- a/.github/workflows/gcc-13.yaml
+++ b/.github/workflows/gcc-13.yaml
@@ -43,11 +43,11 @@ jobs:
 
       - name: Build
         run: |
-          cmake --build build --config Release
+          cmake --build build --config Release --parallel
 
       - name: Run Tests
         working-directory: build
-        run: ctest --output-on-failure
+        run: ctest --output-on-failure --parallel 4
 
       - name: Error-message tests
         run: |

--- a/.github/workflows/msvc-2022.yaml
+++ b/.github/workflows/msvc-2022.yaml
@@ -37,11 +37,11 @@ jobs:
 
       - name: Build
         run: |
-          cmake --build build
+          cmake --build build --parallel
 
       - name: Run Tests
         working-directory: build
-        run: ctest --output-on-failure
+        run: ctest --output-on-failure --parallel 4
 
       - name: Error-message tests
         run: |


### PR DESCRIPTION
The compiler build jobs compiled single-threaded: `cmake --build` was invoked without `--parallel`, so the default Make generator (GCC-13, Clang-19) used one core.

- `cmake --build ... --parallel` — build across all runner cores.
- `ctest --output-on-failure --parallel 4` — the suite has several test executables (the main `unitLibTest` plus the per-config lean/subset-header binaries); run them concurrently.

MSVC already used Ninja (auto-parallel build); the flags are added there too for consistency and to parallelize its ctest.

Pairs with the earlier change that fans out the error-message cases.