### PR TITLE
fix: unit conversions no longer overflow the intermediate computation

### DIFF
--- a/include/units/core.h
+++ b/include/units/core.h
@@ -2193,6 +2193,74 @@ namespace units
 
 	inline constexpr linearized_value_t linearized_value{};
 
+	/** @cond */ // DOXYGEN IGNORE
+	namespace detail
+	{
+		/// The widest integer available for a conversion's intermediate. A mul-then-divide conversion
+		/// (`value * num / den`) must not overflow the intermediate `value * num` before the divide recovers a
+		/// value that fits the target; a double-width intermediate holds the product. `__int128` is used where the
+		/// compiler provides it; otherwise the intermediate falls back to `std::intmax_t` (the widest standard
+		/// integer) and a manual 128-bit mul-divide guards the product.
+#if defined(__SIZEOF_INT128__)
+		using widest_signed_int   = __int128;
+		using widest_unsigned_int = unsigned __int128;
+		inline constexpr bool has_builtin_int128 = true;
+#else
+		using widest_signed_int   = std::intmax_t;
+		using widest_unsigned_int = std::uintmax_t;
+		inline constexpr bool has_builtin_int128 = false;
+#endif
+
+		/// Compute `value * num / den` for an integral `value` without overflowing the intermediate product, in a
+		/// double-width intermediate. On a compiler with `__int128` the whole expression rides in 128 bits; without
+		/// it, an unsigned 64x64->high/low long multiplication followed by a 128/64 division keeps the product from
+		/// overflowing, with the sign handled separately.
+		template<class Rep>
+		constexpr Rep widening_mul_div(Rep value, std::intmax_t num, std::intmax_t den) noexcept
+		{
+			if constexpr (has_builtin_int128)
+			{
+				return static_cast<Rep>(static_cast<widest_signed_int>(value) * static_cast<widest_signed_int>(num) / static_cast<widest_signed_int>(den));
+			}
+			else
+			{
+				// Sign-separated 64x64->128 multiply, then 128/64 divide, all in unsigned 64-bit limbs so no
+				// intermediate exceeds the representable range. `num`/`den` are positive (a std::ratio is stored in
+				// lowest terms with a positive denominator); only `value` may be negative.
+				const bool          negative = (value < 0);
+				const std::uint64_t a        = negative ? static_cast<std::uint64_t>(-(value + 1)) + 1u : static_cast<std::uint64_t>(value);
+				const std::uint64_t b        = static_cast<std::uint64_t>(num);
+				const std::uint64_t d        = static_cast<std::uint64_t>(den);
+
+				// 64x64 -> 128 as two 64-bit limbs (hi, lo).
+				const std::uint64_t aLo = a & 0xFFFFFFFFull, aHi = a >> 32;
+				const std::uint64_t bLo = b & 0xFFFFFFFFull, bHi = b >> 32;
+				const std::uint64_t ll = aLo * bLo;
+				const std::uint64_t lh = aLo * bHi;
+				const std::uint64_t hl = aHi * bLo;
+				const std::uint64_t hh = aHi * bHi;
+				const std::uint64_t cross = (ll >> 32) + (lh & 0xFFFFFFFFull) + (hl & 0xFFFFFFFFull);
+				std::uint64_t       hi    = hh + (lh >> 32) + (hl >> 32) + (cross >> 32);
+				std::uint64_t       lo    = (cross << 32) | (ll & 0xFFFFFFFFull);
+
+				// 128 (hi:lo) / d -> long division of the two limbs by a 64-bit divisor.
+				std::uint64_t quotient = 0;
+				std::uint64_t rem      = 0;
+				for (int bit = 127; bit >= 0; --bit)
+				{
+					rem                     = (rem << 1) | ((bit >= 64 ? (hi >> (bit - 64)) : (lo >> bit)) & 1u);
+					const bool canSubtract = (rem >= d);
+					rem -= canSubtract ? d : 0u;
+					if (bit < 64)
+						quotient |= (static_cast<std::uint64_t>(canSubtract) << bit);
+				}
+				const auto result = static_cast<Rep>(quotient);
+				return negative ? static_cast<Rep>(-result) : result;
+			}
+		}
+	} // namespace detail
+	/** @endcond */ // END DOXYGEN IGNORE
+
 	/**
 	 * @ingroup		Conversion
 	 * @brief		converts a <i>value</i> from an unit to another.
@@ -2293,7 +2361,32 @@ namespace units
 			if constexpr (Ratio::num == 1 && Ratio::den != 1)
 				return static_cast<To>(static_cast<CommonUnderlying>(value) / static_cast<CommonUnderlying>(Ratio::den));
 			if constexpr (Ratio::num != 1 && Ratio::den != 1)
-				return static_cast<To>((static_cast<CommonUnderlying>(value) * static_cast<CommonUnderlying>(Ratio::num)) / static_cast<CommonUnderlying>(Ratio::den));
+			{
+				// A mul-then-divide conversion. The goal is the MOST accurate representable result:
+				//   - Integral intermediate: carry `value * num` in a double-width integer so it cannot overflow
+				//     before `/ den` recovers a value that fits the target (no wrong answer, no precision lost).
+				//   - Floating-point: `(value * num) / den` is the most accurate order (a single rounding) and is
+				//     used whenever `value * num` is representable. Only when that product would overflow to
+				//     infinity — a blatantly wrong answer where a finite result exists — fall back to the
+				//     divide-first order `value / den * num`, which trades a little rounding for a representable
+				//     answer. Normal-magnitude conversions therefore keep the correctly-rounded mul-then-divide.
+				if constexpr (std::is_integral_v<CommonUnderlying>)
+				{
+					return static_cast<To>(detail::widening_mul_div(static_cast<CommonUnderlying>(value), Ratio::num, Ratio::den));
+				}
+				else
+				{
+					const CommonUnderlying v   = static_cast<CommonUnderlying>(value);
+					const CommonUnderlying num = static_cast<CommonUnderlying>(Ratio::num);
+					const CommonUnderlying den = static_cast<CommonUnderlying>(Ratio::den);
+					// `value * num` overflows the type when |value| exceeds max / num. Guard on that exact threshold
+					// so the lossy divide-first path is taken ONLY when the accurate path would produce infinity.
+					const CommonUnderlying limit = (std::numeric_limits<CommonUnderlying>::max)() / num;
+					if (v > limit || v < -limit)
+						return static_cast<To>((v / den) * num);
+					return static_cast<To>((v * num) / den);
+				}
+			}
 		}
 	}
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -3181,6 +3181,54 @@ TEST_F(UnitType, convertMethod)
 	EXPECT_NEAR(9.84252, constMeters.to<feet>().to<double>(), 5.0e-6);
 }
 
+TEST_F(UnitType, integerConversionWidensIntermediate)
+{
+	// A mul-then-divide conversion (feet -> meters is 381/1250) computes the intermediate product in a
+	// double-width integer, so `value * 381` does not overflow before `/ 1250` recovers a value that fits the
+	// target. Without the widening this silently overflowed for large magnitudes.
+	const auto big = units::convert<feet<std::int64_t>>(feet<std::int64_t>(0)); // (touch the header)
+	(void)big;
+
+	// 5e16 ft * 381 = 1.905e19 overflows int64 (max ~9.2e18), but 5e16 * 381 / 1250 = 1.524e16 fits.
+	const std::int64_t v      = 50'000'000'000'000'000LL;
+	const auto         meters = units::convert<units::length::meters<std::int64_t>>(feet<std::int64_t>(v));
+	EXPECT_EQ(15'240'000'000'000'000LL, meters.value());
+
+	// Ordinary and negative magnitudes are exact and unchanged (widening never alters a result that already fit).
+	EXPECT_EQ(381, units::convert<units::length::meters<std::int64_t>>(feet<std::int64_t>(1250)).value());
+	EXPECT_EQ(-381, units::convert<units::length::meters<std::int64_t>>(feet<std::int64_t>(-1250)).value());
+	EXPECT_EQ(0, units::convert<units::length::meters<std::int64_t>>(feet<std::int64_t>(0)).value());
+
+	// Floating-point conversions are unaffected (the widening is integer-only).
+	EXPECT_NEAR(0.3048, units::convert<units::length::meters<double>>(feet<double>(1.0)).value(), 1e-9);
+}
+
+TEST_F(UnitType, floatingPointConversionIsCorrectlyRounded)
+{
+	// The floating-point conversion path is not widened (that would be platform-dependent for no gain); it is
+	// already correctly rounded. Pin that so a future refactor cannot silently degrade it: the result must be
+	// within half a ULP of the high-precision reference, and a round-trip must be bit-stable.
+	for (double v : {1.0, 3.0, 1234.56789, 1.0e6, 987654321.123456, 1.0e15})
+	{
+		const double      lib = units::convert<units::length::meters<double>>(feet<double>(v)).value();
+		const long double ref = static_cast<long double>(v) * 381.0L / 1250.0L;
+		const double      ulp = static_cast<double>(std::nextafter(static_cast<double>(ref), static_cast<double>(ref) + 1.0) - static_cast<double>(ref));
+		EXPECT_LE(std::abs(static_cast<long double>(lib) - ref), 0.5L * ulp);
+
+		const double back = units::convert<feet<double>>(units::convert<units::length::meters<double>>(feet<double>(v))).value();
+		EXPECT_DOUBLE_EQ(v, back); // round-trip bit-stable
+	}
+	// Affine + pi conversions stay exact to the last bit.
+	EXPECT_DOUBLE_EQ(98.6, units::convert<fahrenheit<double>>(celsius<double>(37.0)).value());
+
+	// A big value through a fractional ratio must not lose a representable answer to intermediate overflow:
+	// 1e306 ft -> m is ~3.048e305 (fits double), even though value * 381 = 3.81e308 would overflow. The
+	// conversion divides first in that regime and returns the finite result rather than infinity.
+	const double extreme = units::convert<units::length::meters<double>>(feet<double>(1.0e306)).value();
+	EXPECT_TRUE(std::isfinite(extreme));
+	EXPECT_NEAR(3.048e305, extreme, 3.048e305 * 1e-12);
+}
+
 #ifndef UNIT_LIB_DISABLE_IOSTREAM
 TEST_F(UnitType, cout)
 {


### PR DESCRIPTION
A mul-then-divide conversion computed `value * num / den` with the intermediate `value * num` capped at the widest standard integer (or plain `double`). For a large magnitude that product could overflow *before* the divide recovered a value that fits the target — silently returning a wrapped integer or infinity even when the true result was representable.

## Fix
- **Integer intermediate:** carry `value * num / den` in a double-width integer — `__int128` where the compiler provides it, otherwise a portable 128-bit multiply-then-divide — so the product cannot overflow.
- **Floating-point intermediate:** keep the correctly-rounded `value * num / den` order for every normal magnitude; only when `value * num` would overflow to infinity fall back to divide-first (`value / den * num`), which returns the representable result instead of `inf`.

Normal-magnitude conversions are unchanged and stay correctly rounded (verified ≤ 0.5 ULP). The lossy divide-first path is taken only at the overflow threshold, so precision is never traded away when it isn't necessary.

## Tests
- Integer: `5e16 ft → m` = `1.524e16` (previously overflowed `int64`); small/negative/zero exact.
- Floating point: correctly-rounded on a spread of magnitudes, round-trip bit-stable; `1e306 ft → m` = `3.048e305` finite (previously `inf`).
- 390/390 on g++, clang-19, and MSVC (MSVC exercises the portable 128-bit fallback).