### PR TITLE
Exact compile-time and explicit runtime integer unit narrowing

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,9 @@ meters<int> f(5);         // explicit integer representation
 meters mm = 100.0_ft;     // feet -> meters
 feet   ff = mm;           // meters -> feet
 // meters<int> x = 1.0_ft;   // ERROR: lossy into an integer representation
+constexpr bytes<int> two = 16_b;         // OK: exact at compile time (16 bits == 2 bytes)
+// constexpr bytes<int> bad = 17_b;      // ERROR: not a whole number of bytes (never silently truncated)
+bytes<int> n = units::floor<bytes<int>>(runtimeBits); // runtime lossy: floor/ceil/round/trunc<To>
 
 // Arithmetic (dimensions are tracked)
 square_meters     area  = 15.0_m * 5.0_m;    // m * m -> area

--- a/docs/learn/unit-conversions.md
+++ b/docs/learn/unit-conversions.md
@@ -65,6 +65,23 @@ This is the general rule, not a special case for integers: any conversion the co
 lossless requires you to ask for it explicitly. For the full catalog of what the type system rejects and
 the verbatim diagnostics, see [type safety](../explain/type-safety.md).
 
+### A compile-time-known value that *is* exact converts anyway
+
+The rejection above is about a *runtime* value, which the type system cannot inspect. When the value is a
+compile-time constant, the compiler can check exactness and let an exact conversion through — even into an
+integer of a coarser unit:
+
+```cpp
+constexpr bytes<int> two = 16_b;   // OK   — 16 bits is exactly 2 bytes, proven at compile time
+constexpr bytes<int> bad = 17_b;   // error — 17 bits is not a whole number of bytes; never truncated silently
+bytes<int> runtime = someBits;     // still rejected — a runtime bit count need not divide evenly
+```
+
+This is the same mechanism that already lets `feet<int> f = 16_ft;` compile while `16.5_ft` does not: a
+`consteval` constructor that converts when the value is exact and makes the program ill-formed when it is
+not. You get the frictionless assignment for the common (constant, exact) case, and a compile error — never
+a silent truncation — for a constant that would lose data.
+
 ## Converting through arithmetic
 
 Conversions also fall out of arithmetic. When you divide a distance by a time, the operands may be in any
@@ -108,6 +125,19 @@ meters      exact  = height;                 // implicit, lossless: 21.6408 m
 meters<int> rounded{ round(exact).to<int>() }; // round the quantity (ADL), then narrow explicitly
 std::cout << exact << " -> " << rounded << '\n';
 // 21.6408 m -> 22 m
+```
+
+For a *runtime* value that need not divide evenly — the case the exact compile-time conversion above cannot
+serve — `round`, `floor`, `ceil`, and `trunc` also take the target unit as an explicit template argument,
+the same shape as `std::chrono::floor<To>`. They convert to the coarser integer unit with the rounding you
+name:
+
+```cpp
+bits<int> received = someRuntimeBits;              // e.g. 17 bits
+units::floor<bytes<int>>(received);                //  2 bytes  (toward negative infinity)
+units::ceil <bytes<int>>(received);                //  3 bytes  (toward positive infinity)
+units::round<bytes<int>>(received);                //  2 bytes  (nearest, halfway away from zero)
+units::trunc<bytes<int>>(received);                //  2 bytes  (toward zero)
 ```
 
 > **Note — extraction is a boundary.** Keep quantities typed for as long as they stay inside your code;

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -288,11 +288,12 @@ namespace units
 		/* synthesized inheriting wrapper — it treats the base subobject as uninitialized (accessing uninitialized */    \
 		/* member, this is not a constant expression) — while an explicit derived ctor evaluates correctly. The */       \
 		/* base's own requires-clause gates viability; the derived constraint keeps this a candidate only for the */     \
-		/* floating-source-to-integral-target narrowing the base ctor accepts. */                                        \
+		/* narrowing the base ctors accept — a floating-point source, or a finer integral source that is an exact */    \
+		/* whole number of this integral unit. `base(rhs)` selects whichever base consteval ctor matches the source. */ \
 		template<::units::ConversionFactorType Cf, ::units::ArithmeticType Ty, ::units::NumericalScaleType<Ty> Ns>       \
 			requires(::units::traits::is_same_dimension_unit_v<::units::unit<Cf, Ty, Ns>, base> &&                       \
 					 !::units::detail::is_losslessly_convertible_unit<::units::unit<Cf, Ty, Ns>, base> &&                 \
-					 ::std::is_floating_point_v<Ty> && ::std::is_integral_v<Underlying>)                                  \
+					 (::std::is_floating_point_v<Ty> || ::std::is_integral_v<Ty>) && ::std::is_integral_v<Underlying>)    \
 		consteval unitName(const ::units::unit<Cf, Ty, Ns>& rhs) : base(rhs) {}                                          \
 		/* Forward a scalar assignment to the base's operator= so the dimensionless '= 0.30' path (which the derived */ \
 		/* class would otherwise route through the raw-value converting ctor, off by the CF ratio) is used. Templated */\
@@ -2258,6 +2259,39 @@ namespace units
 				return negative ? static_cast<Rep>(-result) : result;
 			}
 		}
+
+		/// Whether `value * num` is an exact multiple of `den` for an integral `value` — i.e. `value * num / den`
+		/// loses nothing. The product is carried in the widest available signed integer so the divisibility test is
+		/// exact and cannot be defeated by an intermediate overflow (a `value * num` that wrapped could spuriously
+		/// look divisible). `num`/`den` are the numerator/denominator of a `std::ratio` in lowest terms, so `den`
+		/// is positive; only `value` may be negative. Sign does not affect divisibility, so the magnitude of the
+		/// product is tested.
+		template<class Rep>
+		constexpr bool integral_conversion_is_exact(Rep value, std::intmax_t num, std::intmax_t den) noexcept
+		{
+			const widest_signed_int product = static_cast<widest_signed_int>(value) * static_cast<widest_signed_int>(num);
+			return product % static_cast<widest_signed_int>(den) == 0;
+		}
+
+		/// Convert an integral `value` from a finer to a coarser same-dimension unit (`num`/`den` the conversion
+		/// ratio), exactly. When `value * num` is a whole multiple of `den` the exact quotient is returned; when it
+		/// is not, the `throw` makes this a non-constant expression, so the narrowing unit constructor that calls it
+		/// in a constant-evaluated context is ill-formed rather than silently truncating. The exactness test and the
+		/// quotient both ride in a double-width intermediate, so neither is defeated by an intermediate overflow. `To`
+		/// and `From` are integral.
+		/// @tparam		To		the integral target type.
+		/// @tparam		From	the integral source type.
+		/// @param[in]	value	the source magnitude, in the source unit.
+		/// @param[in]	num		the conversion ratio numerator.
+		/// @param[in]	den		the conversion ratio denominator.
+		/// @return		`value * num / den` as `To`, when exact.
+		template<class To, class From>
+		constexpr To exact_integral_unit_cast(From value, std::intmax_t num, std::intmax_t den)
+		{
+			if (!integral_conversion_is_exact(value, num, den))
+				throw "an integral unit converts to a coarser integral unit only when the value is an exact whole number of the target unit";
+			return static_cast<To>(widening_mul_div(value, num, den));
+		}
 	} // namespace detail
 	/** @endcond */ // END DOXYGEN IGNORE
 
@@ -2721,6 +2755,31 @@ namespace units
 					 std::is_floating_point_v<Ty> && std::is_integral_v<T>)
 		consteval unit(const unit<ConversionFactorRhs, Ty, NsRhs>& rhs)
 		  : _linearized_value(detail::exact_integral_cast<T>(unit<ConversionFactor, detail::floating_point_promotion_t<T>, NumericalScale>(rhs).raw()))
+		{
+		}
+
+		/**
+		 * @brief		compile-time exact integral converting constructor
+		 * @details		Constructs an integral-underlying unit from a same-dimension integral one of a FINER unit when
+		 *				the value is an exact whole number of this (coarser) unit — the case the ordinary converting
+		 *				constructor rejects as potentially-lossy because a run-time value need not divide evenly
+		 *				(`bytes<int> b = 16_bit;` is `2`, but a run-time `bits<int>` might be `17`). It is `consteval`,
+		 *				so it participates only in a constant-evaluated context; a value that is not a whole number of
+		 *				the target unit (`17_bit` into `bytes<int>`) makes the constructor a non-constant expression and
+		 *				the program ill-formed — never a silent truncation. The exactness test is exact integer
+		 *				arithmetic in a double-width intermediate, so it cannot be defeated by an intermediate overflow.
+		 *				A run-time integral-to-coarser-integral unit conversion remains rejected; use `round`/`floor`/
+		 *				`ceil`/`trunc<To>` for a deliberate run-time rounding.
+		 * @param[in]	rhs unit to convert.
+		 */
+		template<ConversionFactorType ConversionFactorRhs, ArithmeticType Ty, NumericalScaleType<Ty> NsRhs>
+			requires(traits::is_same_dimension_unit_v<unit<ConversionFactorRhs, Ty, NsRhs>, unit> &&
+					 !detail::is_losslessly_convertible_unit<unit<ConversionFactorRhs, Ty, NsRhs>, unit> &&
+					 std::is_integral_v<Ty> && std::is_integral_v<T>)
+		consteval unit(const unit<ConversionFactorRhs, Ty, NsRhs>& rhs)
+		  : _linearized_value(detail::exact_integral_unit_cast<T>(rhs.raw(),
+				std::ratio_divide<typename ConversionFactorRhs::conversion_ratio, typename ConversionFactor::conversion_ratio>::num,
+				std::ratio_divide<typename ConversionFactorRhs::conversion_ratio, typename ConversionFactor::conversion_ratio>::den))
 		{
 		}
 
@@ -5375,6 +5434,101 @@ namespace units
 	constexpr detail::floating_point_promotion_t<UnitType> round(const UnitType x) noexcept
 	{
 		return detail::floating_point_promotion_t<UnitType>(std::round(x.raw()));
+	}
+
+	/** @cond */ // DOXYGEN IGNORE
+	namespace detail
+	{
+		/// A run-time conversion to a coarser same-dimension unit that need not divide evenly, with the caller's
+		/// rounding intent applied in the target unit. `x` is expressed in `To`'s unit as floating point, the supplied
+		/// rounding function (`std::floor`/`ceil`/`round`/`trunc`) reduces it to a whole number, and the result is
+		/// constructed as `To` from that already-linearized whole value — bypassing the lossless-conversion
+		/// constructor, which correctly rejects the implicit form. `To` and `From` are same-dimension units, `To`
+		/// integral; `From` need not be. This is the run-time counterpart to the compile-time exact narrowing
+		/// constructor.
+		template<class To, class From, class RoundingFn>
+		constexpr To rounded_unit_cast(const From& x, RoundingFn round) noexcept
+		{
+			using Promoted = unit<typename To::conversion_factor, floating_point_promotion_t<typename To::underlying_type>, typename To::numerical_scale_type>;
+			return To(static_cast<typename To::underlying_type>(round(Promoted(x).to_linearized())), linearized_value);
+		}
+
+		/// Whether a run-time rounding conversion from `From` to `To` is meaningful: same dimension, an integral
+		/// target, and a source not already losslessly convertible into the target (a lossless conversion needs no
+		/// rounding and the ordinary converting constructor serves it). Gating the target-unit rounding overloads on
+		/// this keeps them from shadowing the deduced-argument `round`/`floor`/`ceil`/`trunc` math functions.
+		template<class To, class From>
+		inline constexpr bool is_roundable_unit_conversion =
+			traits::is_unit_v<To> && traits::is_unit_v<From> && same_dimension<From, To> &&
+			std::is_integral_v<typename To::underlying_type> && !is_losslessly_convertible_unit<From, To>;
+	} // namespace detail
+	/** @endcond */ // END DOXYGEN IGNORE
+
+	/**
+	 * @ingroup		UnitMath
+	 * @brief		Convert to a coarser integral unit, rounding down (toward negative infinity).
+	 * @details		The run-time counterpart to the compile-time exact narrowing conversion: where
+	 *				`bytes<int> b = someRuntimeBits;` is correctly rejected (a run-time value need not be a whole
+	 *				number of bytes), `units::floor<bytes<int>>(someRuntimeBits)` states the rounding intent and
+	 *				yields the number of whole bytes at or below the value. Same shape as `std::chrono::floor<To>`.
+	 * @tparam		To		the coarser integral target unit (e.g. `bytes<int>`).
+	 * @tparam		From	the source unit (deduced), same dimension as `To`.
+	 * @param[in]	x		the value to convert.
+	 * @return		`x` in units of `To`, rounded toward negative infinity.
+	 */
+	template<class To, UnitType From>
+		requires detail::is_roundable_unit_conversion<To, From>
+	constexpr To floor(const From& x) noexcept
+	{
+		return detail::rounded_unit_cast<To>(x, [](auto v) { return std::floor(v); });
+	}
+
+	/**
+	 * @ingroup		UnitMath
+	 * @brief		Convert to a coarser integral unit, rounding up (toward positive infinity).
+	 * @details		Run-time lossy conversion with explicit rounding intent; see `floor<To>`.
+	 * @tparam		To		the coarser integral target unit.
+	 * @tparam		From	the source unit (deduced), same dimension as `To`.
+	 * @param[in]	x		the value to convert.
+	 * @return		`x` in units of `To`, rounded toward positive infinity.
+	 */
+	template<class To, UnitType From>
+		requires detail::is_roundable_unit_conversion<To, From>
+	constexpr To ceil(const From& x) noexcept
+	{
+		return detail::rounded_unit_cast<To>(x, [](auto v) { return std::ceil(v); });
+	}
+
+	/**
+	 * @ingroup		UnitMath
+	 * @brief		Convert to a coarser integral unit, rounding to nearest (halfway away from zero).
+	 * @details		Run-time lossy conversion with explicit rounding intent; see `floor<To>`.
+	 * @tparam		To		the coarser integral target unit.
+	 * @tparam		From	the source unit (deduced), same dimension as `To`.
+	 * @param[in]	x		the value to convert.
+	 * @return		`x` in units of `To`, rounded to the nearest whole target unit.
+	 */
+	template<class To, UnitType From>
+		requires detail::is_roundable_unit_conversion<To, From>
+	constexpr To round(const From& x) noexcept
+	{
+		return detail::rounded_unit_cast<To>(x, [](auto v) { return std::round(v); });
+	}
+
+	/**
+	 * @ingroup		UnitMath
+	 * @brief		Convert to a coarser integral unit, rounding toward zero.
+	 * @details		Run-time lossy conversion with explicit rounding intent; see `floor<To>`.
+	 * @tparam		To		the coarser integral target unit.
+	 * @tparam		From	the source unit (deduced), same dimension as `To`.
+	 * @param[in]	x		the value to convert.
+	 * @return		`x` in units of `To`, rounded toward zero.
+	 */
+	template<class To, UnitType From>
+		requires detail::is_roundable_unit_conversion<To, From>
+	constexpr To trunc(const From& x) noexcept
+	{
+		return detail::rounded_unit_cast<To>(x, [](auto v) { return std::trunc(v); });
 	}
 
 	//----------------------------------

--- a/test/errorMessages/cases/narrow_indivisible_integer_to_coarser.cpp
+++ b/test/errorMessages/cases/narrow_indivisible_integer_to_coarser.cpp
@@ -1,0 +1,31 @@
+// Case: a whole-number-of-bytes bit count converts into a coarser integer-backed unit at compile time
+// (bytes<int> b = bits<int>(16) is 2 bytes), but an indivisible one cannot — 17 bits is not a whole number
+// of bytes, so bytes<int>{bits<int>(17)} is ill-formed. The exact-integral narrowing constructor is consteval
+// and rejects the indivisible value during constant evaluation; the diagnostic names the target unit and
+// reports that the value is not a whole number of it. This is the integer counterpart of the fractional
+// float->int narrowing case (16.5_ft -> feet<int>).
+//
+// The readable signals differ by compiler and are asserted per-compiler to the STRONGEST token each prints:
+//   - `bytes<int>` (the target unit type) is named by every compiler, so it is asserted universally.
+//   - GCC and clang surface the constructor's own plain-language message (the thrown string
+//     "...exact whole number of the target unit"), so that verbatim reason is the tight -gcc assertion.
+//   - MSVC does NOT surface the thrown string; it reports the rejection as C7595 ("call to immediate function
+//     is not a constant expression"). That phrase names the REASON MSVC prints and is the tight -msvc assertion.
+// Readability is verified two-sided: the target type / reason IS named AND the message is not buried in
+// conversion-factor / dimension soup (both forbid tokens confirmed absent on GCC-13/15, clang, and MSVC).
+//
+// expect: fail
+// expect-match: bytes<int>
+// expect-match-gcc: an integral unit converts to a coarser integral unit only when the value is an exact whole number of the target unit
+// expect-match-msvc: call to immediate function is not a constant expression
+// forbid-match: conversion_factor<std::ratio<1>, units::dimension_t
+// forbid-match: dimension_t<
+#include <units/data.h>
+using namespace units;
+using namespace units::data;
+auto bad = bytes<int>{bits<int>(17)};   // ill-formed: 17 bits is not a whole number of bytes
+int main()
+{
+	(void)bad;
+	return 0;
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -3260,6 +3260,80 @@ TEST_F(UnitType, hashOfLargeValueDoesNotOverflow)
 	EXPECT_EQ(std::hash<meters<int>>()(meters<int>(7)), std::hash<meters<int>>()(meters<int>(7)));
 }
 
+TEST_F(UnitType, exactIntegralNarrowingConstructor)
+{
+	using units::data::bits;
+	using units::data::bytes;
+	using units::data::nibbles;
+
+	// A compile-time-known finer integral value that is an exact whole number of the coarser unit converts, at
+	// compile time, to the exact count. `bits` is ratio<1,8> of `bytes`, so 16 bits is exactly 2 bytes.
+	constexpr bytes<int> two = bits<int>(16);
+	static_assert(two.value() == 2, "16 bits is 2 bytes");
+	EXPECT_EQ(2, two.value());
+
+	constexpr bytes<int> one = bits<int>(8);
+	static_assert(one.value() == 1, "8 bits is 1 byte");
+
+	// Negative carriers convert exactly (divisibility ignores sign).
+	constexpr bytes<int> negTwo = bits<int>(-16);
+	static_assert(negTwo.value() == -2, "-16 bits is -2 bytes");
+	EXPECT_EQ(-2, negTwo.value());
+
+	// A multi-step finer ratio: a nibble is 4 bits, so 2 nibbles is exactly 1 byte.
+	constexpr bytes<int> fromNibbles = nibbles<int>(2);
+	static_assert(fromNibbles.value() == 1, "2 nibbles is 1 byte");
+
+	// The reverse direction is already lossless and unchanged (coarser -> finer never truncates).
+	constexpr bits<int> sixteen = bytes<int>(2);
+	static_assert(sixteen.value() == 16, "2 bytes is 16 bits");
+
+	// The exactness test rides in a double-width intermediate, so a large exact value still converts (no overflow
+	// of value*num before the divide). 2^60 bits is exactly 2^57 bytes.
+	constexpr bytes<std::int64_t> big = bits<std::int64_t>(1LL << 60);
+	static_assert(big.value() == (1LL << 57), "2^60 bits is 2^57 bytes");
+}
+
+TEST_F(UnitType, runtimeLossyRoundingConversion)
+{
+	using units::data::bits;
+	using units::data::bytes;
+
+	// A genuinely run-time finer value need not be a whole number of the coarser unit; the caller states the
+	// rounding intent with the target-taking round/floor/ceil/trunc, mirroring std::chrono::floor<To>.
+	const bits<int> seventeen(17); // 2.125 bytes
+	EXPECT_EQ(2, units::floor<bytes<int>>(seventeen).value());
+	EXPECT_EQ(3, units::ceil<bytes<int>>(seventeen).value());
+	EXPECT_EQ(2, units::round<bytes<int>>(seventeen).value());
+	EXPECT_EQ(2, units::trunc<bytes<int>>(seventeen).value());
+
+	const bits<int> twenty(20); // 2.5 bytes -> round halfway away from zero
+	EXPECT_EQ(2, units::floor<bytes<int>>(twenty).value());
+	EXPECT_EQ(3, units::ceil<bytes<int>>(twenty).value());
+	EXPECT_EQ(3, units::round<bytes<int>>(twenty).value());
+	EXPECT_EQ(2, units::trunc<bytes<int>>(twenty).value());
+
+	// Negative values distinguish floor (toward -inf) from trunc (toward zero).
+	const bits<int> negSeventeen(-17); // -2.125 bytes
+	EXPECT_EQ(-3, units::floor<bytes<int>>(negSeventeen).value());
+	EXPECT_EQ(-2, units::ceil<bytes<int>>(negSeventeen).value());
+	EXPECT_EQ(-2, units::round<bytes<int>>(negSeventeen).value());
+	EXPECT_EQ(-2, units::trunc<bytes<int>>(negSeventeen).value());
+
+	// An exactly-divisible run-time value rounds to itself under every mode.
+	const bits<int> sixteen(16); // exactly 2 bytes
+	EXPECT_EQ(2, units::floor<bytes<int>>(sixteen).value());
+	EXPECT_EQ(2, units::ceil<bytes<int>>(sixteen).value());
+	EXPECT_EQ(2, units::round<bytes<int>>(sixteen).value());
+	EXPECT_EQ(2, units::trunc<bytes<int>>(sixteen).value());
+
+	// The target-taking overloads do not shadow the deduced-argument rounding math functions.
+	EXPECT_DOUBLE_EQ(3.0, units::floor(meters<double>(3.7)).value());
+	EXPECT_DOUBLE_EQ(4.0, units::ceil(meters<double>(3.7)).value());
+	EXPECT_DOUBLE_EQ(4.0, units::round(meters<double>(3.7)).value());
+	EXPECT_DOUBLE_EQ(3.0, units::trunc(meters<double>(3.7)).value());
+}
+
 #ifndef UNIT_LIB_DISABLE_IOSTREAM
 TEST_F(UnitType, cout)
 {


### PR DESCRIPTION
Closes #375.

Makes a same-dimension integer-to-coarser-integer conversion frictionless where it is provably safe, and gives the genuinely-lossy runtime case an intention-revealing spelling — without a new conversion verb and without loosening the lossless guarantee.

## Compile-time exact narrowing

A `consteval` constructor converts a compile-time-known finer integer unit into a coarser integer unit when the value is an exact whole number of the target:

```cpp
constexpr bytes<int> b = 16_b;   // OK    — 16 bits is exactly 2 bytes, proven at compile time
constexpr bytes<int> c = 17_b;   // error — not a whole number of bytes; never a silent truncation
bytes<int> d = runtimeBits;      // still rejected — a runtime bit count need not divide evenly
```

This is the same mechanism that already makes `feet<int> f = 16_ft;` compile while `16.5_ft` does not, extended to the finer-int -> coarser-int case. The exactness test is exact integer arithmetic carried in a double-width intermediate, so it cannot be defeated by an intermediate overflow (routing through floating-point promotion would have silently accepted a large indivisible value — that path is not used for int -> int).

## Runtime lossy conversion

For a genuinely-runtime value the caller states the rounding intent using the functions the library already provides, with a target-unit overload — the same shape as `std::chrono::floor<To>`:

```cpp
units::floor<bytes<int>>(runtimeBits);   // toward -inf
units::ceil <bytes<int>>(runtimeBits);   // toward +inf
units::round<bytes<int>>(runtimeBits);   // nearest, halfway away from zero
units::trunc<bytes<int>>(runtimeBits);   // toward zero
```

The overloads are constrained to the same-dimension, integral-target, not-already-lossless case, so they never shadow the existing deduced-argument `round`/`floor`/`ceil`/`trunc` math functions. Exact-or-fail is still served by `to<Unit>()` -> `expected` / `try_to<Unit>()`, and the deliberate cast by `unit_cast`. No new conversion verb is introduced.

## Tests and docs

- `exactIntegralNarrowingConstructor` and `runtimeLossyRoundingConversion` in the unit suite (exact, negative carriers, nibbles, large-value no-overflow, negative-rounding sign semantics, and a guard that the deduced math functions are not shadowed).
- An error-message case pinning the `17 bits -> bytes<int>` rejection: it names the target type and carries no conversion-factor soup.
- Conversions guide and README quick reference updated.

Full suite: 467/467 green on GCC-13 and clang-19; 77/77 error-message cases on both. MSVC verified by CI.