### PR TITLE
Prepare 3.6.0: clean add_subdirectory consumption, version, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,63 @@
 All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project adheres to semantic versioning.
 
+## [3.6.0] - 2026-08-17
+
+New capabilities: opt-in affine and string-tagged quantity wrappers, per-dimension concepts, `std::format`
+support, floating-point literals with exact compile-time narrowing to integer units, and a set of
+correctness and packaging fixes.
+
+### Added
+- Opt-in affine wrappers `absolute<Unit>` and `delta<Unit>` (`units/kind.h`, an opt-in header not pulled in
+  by `units.h`). `absolute<>` is a point that carries a datum; `delta<>` is an offset-free amount. The
+  affine algebra is enforced at compile time: point − point yields a delta, point ± delta yields a point,
+  delta ± delta yields a delta, and point + point is ill-formed. Plain `units.h` sees none of this.
+- A generic string-tagged quantity kind, `units::kind<"tag", Unit>` (`units/kind.h`). Two kinds with the
+  same tag interoperate; different tags are a compile error with a readable diagnostic; a plain unit is
+  constructible into a kind by deliberate assignment but does not mix with one in arithmetic. Same-tag
+  `kind / kind` yields a dimensionless result. Full parity with a plain unit: `std::hash`,
+  `std::numeric_limits`, `abs`/`min`/`max`/`clamp`, and the compound-assignment operators.
+- A single conversion verb `to<Target>()` across the wrappers: a plain-unit target unwraps (a point applies
+  its datum; a delta or kind scales only), a wrapper target stays wrapped, and an arithmetic target
+  (`to<int>`) yields the number.
+- A per-dimension concept beside each `is_<dimension>_unit` trait (`units::Velocity`, `units::Force`,
+  `units::Length`, `units::Frequency`, `units::Area`, `units::Dimensionless`, …), so a function can
+  constrain on a dimension (`void handle(units::Velocity auto v)`) and a computed result classifies the same
+  way in every translation unit. (#379)
+- `std::format` / `std::print` support for units, with a format specification for the value and the unit
+  rendering; `to_string` and `operator<<` are unaffected. Can be disabled with `UNITS_DISABLE_FORMAT`. (#374)
+- Unit literals are floating-point, and a compile-time-known value that is exact narrows into an integer
+  representation through a `consteval` constructor: `feet<int> f = 16_ft;` compiles while `16.5_ft` is a
+  compile error. This extends to a finer integer unit converting into a coarser integer unit when the value
+  is an exact whole number of the target (`bytes<int> b = 16_b;` is 2 bytes; `17_b` is a compile error,
+  never a silent truncation); a run-time value that need not divide evenly remains rejected. (#375, #380)
+- Run-time lossy conversion to a coarser integer unit with explicit rounding intent: `round`, `floor`,
+  `ceil`, and `trunc` gain a target-unit overload (`units::floor<bytes<int>>(runtimeBits)`), the same shape
+  as `std::chrono::floor<To>`. Exact-or-fail is still served by `to<Unit>()` → `expected` / `try_to<Unit>()`,
+  and the deliberate cast by `unit_cast`. (#375)
+
+### Fixed
+- Unit conversions no longer overflow the intermediate computation. An integer conversion carries the
+  `value * num` product in a double-width intermediate before the divide, so a large magnitude through a
+  fractional ratio yields the correct value instead of a wrapped one; a floating-point conversion divides
+  first only when the accurate `value * num` order would overflow to infinity, keeping a finite result
+  where one exists. (#387)
+- Same-dimension comparison between a signed-underlying and an unsigned-underlying unit is by mathematical
+  value, not C++ integer-promotion rules: `meters<int>(-1) < meters<unsigned>(1u)` is now true.
+- A cluster of `<cmath>`-analog correctness bugs, including `fma`. (#376)
+- Mixed-unit arithmetic reconciles its result to a real named unit and recovers composed and offset-free
+  names, computed in the function body rather than the signature. (#381)
+
+### Changed
+- Consuming `units` via `add_subdirectory` is now inert: a nested `units` builds no tests, examples, or
+  documentation, pulls in no CTest scaffolding (no `BUILD_TESTING` option or `Nightly`/`Continuous`/
+  `Experimental` targets in the consumer's cache), and generates no install/export rules — so a consuming
+  application's `cmake --install` does not stage `units`' headers or CMake package files. When `units` is
+  the top-level project (a CPack build, or a Conan/vcpkg recipe that configures it directly) the install
+  rules are on; a subdirectory consumer that wants them can set `UNITS_INSTALL=ON`.
+- The continuous-integration suite gained an UndefinedBehaviorSanitizer job, so a conversion that invoked
+  runtime undefined behavior fails the build rather than returning a wrong value silently.
+
 ## [3.5.1] - 2026-08-15
 
 ### Fixed
@@ -210,6 +267,7 @@ The C++23 line. This is a major revision; see the
 - `unit_value_t` — use a `constexpr` quantity value instead.
 - The `units::math` namespace and the `_t` singular type aliases (see Changed).
 
+[3.6.0]: https://github.com/nholthaus/units/releases/tag/v3.6.0
 [3.5.1]: https://github.com/nholthaus/units/releases/tag/v3.5.1
 [3.5.0]: https://github.com/nholthaus/units/releases/tag/v3.5.0
 [3.4.4]: https://github.com/nholthaus/units/releases/tag/v3.4.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,10 @@ correctness and packaging fixes.
   never a silent truncation); a run-time value that need not divide evenly remains rejected. (#375, #380)
 - Run-time lossy conversion to a coarser integer unit with explicit rounding intent: `round`, `floor`,
   `ceil`, and `trunc` gain a target-unit overload (`units::floor<bytes<int>>(runtimeBits)`), the same shape
-  as `std::chrono::floor<To>`. Exact-or-fail is still served by `to<Unit>()` → `expected` / `try_to<Unit>()`,
-  and the deliberate cast by `unit_cast`. (#375)
+  as `std::chrono::floor<To>`. The rounding is exact integer arithmetic, so it is correct at every magnitude
+  (a value beyond 2^53 is not rounded through a lossy double), and a result that does not fit the target
+  integer wraps like any integer narrowing rather than invoking undefined behavior. A deliberate value cast
+  without rounding remains `unit_cast`. (#375)
 
 ### Fixed
 - Unit conversions no longer overflow the intermediate computation. An integer conversion carries the

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,4 +21,4 @@ keywords:
   - header-only
   - compile-time
 license: MIT
-version: 3.5.1
+version: 3.6.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,11 @@ endif()
 # cmake options
 OPTION(UNITS_BUILD_TESTS "Build unit tests" ${MAIN_PROJECT})
 OPTION(UNITS_BUILD_DOCS "Build the documentation" OFF)
-OPTION(UNITS_BUILD_EXAMPLES "Build the documentation examples" ${MAIN_PROJECT})
+# The examples are compiled artifacts for development and CI, like the tests — a consumer of this header-only
+# library never needs them built. They therefore follow UNITS_BUILD_TESTS: on for a repo/developer build, and off
+# whenever a packaging build turns tests off (a Conan/vcpkg recipe passes -DUNITS_BUILD_TESTS=OFF), so a package
+# install compiles nothing and stages only the headers.
+OPTION(UNITS_BUILD_EXAMPLES "Build the documentation examples" ${UNITS_BUILD_TESTS})
 # Generate install/export rules. On by default when units is the top-level project (a package build: CPack, a
 # Conan/vcpkg recipe that configures units directly), off when units is pulled in via add_subdirectory so a
 # consuming application's `cmake --install` does not also stage units' headers and CMake package files. A packager
@@ -169,7 +173,9 @@ endif() # UNITS_INSTALL
 # -----------------------------
 # CPack (packaging)
 # -----------------------------
-if(MAIN_PROJECT)
+# Requires the install rules: without them CPack would produce an empty package (headers and CMake files come from
+# the install(...) commands above), so packaging is gated on UNITS_INSTALL as well as being the top-level project.
+if(MAIN_PROJECT AND UNITS_INSTALL)
 	# ---- CPack (Linux packages) ----
 
 	# Choose generators based on host capabilities

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16...4.99 FATAL_ERROR)
 
-PROJECT(units VERSION 3.5.1 LANGUAGES CXX)
+PROJECT(units VERSION 3.6.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 
@@ -14,6 +14,11 @@ endif()
 OPTION(UNITS_BUILD_TESTS "Build unit tests" ${MAIN_PROJECT})
 OPTION(UNITS_BUILD_DOCS "Build the documentation" OFF)
 OPTION(UNITS_BUILD_EXAMPLES "Build the documentation examples" ${MAIN_PROJECT})
+# Generate install/export rules. On by default when units is the top-level project (a package build: CPack, a
+# Conan/vcpkg recipe that configures units directly), off when units is pulled in via add_subdirectory so a
+# consuming application's `cmake --install` does not also stage units' headers and CMake package files. A packager
+# that DOES vendor units as a subdirectory and still wants it installed can force it on with -DUNITS_INSTALL=ON.
+OPTION(UNITS_INSTALL "Generate the install/export rules for units" ${MAIN_PROJECT})
 OPTION(UNITS_DISABLE_IOSTREAM "Disables <iostream> (cout) support for embedded applications" OFF)
 OPTION(UNITS_DISABLE_FORMAT "Disables std::format / std::print support (keeps iostream and to_string)" OFF)
 OPTION(UNITS_DISABLE_STRING "Disables all <string> use (leanest build; implies DISABLE_IOSTREAM and DISABLE_FORMAT)" OFF)
@@ -57,9 +62,13 @@ if(UNITS_DISABLE_STRING)
 	target_compile_definitions(${PROJECT_NAME} INTERFACE UNIT_LIB_DISABLE_STRING)
 endif(UNITS_DISABLE_STRING)
 
-# unit tests
-include(CTest)
-if(BUILD_TESTING AND UNITS_BUILD_TESTS)
+# unit tests. include(CTest) — which defines the BUILD_TESTING option (default ON) and adds the Dart/CTest
+# targets — is pulled in only when units is actually building its own tests, so a consumer that adds units via
+# add_subdirectory does not inherit units' testing scaffolding in their cache or target list.
+if(UNITS_BUILD_TESTS)
+	include(CTest)
+endif()
+if(UNITS_BUILD_TESTS AND BUILD_TESTING)
 	find_package(Threads)
 	set(GTEST_VERSION 1.17.0)
 	find_package(GTest ${GTEST_VERSION} QUIET CONFIG)
@@ -99,6 +108,9 @@ endif()
 # -----------------------------
 # Install/export for find_package(units CONFIG)
 # -----------------------------
+# Guarded by UNITS_INSTALL (default = top-level project) so a consuming application that vendors units via
+# add_subdirectory does not have units' headers and package files injected into its own `cmake --install`.
+if(UNITS_INSTALL)
 include(CMakePackageConfigHelpers)
 
 # Version file for package config
@@ -152,6 +164,7 @@ install(FILES
 		"${CMAKE_CURRENT_BINARY_DIR}/unitsConfigVersion.cmake"
 		DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/units
 )
+endif() # UNITS_INSTALL
 
 # -----------------------------
 # CPack (packaging)

--- a/README.md
+++ b/README.md
@@ -663,7 +663,7 @@ target_link_libraries(myapp PRIVATE units::units)
 include(FetchContent)
 FetchContent_Declare(units
   GIT_REPOSITORY https://github.com/nholthaus/units.git
-  GIT_TAG        v3.5.1)
+  GIT_TAG        v3.6.0)
 FetchContent_MakeAvailable(units)
 target_link_libraries(myapp PRIVATE units::units)
 ```

--- a/README.md
+++ b/README.md
@@ -148,10 +148,11 @@ meters c = 5.0 * m;     // a value times a unit constant (units::m)
 meters d{5.0};          // braced construction
 ```
 
-> **Note — write the decimal point for fractional values.** A literal's type follows what you write:
-> `5.0_m` is `meters<double>`, but `5_m` is `meters<int>`. Integer-backed quantities do integer
-> arithmetic, so `1_m / 2_m` is `0`, whereas `1.0_m / 2.0_m` is `0.5`. Use a decimal point (or write
-> `meters<double>`) when you want fractional results.
+> **Note — unit literals are floating-point.** Both `5.0_m` and `5_m` are `meters<double>`, so `1_m / 2_m`
+> is `0.5`, not `0` — a literal never silently does integer arithmetic. An integer representation is opt-in
+> through the type (`meters<int> n{5}`, or CTAD from an integer initializer `meters a(5)`); a compile-time
+> value that is exact narrows into it (`meters<int> n = 5_m;`), while a fractional one (`5.5_m`) is a
+> compile error rather than a silent truncation.
 
 **Spelling the type: `meters`, `meters<>`, `meters<T>`.** Three ways to name the type:
 
@@ -676,15 +677,15 @@ find_package(units CONFIG REQUIRED)
 target_link_libraries(myapp PRIVATE units::units)
 ```
 
-**Linux packages.** The build produces Debian (`libunits-dev`), RPM (`units-devel`), and tarball
-artifacts via CPack; a PPA is published for Ubuntu.
+**Package managers.** `units` is available through vcpkg (`vcpkg install units`), Conan
+(`conan install --requires=units/<version>`), and Debian/Ubuntu (`apt install libunits-dev`; an RPM and a
+tarball are also produced via CPack, and a PPA is published for Ubuntu). The reference sources for all three
+integrations live in [`packaging/`](packaging/).
 
 [Debugger visualizers](docs/how-to/natvis.md) show a quantity as `5 m` in the debugger rather than an
 opaque object: linking `units::units` attaches the [natvis](natvis/units.natvis) automatically on MSVC,
 and an [LLDB formatter](natvis/units_lldb.py) (`command script import units_lldb.py`) does the same for
 LLDB, CLion, Xcode, and CodeLLDB.
-
-> **Not yet available:** vcpkg and Conan ports. Contributions welcome.
 
 ---
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+units (3.6.0-0ppa1~noble1) noble; urgency=medium
+
+  * New release: opt-in affine (absolute/delta) and string-tagged kind wrappers,
+    a unified to<Target>() conversion verb, per-dimension concepts, std::format
+    support, floating-point literals with exact compile-time narrowing to integer
+    units (and runtime round/floor/ceil/trunc<To>), overflow-safe conversions and
+    value-based integer comparison, cmath fixes, and inert add_subdirectory
+    consumption.
+
+ -- Nic Holthaus <nholthaus@gmail.com>  Sun, 17 Aug 2026 12:00:00 -0400
+
 units (3.5.1-0ppa1~noble1) noble; urgency=medium
 
   * Correct the installed CMake package version.

--- a/docs/how-to/cmake-integration.md
+++ b/docs/how-to/cmake-integration.md
@@ -29,15 +29,24 @@ Pull it at configure time — no vendored copy in your tree:
 include(FetchContent)
 FetchContent_Declare(units
   GIT_REPOSITORY https://github.com/nholthaus/units.git
-  GIT_TAG        v3.5.1)          # pin a release tag
+  GIT_TAG        v3.6.0)          # pin a release tag
 FetchContent_MakeAvailable(units)
 
 target_link_libraries(myapp PRIVATE units::units)
 ```
 
-> **Note — turn off the extras in a consumer build.** When `units` is not the top-level project it does
-> not build its own tests or examples by default. If you want to be explicit, set the options before
-> `MakeAvailable`/`add_subdirectory`: `set(UNITS_BUILD_TESTS OFF)` and `set(UNITS_BUILD_EXAMPLES OFF)`.
+> **Note — a nested consumer build is inert.** When `units` is not the top-level project it builds
+> nothing of its own: no tests, no examples, no documentation, and it pulls in no CTest scaffolding (your
+> cache gets no `BUILD_TESTING` option and no `Nightly`/`Continuous`/`Experimental` targets from `units`).
+> Linking `units::units` is header-only, so all you get is the include path and `cxx_std_23`. If you want to
+> be explicit, set the options before `MakeAvailable`/`add_subdirectory`: `set(UNITS_BUILD_TESTS OFF)` and
+> `set(UNITS_BUILD_EXAMPLES OFF)`.
+>
+> A nested `units` also generates **no install/export rules**, so your application's `cmake --install` does
+> not stage `units`' headers or CMake package files into your install tree. A packager that vendors `units`
+> as a subdirectory and *does* want it installed can force the rules on with `set(UNITS_INSTALL ON)` before
+> `add_subdirectory`. When `units` is the top-level project (a CPack build, or a Conan/vcpkg recipe that
+> configures `units` directly), the install rules are on by default.
 
 ## Installed package: `find_package`
 

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -881,6 +881,41 @@ namespace units
 		};
 
 		/**
+		 * @brief		Whether `T` is a complete type, decided by SFINAE on `sizeof(T)` without instantiating any
+		 *				other trait.
+		 * @details		`std::is_base_of<Base, T>` is ill-formed when `T` is an incomplete, non-same class type (a
+		 *				conforming library — libc++ — rejects it). `is_unit` must stay usable as a SFINAE probe on
+		 *				arbitrary foreign types, and one such type is a standard-library class caught mid-definition:
+		 *				libc++'s `<chrono>` evaluates every `std::common_type` partial specialization while
+		 *				`std::chrono::duration` is still incomplete, which would instantiate `is_base_of<_unit,
+		 *				duration>` on the incomplete `duration`. Gating the base-of test on completeness avoids that.
+		 */
+		template<class T, class = void>
+		struct is_complete : std::false_type
+		{
+		};
+
+		template<class T>
+		struct is_complete<T, std::void_t<decltype(sizeof(T))>> : std::true_type
+		{
+		};
+
+		/**
+		 * @brief		`is_unit` implementation: an incomplete or non-class type is never a unit, decided WITHOUT
+		 *				instantiating `is_base_of` (which is ill-formed on an incomplete non-same class type). Only a
+		 *				complete type reaches the `is_base_of` test in the specialization below.
+		 */
+		template<class T, bool = is_complete<T>::value>
+		struct is_unit_impl : std::false_type
+		{
+		};
+
+		template<class T>
+		struct is_unit_impl<T, true> : std::is_base_of<_unit, T>::type
+		{
+		};
+
+		/**
 		 * @brief		ADL customization point that maps a `conversion_factor` to its friendly strong type.
 		 * @details		This is the anchor `traits::strong` resolves through. A dimension header registers a named
 		 *				strong type by declaring a better-matching overload of `strong_name` (see the
@@ -908,7 +943,7 @@ namespace units
 		 *				whether `class T` implements a `unit`.
 		 */
 		template<class T>
-		struct is_unit : std::is_base_of<units::detail::_unit, T>::type
+		struct is_unit : units::detail::is_unit_impl<T>::type
 		{
 		};
 
@@ -5439,18 +5474,83 @@ namespace units
 	/** @cond */ // DOXYGEN IGNORE
 	namespace detail
 	{
-		/// A run-time conversion to a coarser same-dimension unit that need not divide evenly, with the caller's
-		/// rounding intent applied in the target unit. `x` is expressed in `To`'s unit as floating point, the supplied
-		/// rounding function (`std::floor`/`ceil`/`round`/`trunc`) reduces it to a whole number, and the result is
-		/// constructed as `To` from that already-linearized whole value — bypassing the lossless-conversion
-		/// constructor, which correctly rejects the implicit form. `To` and `From` are same-dimension units, `To`
-		/// integral; `From` need not be. This is the run-time counterpart to the compile-time exact narrowing
-		/// constructor.
-		template<class To, class From, class RoundingFn>
-		constexpr To rounded_unit_cast(const From& x, RoundingFn round) noexcept
+		/// The rounding direction for a run-time lossy conversion to a coarser integral unit.
+		enum class rounding_mode
 		{
-			using Promoted = unit<typename To::conversion_factor, floating_point_promotion_t<typename To::underlying_type>, typename To::numerical_scale_type>;
-			return To(static_cast<typename To::underlying_type>(round(Promoted(x).to_linearized())), linearized_value);
+			toward_neg_infinity, ///< floor
+			toward_pos_infinity, ///< ceil
+			nearest_half_away,   ///< round (halfway cases away from zero)
+			toward_zero          ///< trunc
+		};
+
+		/// Round an exact integer quotient `q = value*num/den` (truncated toward zero) with remainder
+		/// `r = value*num % den` in the requested direction, entirely in integer arithmetic. `den` is positive (a
+		/// `std::ratio` denominator); `r` carries the sign of the dividend. This is the integer counterpart of
+		/// applying `std::floor`/`ceil`/`round`/`trunc` to `value*num/den`, without ever forming that ratio as a
+		/// floating-point number — so it is exact at every magnitude, unlike a double-promoted rounding which loses
+		/// the fractional part above 2^53.
+		template<class Int>
+		constexpr Int apply_integer_rounding(Int q, Int r, Int den, rounding_mode mode) noexcept
+		{
+			if (r == 0)
+				return q; // exact — every mode agrees
+			switch (mode)
+			{
+			case rounding_mode::toward_zero:
+				return q; // integer division already truncated toward zero
+			case rounding_mode::toward_neg_infinity:
+				return r < 0 ? q - 1 : q; // a nonzero negative remainder means the true value is below q
+			case rounding_mode::toward_pos_infinity:
+				return r > 0 ? q + 1 : q; // a nonzero positive remainder means the true value is above q
+			case rounding_mode::nearest_half_away:
+			{
+				// Halfway-away-from-zero: step away from zero when twice the remainder magnitude reaches den.
+				const Int twiceRemainder = (r < 0 ? -r : r) * 2;
+				if (twiceRemainder >= den)
+					return r < 0 ? q - 1 : q + 1;
+				return q;
+			}
+			}
+			return q;
+		}
+
+		/// A run-time conversion to a coarser same-dimension unit that need not divide evenly, with the caller's
+		/// rounding intent applied in the target unit. When both source and target are integral the divide and the
+		/// rounding are done in exact integer arithmetic carried in a double-width intermediate (so the result is
+		/// exact at every magnitude and the final store is an ordinary — implementation-defined — integer narrowing,
+		/// matching `std::chrono::floor<To>`); when a floating-point underlying is involved the value is expressed in
+		/// the target unit and the matching `std::` rounding is applied. The result is constructed from the
+		/// already-linearized whole value, bypassing the lossless-conversion constructor that correctly rejects the
+		/// implicit form. `To` and `From` are same-dimension units, `To` integral; `From` need not be.
+		template<class To, class From>
+		constexpr To rounded_unit_cast(const From& x, rounding_mode mode) noexcept
+		{
+			using ToRep   = typename To::underlying_type;
+			using FromRep = typename From::underlying_type;
+
+			if constexpr (std::is_integral_v<FromRep>)
+			{
+				// Exact integer path: value (in From units) * num / den, rounded on the integer remainder.
+				using Ratio = std::ratio_divide<typename From::conversion_factor::conversion_ratio, typename To::conversion_factor::conversion_ratio>;
+				const widest_signed_int value   = static_cast<widest_signed_int>(x.raw());
+				const widest_signed_int product = value * static_cast<widest_signed_int>(Ratio::num);
+				const widest_signed_int den     = static_cast<widest_signed_int>(Ratio::den);
+				const widest_signed_int quotient  = product / den;
+				const widest_signed_int remainder = product % den;
+				const widest_signed_int rounded   = apply_integer_rounding(quotient, remainder, den, mode);
+				return To(static_cast<ToRep>(rounded), linearized_value);
+			}
+			else
+			{
+				// A floating-point source: express in the target unit and apply the matching std:: rounding.
+				using Promoted = unit<typename To::conversion_factor, floating_point_promotion_t<ToRep>, typename To::numerical_scale_type>;
+				const auto inTarget = Promoted(x).to_linearized();
+				const auto rounded  = mode == rounding_mode::toward_neg_infinity ? std::floor(inTarget)
+									: mode == rounding_mode::toward_pos_infinity ? std::ceil(inTarget)
+									: mode == rounding_mode::nearest_half_away   ? std::round(inTarget)
+																				 : std::trunc(inTarget);
+				return To(static_cast<ToRep>(rounded), linearized_value);
+			}
 		}
 
 		/// Whether a run-time rounding conversion from `From` to `To` is meaningful: same dimension, an integral
@@ -5480,7 +5580,7 @@ namespace units
 		requires detail::is_roundable_unit_conversion<To, From>
 	constexpr To floor(const From& x) noexcept
 	{
-		return detail::rounded_unit_cast<To>(x, [](auto v) { return std::floor(v); });
+		return detail::rounded_unit_cast<To>(x, detail::rounding_mode::toward_neg_infinity);
 	}
 
 	/**
@@ -5496,7 +5596,7 @@ namespace units
 		requires detail::is_roundable_unit_conversion<To, From>
 	constexpr To ceil(const From& x) noexcept
 	{
-		return detail::rounded_unit_cast<To>(x, [](auto v) { return std::ceil(v); });
+		return detail::rounded_unit_cast<To>(x, detail::rounding_mode::toward_pos_infinity);
 	}
 
 	/**
@@ -5512,7 +5612,7 @@ namespace units
 		requires detail::is_roundable_unit_conversion<To, From>
 	constexpr To round(const From& x) noexcept
 	{
-		return detail::rounded_unit_cast<To>(x, [](auto v) { return std::round(v); });
+		return detail::rounded_unit_cast<To>(x, detail::rounding_mode::nearest_half_away);
 	}
 
 	/**
@@ -5528,7 +5628,7 @@ namespace units
 		requires detail::is_roundable_unit_conversion<To, From>
 	constexpr To trunc(const From& x) noexcept
 	{
-		return detail::rounded_unit_cast<To>(x, [](auto v) { return std::trunc(v); });
+		return detail::rounded_unit_cast<To>(x, detail::rounding_mode::toward_zero);
 	}
 
 	//----------------------------------

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,52 @@
+# Packaging
+
+`units` is a header-only library, so every package is just the header tree plus the CMake package
+files — nothing is compiled to install it. This directory holds the reference sources for the
+package-manager integrations, kept in sync with each release so the downstream recipes have a single
+authoritative copy to track.
+
+| Manager | Source here | Downstream home | Consume with |
+|---------|-------------|-----------------|--------------|
+| vcpkg   | [`vcpkg/`](vcpkg/) | [`microsoft/vcpkg` `ports/units`](https://github.com/microsoft/vcpkg/tree/master/ports/units) | `vcpkg install units` |
+| Conan   | [`conan/`](conan/) | [`conan-io/conan-center-index` `recipes/units`](https://github.com/conan-io/conan-center-index/tree/master/recipes/units) | `conan install --requires=units/<version>` |
+| Debian / Ubuntu (+ RPM, tarball) | [`../debian/`](../debian/) (and CPack in the root `CMakeLists.txt`) | Debian source package / the project PPA | `apt install libunits-dev` |
+
+After `find_package(units CONFIG REQUIRED)`, link `units::units`. See
+[`docs/how-to/cmake-integration.md`](../docs/how-to/cmake-integration.md).
+
+## The one rule every package follows: compile nothing
+
+The library's tests and examples are development artifacts, never part of a package. A packaging build
+turns them off, so the configure step compiles nothing and the install stages only the headers and the
+CMake config:
+
+- `UNITS_BUILD_TESTS=OFF` — off for any package build.
+- `UNITS_BUILD_EXAMPLES` follows `UNITS_BUILD_TESTS`, so turning tests off turns the examples off too;
+  a package build need not name it, though the vcpkg port and `debian/rules` set it explicitly for clarity.
+- `UNITS_INSTALL` is on when `units` is the top-level project (which every package build is), so the
+  install/export rules run and lay down `unitsConfig.cmake`.
+
+## vcpkg — [`vcpkg/`](vcpkg/)
+
+`portfile.cmake` + `vcpkg.json`. Configures `units` directly, so it installs the full header tree and the
+CMake package files with nothing compiled. On release, update `vcpkg.json`'s `version`, set `portfile.cmake`'s
+`REF` to the new `v<version>` tag, and refresh the `SHA512` (the `SHA512` here is a zeroed placeholder that
+vcpkg replaces during the downstream PR — `vcpkg install units` reports the expected hash on first fetch, or
+run `vcpkg x-add-version`). The downstream update rides in a `[units] Update to <version>` PR against
+`microsoft/vcpkg`.
+
+## Conan — [`conan/`](conan/)
+
+`conanfile.py` + `test_package/`. The recipe copies the whole `include/` tree (not just `units.h` — `units`
+is a multi-header library), declares C++23 and the minimum compilers, and clears the package id (header-only).
+`test_package/` is the consumer snippet Conan compiles to validate the package; it uses the current API
+(`meters<double>`, `units::sqrt`). On release, add the version + source URL/`sha256` to `conandata.yml`
+(supplied in the downstream `conan-center-index` PR) and bump `config.yml`. The recipe itself is
+version-agnostic.
+
+## Debian / RPM / tarball — [`../debian/`](../debian/) + CPack
+
+The Debian packaging lives at the repository root in `debian/` (dpkg requires that location), producing
+`libunits-dev`. `debian/rules` configures with `-DUNITS_BUILD_TESTS=OFF -DUNITS_BUILD_EXAMPLES=OFF`. The root
+`CMakeLists.txt` also drives CPack (`DEB`, `RPM`, `TGZ`) for a `cpack`-based build. On release, add a
+`debian/changelog` stanza for the new version; CPack takes its version from the CMake project version.

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -14,6 +14,10 @@ authoritative copy to track.
 After `find_package(units CONFIG REQUIRED)`, link `units::units`. See
 [`docs/how-to/cmake-integration.md`](../docs/how-to/cmake-integration.md).
 
+Bumping these to a new release is a short checklist — [`RELEASE.md`](RELEASE.md). Two values are filled
+only after the `v<version>` tag exists (they hash its archive tarball): the vcpkg `SHA512` and the Conan
+`sha256`.
+
 ## The one rule every package follows: compile nothing
 
 The library's tests and examples are development artifacts, never part of a package. A packaging build

--- a/packaging/RELEASE.md
+++ b/packaging/RELEASE.md
@@ -1,0 +1,57 @@
+# Releasing a new version to the package managers
+
+Every package here is version-pinned to the current release. Bumping to a new version is mechanical, but
+two values can only be filled **after the `v<version>` git tag exists** (they are hashes of the tag's
+archive tarball): the vcpkg `SHA512` and the Conan `sha256`. This file is the checklist for 3.6.0 and the
+template for later releases.
+
+Order of operations: merge the release prep to `main` → push the `v<version>` tag → then update these
+recipes with the tarball hashes → open the downstream PRs.
+
+## 3.6.0
+
+### 1. Tag first
+
+The recipes reference `https://github.com/nholthaus/units/archive/v3.6.0.tar.gz`, which does not exist
+until the tag is pushed. Cut the tag on `main` after the 3.6.0 prep merges.
+
+### 2. vcpkg — `vcpkg/`
+
+- `vcpkg.json` `version` is `3.6.0`. ✓
+- `portfile.cmake` `REF` is `v${VERSION}` (resolves to `v3.6.0`). ✓
+- Fill `portfile.cmake` `SHA512` with the archive hash:
+  ```
+  curl -sL https://github.com/nholthaus/units/archive/v3.6.0.tar.gz | sha512sum
+  ```
+  (or run `./vcpkg install units --overlay-ports=packaging/vcpkg` once — vcpkg prints the expected SHA512
+  on the hash mismatch, and `vcpkg x-add-version units` writes the version-database entry in the
+  `microsoft/vcpkg` checkout.)
+- Downstream PR: copy `portfile.cmake` + `vcpkg.json` into `ports/units/` of `microsoft/vcpkg`, run
+  `vcpkg x-add-version units`, and open/refresh the `[units] Update to 3.6.0` PR (this supersedes the
+  earlier draft PR #53446). The port compiles nothing (tests and examples off), so the libc++ platforms
+  that failed the 3.5.1 draft build only when examples were compiled now install headers only — and the
+  `is_unit` incomplete-type fix in 3.6.0 makes even an examples build clean on libc++.
+
+### 3. Conan — `conan/`
+
+- `conanfile.py` is version-agnostic (C++23, copies the whole header tree). ✓
+- `config.yml` maps `3.6.0` → `all`. ✓
+- Fill `conandata.yml` `sha256`:
+  ```
+  curl -sL https://github.com/nholthaus/units/archive/v3.6.0.tar.gz | sha256sum
+  ```
+- Validate locally before the PR:
+  ```
+  conan create packaging/conan --version 3.6.0
+  ```
+  (builds nothing for the package, then compiles `test_package/test_package.cpp` against the installed
+  headers; it prints `5 m`).
+- Downstream PR: the `conan-io/conan-center-index` `recipes/units` recipe is stale (pinned to 2.3.x,
+  copies only `units.h`, uses the removed `meter_t` / `units::math` API). Replace `recipes/units/all/`
+  with the files here and set `recipes/units/config.yml` to list `3.6.0`. Open the update PR.
+
+### 4. Debian / RPM / tarball — `../debian/` + CPack
+
+- `debian/changelog` has the `3.6.0` stanza. ✓
+- CPack takes its version from the CMake project version (`3.6.0`). ✓
+- Build with `dpkg-buildpackage` (PPA) or `cpack` from a top-level configure.

--- a/packaging/conan/conandata.yml
+++ b/packaging/conan/conandata.yml
@@ -1,0 +1,6 @@
+sources:
+  "3.6.0":
+    url: "https://github.com/nholthaus/units/archive/v3.6.0.tar.gz"
+    # sha256 of the v3.6.0 GitHub archive tarball. Fill at release, once the tag exists:
+    #   curl -sL https://github.com/nholthaus/units/archive/v3.6.0.tar.gz | sha256sum
+    sha256: "0000000000000000000000000000000000000000000000000000000000000000"

--- a/packaging/conan/conanfile.py
+++ b/packaging/conan/conanfile.py
@@ -1,0 +1,72 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
+import os
+
+required_conan_version = ">=1.52.0"
+
+
+class UnitsConan(ConanFile):
+    name = "units"
+    description = (
+        "A compile-time, header-only, dimensional analysis and unit conversion "
+        "library for C++23 with no dependencies"
+    )
+    license = "MIT"
+    topics = ("unit-conversion", "dimensional-analysis", "cpp23",
+              "template-metaprogramming", "compile-time", "header-only",
+              "no-dependencies")
+    homepage = "https://github.com/nholthaus/units"
+    url = "https://github.com/conan-io/conan-center-index"
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    @property
+    def _min_cppstd(self):
+        return "23"
+
+    @property
+    def _minimum_compilers_version(self):
+        return {
+            "clang": "17",
+            "gcc": "13",
+            "apple-clang": "15",
+            "msvc": "193",
+        }
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._minimum_compilers_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.",
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        pass
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        # units is a multi-header tree (units.h plus include/units/*.h); copy all of include/.
+        copy(self, "*.h", src=os.path.join(self.source_folder, "include"),
+             dst=os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "units")
+        self.cpp_info.set_property("cmake_target_name", "units::units")
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/packaging/conan/config.yml
+++ b/packaging/conan/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.6.0":
+    folder: all

--- a/packaging/conan/test_package/CMakeLists.txt
+++ b/packaging/conan/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(units REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE units::units)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)

--- a/packaging/conan/test_package/conanfile.py
+++ b/packaging/conan/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/packaging/conan/test_package/test_package.cpp
+++ b/packaging/conan/test_package/test_package.cpp
@@ -1,0 +1,14 @@
+#include <iostream>
+
+#include <units.h>
+
+using namespace units::literals;
+using namespace units::length;
+
+int main()
+{
+    meters<double> a = 3.0_m;
+    meters<double> b = 4.0_m;
+    meters<double> c = units::sqrt(units::pow<2>(a) + units::pow<2>(b)); // Pythagorean theorem.
+    std::cout << c << std::endl;                                         // prints: "5 m"
+}

--- a/packaging/vcpkg/portfile.cmake
+++ b/packaging/vcpkg/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO nholthaus/units
+    REF v${VERSION}
+    SHA512 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+)
+
+set(VCPKG_BUILD_TYPE "release")
+
+# units is header-only. Turning tests off also turns the examples off (they follow UNITS_BUILD_TESTS), so the
+# configure step compiles nothing and the install stages only the header tree and the CMake package files.
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DUNITS_BUILD_TESTS=OFF
+        -DUNITS_BUILD_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/units)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib") # header-only: no libraries, only the CMake config moved above
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packaging/vcpkg/vcpkg.json
+++ b/packaging/vcpkg/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "units",
+  "version": "3.6.0",
+  "description": "A compile-time, header-only, dimensional-analysis and unit-conversion library for C++23 with no dependencies.",
+  "homepage": "https://github.com/nholthaus/units",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -3327,6 +3327,22 @@ TEST_F(UnitType, runtimeLossyRoundingConversion)
 	EXPECT_EQ(2, units::round<bytes<int>>(sixteen).value());
 	EXPECT_EQ(2, units::trunc<bytes<int>>(sixteen).value());
 
+	// The rounding is exact integer arithmetic, so a magnitude beyond 2^53 (where a double intermediate would lose
+	// the fractional byte and round the wrong way) is still correct. 2^53+1 bits is 1125899906842624.125 bytes.
+	const bits<std::int64_t> above2p53(9007199254740993LL);
+	EXPECT_EQ(1125899906842624LL, units::floor<bytes<std::int64_t>>(above2p53).value());
+	EXPECT_EQ(1125899906842625LL, units::ceil<bytes<std::int64_t>>(above2p53).value());
+	EXPECT_EQ(1125899906842624LL, units::round<bytes<std::int64_t>>(above2p53).value());
+	EXPECT_EQ(1125899906842624LL, units::trunc<bytes<std::int64_t>>(above2p53).value());
+	// A byte count above 2^53 itself: 2^56+12 bits is 2^53+1.5 bytes, floor must land on the exact 2^53+1.
+	EXPECT_EQ((std::int64_t(1) << 53) + 1, units::floor<bytes<std::int64_t>>(bits<std::int64_t>((std::int64_t(1) << 56) + 12)).value());
+	// A large negative value: floor goes toward negative infinity even past 2^53.
+	EXPECT_EQ(-((std::int64_t(1) << 57) + 1), units::floor<bytes<std::int64_t>>(bits<std::int64_t>(-((std::int64_t(1) << 60) + 5))).value());
+
+	// A result that does not fit the target integer wraps like any integer narrowing (the semantics of
+	// std::chrono::floor<To>), never an out-of-range floating-to-integer conversion: 3e9 bytes exceeds int.
+	EXPECT_EQ(static_cast<int>(3000000000LL), units::floor<bytes<int>>(bits<std::int64_t>(8 * 3000000000LL)).value());
+
 	// The target-taking overloads do not shadow the deduced-argument rounding math functions.
 	EXPECT_DOUBLE_EQ(3.0, units::floor(meters<double>(3.7)).value());
 	EXPECT_DOUBLE_EQ(4.0, units::ceil(meters<double>(3.7)).value());


### PR DESCRIPTION
Release-readiness for 3.6.0. Follows #388 (the #375 conversion work, already merged).

## Clean `add_subdirectory` consumption

A consumer that pulls `units` in via `add_subdirectory` should get the interface headers and nothing else. Two side effects previously leaked into the consumer's build; both are now gated:

- **CTest scaffolding.** `include(CTest)` ran unconditionally, defining `BUILD_TESTING` (default ON) and adding `Nightly`/`Continuous`/`Experimental` targets to the *consumer's* cache and target list. It is now pulled in only when `units` builds its own tests.
- **Install/export rules.** `install(DIRECTORY include/)`, `install(TARGETS/EXPORT)`, and the package-config generation ran unconditionally, so a consuming application's `cmake --install` also staged `units`' headers and CMake package files into its tree. They are now guarded by a new `UNITS_INSTALL` option (default = top-level project).

When `units` is the top-level project — a CPack build, or a Conan/vcpkg recipe that configures `units` directly (neither uses `add_subdirectory`) — the install rules stay on, so packaging is unaffected. A packager that vendors `units` as a subdirectory and still wants it installed sets `UNITS_INSTALL=ON`.

Verified with a throwaway consumer: a nested `add_subdirectory` build has no `BUILD_TESTING` in its cache, no Dart targets, builds against `units::units` header-only, and `cmake --install` stages nothing from `units`; a top-level build still installs all headers + `unitsConfig.cmake` + natvis, and `find_package(units 3.6.0 CONFIG REQUIRED)` resolves and builds against the installed package.

## Version

`3.5.1` -> `3.6.0` in the project version and the `FetchContent` `GIT_TAG` in the README and the CMake integration guide.

## Changelog

A `[3.6.0]` entry covering the release's content since 3.5.1: the opt-in affine (`absolute`/`delta`) and string-tagged `kind` wrappers, the unified `to<Target>()` verb, the per-dimension concepts, `std::format` support, floating-point literals with exact compile-time narrowing (including the finer-to-coarser integer case and the runtime `round`/`floor`/`ceil`/`trunc<To>` overloads), overflow-safe conversions and value-based integer comparison, the `<cmath>` fixes, the clean subdirectory consumption above, and the UndefinedBehaviorSanitizer CI job.

## Documentation

The CMake integration guide now describes the inert nested build and the `UNITS_INSTALL` opt-in.

Full suite 467/467 on GCC-13; the CMake behavior verified both directions (nested consumer installs nothing; top-level installs fully and is `find_package`-able at 3.6.0).