### PR TITLE
fix: constexpr function local must not be static (GCC 11/12 portability)

### DIFF
--- a/include/units/core.h
+++ b/include/units/core.h
@@ -2999,7 +2999,7 @@ namespace units
 		{
 			using CfTraits = traits::conversion_factor_traits<ConversionFactor>;
 
-			static constexpr bool needs_fp = traits::is_ratio_dimensionless_cf_v<ConversionFactor> || !std::ratio_equal_v<typename CfTraits::pi_exponent_ratio, std::ratio<0>> ||
+			constexpr bool needs_fp = traits::is_ratio_dimensionless_cf_v<ConversionFactor> || !std::ratio_equal_v<typename CfTraits::pi_exponent_ratio, std::ratio<0>> ||
 				!std::ratio_equal_v<typename CfTraits::translation_ratio, std::ratio<0>>;
 
 			using normalized_value_type = std::conditional_t<needs_fp, detail::floating_point_promotion_t<underlying_type>, underlying_type>;


### PR DESCRIPTION
`unit::value()` declared its `needs_fp` compile-time selector as a `static constexpr` local. A `static` local inside a `constexpr` function is only well-formed from GCC 13 / Clang 17 ([P2647](https://wg21.link/p2647)); GCC 11 and 12 reject it:

```
error: 'needs_fp' declared 'static' in 'constexpr' function
```

so a translation unit that instantiates `value()` fails to compile on those compilers. (Surfaced by a downstream project whose CI builds on GCC 11.)

`needs_fp` is used only as a `std::conditional_t` condition — its address is never taken and it is never materialized — so dropping `static` is behavior-identical on every compiler while restoring the build on GCC 11/12.

Verified: full suite 467/467 on GCC 15; and under a GCC 11 container the pre-fix tree fails with the error above while the fixed tree compiles. The declared support floor stays GCC 13 (this is a free portability widening, not a new supported target).