### PR TITLE
release: 3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project adheres to semantic versioning.
 
+## [3.6.1] - 2026-08-18
+
+### Fixed
+- `unit::value()` declared its `needs_fp` compile-time selector as a `static constexpr` local. A `static`
+  local in a `constexpr` function is only well-formed from GCC 13 / Clang 17, so GCC 11 and 12 rejected any
+  translation unit that instantiated `value()` ("declared 'static' in 'constexpr' function"). The variable is
+  used only as a compile-time condition, so dropping `static` is behavior-identical on every compiler while
+  restoring the build on GCC 11/12. The declared support floor is unchanged (GCC 13).
+
 ## [3.6.0] - 2026-08-17
 
 New capabilities: opt-in affine and string-tagged quantity wrappers, per-dimension concepts, `std::format`
@@ -269,6 +278,7 @@ The C++23 line. This is a major revision; see the
 - `unit_value_t` — use a `constexpr` quantity value instead.
 - The `units::math` namespace and the `_t` singular type aliases (see Changed).
 
+[3.6.1]: https://github.com/nholthaus/units/releases/tag/v3.6.1
 [3.6.0]: https://github.com/nholthaus/units/releases/tag/v3.6.0
 [3.5.1]: https://github.com/nholthaus/units/releases/tag/v3.5.1
 [3.5.0]: https://github.com/nholthaus/units/releases/tag/v3.5.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,4 +21,4 @@ keywords:
   - header-only
   - compile-time
 license: MIT
-version: 3.6.0
+version: 3.6.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16...4.99 FATAL_ERROR)
 
-PROJECT(units VERSION 3.6.0 LANGUAGES CXX)
+PROJECT(units VERSION 3.6.1 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ target_link_libraries(myapp PRIVATE units::units)
 include(FetchContent)
 FetchContent_Declare(units
   GIT_REPOSITORY https://github.com/nholthaus/units.git
-  GIT_TAG        v3.6.0)
+  GIT_TAG        v3.6.1)
 FetchContent_MakeAvailable(units)
 target_link_libraries(myapp PRIVATE units::units)
 ```

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+units (3.6.1-0ppa1~noble1) noble; urgency=medium
+
+  * Portability fix: a constexpr function's local is no longer declared static,
+    so units compiles on GCC 11/12 (behavior-identical on GCC 13+).
+
+ -- Nic Holthaus <nholthaus@gmail.com>  Mon, 18 Aug 2026 09:00:00 -0400
+
 units (3.6.0-0ppa1~noble1) noble; urgency=medium
 
   * New release: opt-in affine (absolute/delta) and string-tagged kind wrappers,

--- a/docs/how-to/cmake-integration.md
+++ b/docs/how-to/cmake-integration.md
@@ -29,7 +29,7 @@ Pull it at configure time — no vendored copy in your tree:
 include(FetchContent)
 FetchContent_Declare(units
   GIT_REPOSITORY https://github.com/nholthaus/units.git
-  GIT_TAG        v3.6.0)          # pin a release tag
+  GIT_TAG        v3.6.1)          # pin a release tag
 FetchContent_MakeAvailable(units)
 
 target_link_libraries(myapp PRIVATE units::units)


### PR DESCRIPTION
Patch release carrying the GCC 11/12 portability fix (#390 — a constexpr function's local no longer declared `static`). Bumps version, CHANGELOG, CITATION.cff, debian/changelog, and the FetchContent `GIT_TAG` references 3.6.0 → 3.6.1. No functional change on GCC 13+.