### PR TITLE
docs: fix unresolved doxygen references so the PR docs gate passes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ int main()
 `units` favors syntax that reads as ordinary code: quantities are written and combined the way you would
 write them by hand, so the common cases are apparent from the code without consulting the reference.
 
-Every snippet in this README and in the [documentation](docs/) is compiled and run as part of the test
-suite — see [`examples/`](examples/).
+Every snippet in this README and in the [documentation](docs/README.md) is compiled and run as part of the test
+suite — see [`examples/`](https://github.com/nholthaus/units/tree/main/examples).
 
 ## Design
 
@@ -119,7 +119,7 @@ series (see [Migrating from 2.x](docs/meta/migrate-v2-to-v3.md)).
 
 ## Getting started
 
-This section covers what most code needs. The [full manual](docs/) has the rest.
+This section covers what most code needs. The [full manual](docs/README.md) has the rest.
 
 **Include a header, and bring in the literal operators.** Include the umbrella header `<units.h>` for
 every dimension, or one per-dimension header (`<units/length.h>`, `<units/time.h>`, …) for just the
@@ -680,11 +680,11 @@ target_link_libraries(myapp PRIVATE units::units)
 **Package managers.** `units` is available through vcpkg (`vcpkg install units`), Conan
 (`conan install --requires=units/<version>`), and Debian/Ubuntu (`apt install libunits-dev`; an RPM and a
 tarball are also produced via CPack, and a PPA is published for Ubuntu). The reference sources for all three
-integrations live in [`packaging/`](packaging/).
+integrations live in [`packaging/`](https://github.com/nholthaus/units/tree/main/packaging).
 
 [Debugger visualizers](docs/how-to/natvis.md) show a quantity as `5 m` in the debugger rather than an
-opaque object: linking `units::units` attaches the [natvis](natvis/units.natvis) automatically on MSVC,
-and an [LLDB formatter](natvis/units_lldb.py) (`command script import units_lldb.py`) does the same for
+opaque object: linking `units::units` attaches the [natvis](https://github.com/nholthaus/units/blob/main/natvis/units.natvis) automatically on MSVC,
+and an [LLDB formatter](https://github.com/nholthaus/units/blob/main/natvis/units_lldb.py) (`command script import units_lldb.py`) does the same for
 LLDB, CLion, Xcode, and CodeLLDB.
 
 ---
@@ -1345,13 +1345,13 @@ and `std::numeric_limits` specializations, NaN/infinity support, self-describing
 `ConversionFactorType`, …) plus a per-dimension concept for every dimension (`Velocity`, `Force`, `Length`,
 …) so you can constrain a template on a physical quantity by dimension (`void f(Velocity auto v)`),
 non-linear (decibel) scales, and affine temperature. Each has a how-to or reference page under
-[docs/](docs/).
+[docs/](docs/README.md).
 
 ---
 
 ## Documentation
 
-The manual is under **[docs/](docs/)** (hub: [docs/README.md](docs/README.md)). The generated API
+The manual is under **[docs/](docs/README.md)** (hub: [docs/README.md](docs/README.md)). The generated API
 reference is published at <https://nholthaus.github.io/units/>.
 
 ### Learn
@@ -1407,7 +1407,7 @@ reference is published at <https://nholthaus.github.io/units/>.
 ## Citing
 
 If you use `units` in academic or published work, a citation is appreciated. The repository includes a
-[`CITATION.cff`](CITATION.cff), so GitHub's **"Cite this repository"** button (top right of the repository
+[`CITATION.cff`](https://github.com/nholthaus/units/blob/main/CITATION.cff), so GitHub's **"Cite this repository"** button (top right of the repository
 page) generates a formatted citation and BibTeX for you. A BibTeX entry:
 
 ```bibtex

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # units documentation
 
 The manual for the [units](https://github.com/nholthaus/units) library, grouped by what you are trying to do. Every code
-snippet in these pages compiles under C++23; the runnable ones are drawn from [`examples/`](../examples/),
+snippet in these pages compiles under C++23; the runnable ones are drawn from [`examples/`](https://github.com/nholthaus/units/tree/main/examples),
 and the compiler diagnostics shown are captured verbatim from the compilers.
 
 Start with [Getting started](learn/getting-started.md); the

--- a/docs/explain/type-safety.md
+++ b/docs/explain/type-safety.md
@@ -3,7 +3,7 @@
 *Giving a quantity a type makes the compiler refuse the operations that have no physical meaning. This
 page catalogs the mistakes the library is built to catch, and shows the **verbatim** diagnostic each one
 produces. The diagnostics below are captured directly from the compiler by the
-[error-message test harness](../../test/errorMessages/) (`run.py --emit-doc`), so what you read here is
+[error-message test harness](https://github.com/nholthaus/units/tree/main/test/errorMessages) (`run.py --emit-doc`), so what you read here is
 what the compiler emits, not a paraphrase.*
 
 Each example is a case in `test/errorMessages/cases/`; the harness asserts that it fails to compile

--- a/docs/how-to/natvis.md
+++ b/docs/how-to/natvis.md
@@ -23,7 +23,7 @@ time, frequency, compound, dimensionless, decibel — with no unit name enumerat
 
 ## Visual Studio (natvis)
 
-The file [`natvis/units.natvis`](../../natvis/units.natvis) is attached to the `units` CMake interface
+The file [`natvis/units.natvis`](https://github.com/nholthaus/units/blob/main/natvis/units.natvis) is attached to the `units` CMake interface
 target and installed with the package. When you link `units::units` (see
 [CMake integration](cmake-integration.md)) under MSVC, Visual Studio picks it up automatically for that
 target — no project setting, no manual "add existing item."
@@ -34,7 +34,7 @@ or add it to your project.
 
 ## LLDB (and CLion / Xcode / CodeLLDB)
 
-The file [`natvis/units_lldb.py`](../../natvis/units_lldb.py) is an LLDB summary provider. Load it into a
+The file [`natvis/units_lldb.py`](https://github.com/nholthaus/units/blob/main/natvis/units_lldb.py) is an LLDB summary provider. Load it into a
 debug session, or once from your `~/.lldbinit`:
 
 ```

--- a/docs/how-to/serialization.md
+++ b/docs/how-to/serialization.md
@@ -415,7 +415,7 @@ asks for.
 
 The numbers below are measured on the machine that built the docs (GCC 15, `x86-64`); treat them as
 representative, not as guarantees. Reproduce them with the snippets under
-[`examples/`](../../examples/) compiled at `-std=c++23 -I include`.
+[`examples/`](https://github.com/nholthaus/units/tree/main/examples) compiled at `-std=c++23 -I include`.
 
 ### Size
 

--- a/docs/reference/constants.md
+++ b/docs/reference/constants.md
@@ -2,7 +2,7 @@
 
 *The `units::constants` namespace provides the physical constants as typed quantities — each carries its
 correct dimension, so it participates in dimensional analysis like any other quantity. Values are the
-2018 CODATA recommended values. Defined in [`include/units.h`](../../include/units.h).*
+2018 CODATA recommended values. Defined in [`include/units.h`](https://github.com/nholthaus/units/blob/main/include/units.h).*
 
 ```cpp
 #include <units.h>


### PR DESCRIPTION
The docs workflow builds doxygen with `DOXYGEN_WARN_AS_ERROR=FAIL_ON_WARNINGS` on pull requests (and `NO` on push). Several Markdown links in `README.md` and `docs/` point at repo **source** paths outside doxygen's input — `examples/`, `test/errorMessages/`, `natvis/units.natvis`, `natvis/units_lldb.py`, `include/units.h`, `packaging/`, `CITATION.cff`. Doxygen treats those as `\ref` cross-references, cannot resolve them, and warns — so the doc build passes on push (warnings ignored) but **fails on every pull request**. The workflow comment's "builds with zero warnings" was stale.

This repoints those source-path links to absolute `https://github.com/nholthaus/units` URLs (`tree/main/…` for directories, `blob/main/…` for files), which doxygen leaves alone and which render correctly on both the generated site and GitHub; `docs/`-directory links now point at `docs/README.md`. Link text is unchanged.

Verified locally: `cmake -B build -DUNITS_BUILD_DOCS=ON -DDOXYGEN_WARN_AS_ERROR=FAIL_ON_WARNINGS && cmake --build build --target doc` succeeds with **zero** unresolved-reference warnings.

This unblocks the docs gate for all pull requests.