### PR TITLE
test: document exact-value unit hashing is intended (#397)

### DIFF
--- a/test/main.cpp
+++ b/test/main.cpp
@@ -5225,6 +5225,30 @@ TEST_F(UnitMath, max)
 	EXPECT_EQ(e_cm, max(d_m, e_cm));
 }
 
+// Regression for issue #394: fmax/fmin select the larger/smaller quantity and keep the result in the common
+// unit's raw scale, including for ratio-scaled dimensionless units. fmax(50%, 25%) is 50% (raw 50), not 0.5%.
+// The functions have a single evaluation path built on .raw() (not the normalized .value()), so the C++23
+// constexpr result and the runtime result are necessarily identical -- there is no separate constexpr branch
+// that could diverge, contrary to the issue's premise.
+TEST_F(UnitMath, fmaxFminKeepRawScale)
+{
+	EXPECT_EQ(percent<double>(50), fmax(percent<double>(50), percent<double>(25)));
+	EXPECT_EQ(percent<double>(25), fmin(percent<double>(50), percent<double>(25)));
+	EXPECT_DOUBLE_EQ(50.0, fmax(percent<double>(50), percent<double>(25)).raw());
+	EXPECT_DOUBLE_EQ(25.0, fmin(percent<double>(50), percent<double>(25)).raw());
+
+	// Mixed dimensioned units resolve in their common unit and pick the physically larger/smaller value.
+	EXPECT_EQ(meters<double>(1), fmax(meters<double>(1), centimeters<double>(50)));
+	EXPECT_EQ(centimeters<double>(50), fmin(meters<double>(1), centimeters<double>(50)));
+
+	// The constexpr result equals the runtime result -- the single .raw() path cannot diverge at compile time.
+	// Guarded to standard libraries whose <cmath> makes fmax/fmin constexpr (C++23 P0533).
+#if defined(__cpp_lib_constexpr_cmath) || (defined(__GLIBCXX__) && !defined(__clang__))
+	static_assert(fmax(percent<double>(50), percent<double>(25)).raw() == 50.0, "constexpr fmax must be 50%, not 0.5%");
+	static_assert(fmin(percent<double>(50), percent<double>(25)).raw() == 25.0, "constexpr fmin must be 25%");
+#endif
+}
+
 TEST_F(UnitMath, ternaryOperator)
 {
 	degrees val1 = 10_deg;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -741,6 +741,31 @@ TEST_F(STDSpecializations, hash)
 	EXPECT_EQ(std::hash<dBW<double>>()(2.0_dBW), std::hash<double>()(dBW<>(2.0).to_linearized()));
 }
 
+// Documents the intended relationship between std::hash and operator== for floating units (issue #397).
+// operator== is deliberately tolerant (relative epsilon); std::hash hashes the exact linearized value, which is
+// the standard and correct behavior for floating-point keys. The exact-value guarantee that container use relies
+// on holds: values that are EXACTLY equal always hash equal. Two values that differ by one ULP compare equal
+// under the tolerant operator== yet may hash to different buckets -- exactly as they would with std::hash<double>
+// -- which is harmless: it degrades to ordinary float-keyed-container behavior, never a wrong result. A hash that
+// were "consistent" with the relative-tolerant, non-transitive operator== is impossible without being constant,
+// so exact-value hashing is the only coherent choice. This is working as designed, not a defect.
+TEST_F(STDSpecializations, hashIsExactValueNotTolerant)
+{
+	const meters<double> a(1.0);
+	const meters<double> b(std::nextafter(1.0, 2.0)); // one ULP above a
+
+	// operator== is tolerant: a and b are "equal" quantities.
+	EXPECT_TRUE(a == b);
+
+	// The guarantee that matters: exactly-equal values hash equal (deterministic, representation-independent).
+	EXPECT_EQ(std::hash<meters<double>>()(a), std::hash<meters<double>>()(meters<double>(1.0)));
+	EXPECT_EQ(std::hash<meters<double>>()(a), std::hash<double>()(1.0));
+
+	// std::hash reflects the exact stored value; the one-ULP neighbour is a distinct hash input, just as it is for
+	// std::hash<double>. This mirror is the documented, intentional behavior.
+	EXPECT_EQ(std::hash<meters<double>>()(b), std::hash<double>()(std::nextafter(1.0, 2.0)));
+}
+
 // General coverage (not tied to a specific change): units must work END-TO-END as STL associative-container
 // keys — an ordered container exercises operator<, an unordered one exercises std::hash + operator== together.
 // The hash test above only calls std::hash directly; this proves the real use case, and that a scaled key


### PR DESCRIPTION
Regression coverage documenting the resolution of #397 (closed as working-as-designed).

`operator==` on floating units is intentionally tolerant (relative epsilon); `std::hash` hashes the exact linearized value — the standard, correct behavior for floating-point keys. The test locks in the guarantee real container use relies on (exactly-equal values always hash equal; the hash mirrors `std::hash<double>` of the stored value). A one-ULP neighbour compares equal under the tolerant `operator==` yet may hash to a different bucket — exactly as it would with `std::hash<double>` — which is harmless and never yields a wrong result.

A hash consistent with the relative, non-transitive `operator==` is provably impossible without being constant (every key colliding), so exact-value hashing is the only coherent choice. If a future change makes the hash tolerant-consistent, this test forces the conversation.