### PR TITLE
fix: ratio-scaled dimensionless serialization + integer-only modulo + min/max anonymous-unit leak (#404, #408)

### DIFF
--- a/include/units/core.h
+++ b/include/units/core.h
@@ -1542,6 +1542,9 @@ namespace units
 	template<typename U>
 	concept OrdinaryDimensionlessUnitType = DimensionlessUnitType<U> && !RatioDimensionlessUnitType<U>;
 
+	template<typename U>
+	concept IntegralUnitType = units::traits::is_unit_v<U> && std::integral<typename U::underlying_type>;
+
 	/**
 	 * @brief		Type representing an arbitrary conversion factor between units.
 	 * @ingroup		ConversionFactor
@@ -4221,7 +4224,7 @@ namespace units
 	}
 
 	template<DimensionedUnitType UnitTypeLhs>
-		requires(!RatioDimensionlessUnitType<UnitTypeLhs>)
+		requires(!RatioDimensionlessUnitType<UnitTypeLhs> && IntegralUnitType<UnitTypeLhs>)
 	constexpr UnitTypeLhs& operator%=(UnitTypeLhs& lhs, const detail::type_identity_t<UnitTypeLhs>& rhs) noexcept
 	{
 		lhs = lhs % rhs;
@@ -4229,7 +4232,7 @@ namespace units
 	}
 
 	template<DimensionlessUnitType UnitTypeLhs, DimensionlessUnitType UnitTypeRhs>
-		requires(!(RatioDimensionlessUnitType<UnitTypeLhs> || RatioDimensionlessUnitType<UnitTypeRhs>))
+		requires(!(RatioDimensionlessUnitType<UnitTypeLhs> || RatioDimensionlessUnitType<UnitTypeRhs>) && IntegralUnitType<UnitTypeLhs> && IntegralUnitType<UnitTypeRhs>)
 	constexpr UnitTypeLhs& operator%=(UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
 		using CommonUnit = decltype(lhs % rhs);
@@ -4238,7 +4241,7 @@ namespace units
 	}
 
 	template<UnitType UnitTypeLhs>
-		requires(!RatioDimensionlessUnitType<UnitTypeLhs>)
+		requires(!RatioDimensionlessUnitType<UnitTypeLhs> && IntegralUnitType<UnitTypeLhs>)
 	constexpr UnitTypeLhs& operator%=(UnitTypeLhs& lhs, const typename UnitTypeLhs::underlying_type& rhs) noexcept
 	{
 		lhs = lhs % rhs;
@@ -4247,7 +4250,7 @@ namespace units
 
 	// ratio-dimensionless %= ratio-dimensionless  (percent points modulo percent points)
 	template<RatioDimensionlessUnitType U>
-		requires(traits::has_linear_scale_v<U>)
+		requires(traits::has_linear_scale_v<U> && IntegralUnitType<U>)
 	constexpr U& operator%=(U& lhs, const U& rhs) noexcept
 	{
 		lhs = lhs % rhs;
@@ -4256,7 +4259,7 @@ namespace units
 
 	// ratio-dimensionless %= scalar  (percent points modulo scalar)
 	template<RatioDimensionlessUnitType U>
-		requires(traits::has_linear_scale_v<U>)
+		requires(traits::has_linear_scale_v<U> && IntegralUnitType<U>)
 	constexpr U& operator%=(U& lhs, const typename U::underlying_type& rhs) noexcept
 	{
 		lhs = lhs % rhs;
@@ -4265,13 +4268,24 @@ namespace units
 
 	// ratio-dimensionless %= base dimensionless unit  (treat as scalar)
 	template<RatioDimensionlessUnitType U, DimensionlessUnitType D>
-		requires(traits::has_linear_scale_v<U, D> && !RatioDimensionlessUnitType<D>)
+		requires(traits::has_linear_scale_v<U, D> && !RatioDimensionlessUnitType<D> && IntegralUnitType<U> && IntegralUnitType<D>)
 	constexpr U& operator%=(U& lhs, const D& rhs) noexcept
 	{
 		// D is ordinary dimensionless: safe scalar conversion
 		lhs = lhs % static_cast<typename U::underlying_type>(rhs);
 		return lhs;
 	}
+
+	// Two DIFFERENT ratio-scaled dimensionless units (percent and parts-per-million, say) count in different ticks, so
+	// the modulo of their point counts has no meaning. These deleted overloads catch that mix explicitly -- otherwise
+	// the right operand would implicitly convert into the left's unit and silently bind the same-unit overload -- and
+	// give a clean "use of deleted function" diagnostic instead. Use a common scale or `fmod` on the physical value.
+	template<RatioDimensionlessUnitType U, RatioDimensionlessUnitType V>
+		requires(!std::is_same_v<U, V>)
+	constexpr std::common_type_t<U, V> operator%(const U&, const V&) = delete;
+	template<RatioDimensionlessUnitType U, RatioDimensionlessUnitType V>
+		requires(!std::is_same_v<U, V>)
+	constexpr U& operator%=(U&, const V&) = delete;
 
 	//------------------------------
 	//	UNIT UNARY OPERATORS
@@ -4803,7 +4817,8 @@ namespace units
 	///			back to the coarser lhs is lossy for an integer underlying, disabling the constructor). The
 	///			common-unit result mirrors `fmod` and removes the asymmetry.
 	template<DimensionedUnitType UnitTypeLhs, DimensionedUnitType UnitTypeRhs>
-		requires(same_dimension<UnitTypeLhs, UnitTypeRhs> && traits::has_linear_scale_v<UnitTypeLhs, UnitTypeRhs>)
+		requires(same_dimension<UnitTypeLhs, UnitTypeRhs> && traits::has_linear_scale_v<UnitTypeLhs, UnitTypeRhs> &&
+			IntegralUnitType<UnitTypeLhs> && IntegralUnitType<UnitTypeRhs>)
 	constexpr std::common_type_t<UnitTypeLhs, UnitTypeRhs> operator%(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
 		using CommonUnit = std::common_type_t<UnitTypeLhs, UnitTypeRhs>;
@@ -4812,7 +4827,7 @@ namespace units
 
 	/// Modulo by a dimensionless for unit types with a linear scale
 	template<DimensionedUnitType UnitTypeLhs, DimensionlessUnitType UnitTypeRhs>
-		requires(traits::has_linear_scale_v<UnitTypeLhs, UnitTypeRhs>)
+		requires(traits::has_linear_scale_v<UnitTypeLhs, UnitTypeRhs> && IntegralUnitType<UnitTypeLhs> && IntegralUnitType<UnitTypeRhs>)
 	constexpr traits::replace_underlying_t<UnitTypeLhs, std::common_type_t<typename UnitTypeLhs::underlying_type, typename UnitTypeRhs::underlying_type>> operator%(
 		const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
@@ -4823,8 +4838,18 @@ namespace units
 
 	/// Modulo for two dimensionless unit types with a linear scale.
 	/// @returns the lhs value modulo the rhs value, whose type is their common type
+	/// @note	`%` is an integer count operation, so it operates on the operands' point counts, which are only
+	///			comparable when the operands share a tick scale. Two DIFFERENT ratio-scaled dimensionless units
+	///			(percent and parts-per-million, say) count in different ticks, so a modulo of their raw counts has no
+	///			meaning; that mix is excluded here (`!(RatioDimensionlessUnitType<UnitTypeLhs> &&
+	///			RatioDimensionlessUnitType<UnitTypeRhs>)`, reinforced by a deleted overload for the convertible case)
+	///			and does not compile, exactly as the ratio-dimensionless compound assignment excludes it. The permitted forms are two
+	///			operands of the SAME unit (handled by the same-unit ratio overload) and a ratio-scaled unit modulo a
+	///			plain `dimensionless` (a bare count), which this overload serves.
 	template<DimensionlessUnitType UnitTypeLhs, DimensionlessUnitType UnitTypeRhs>
-		requires(same_dimension<UnitTypeLhs, UnitTypeRhs> && traits::has_linear_scale_v<UnitTypeLhs, UnitTypeRhs>)
+		requires(same_dimension<UnitTypeLhs, UnitTypeRhs> && traits::has_linear_scale_v<UnitTypeLhs, UnitTypeRhs> &&
+			IntegralUnitType<UnitTypeLhs> && IntegralUnitType<UnitTypeRhs> &&
+			!(RatioDimensionlessUnitType<UnitTypeLhs> && RatioDimensionlessUnitType<UnitTypeRhs>))
 	constexpr traits::replace_underlying_t<UnitTypeLhs, typename std::common_type_t<UnitTypeLhs, UnitTypeRhs>::underlying_type> operator%(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs) noexcept
 	{
 		using CommonUnit = decltype(lhs % rhs);
@@ -4833,7 +4858,7 @@ namespace units
 
 	/// Modulo by an arithmetic type for unit types with a linear scale
 	template<UnitType UnitTypeLhs, ArithmeticType T>
-		requires(traits::has_linear_scale_v<UnitTypeLhs> && !RatioDimensionlessUnitType<UnitTypeLhs>)
+		requires(traits::has_linear_scale_v<UnitTypeLhs> && !RatioDimensionlessUnitType<UnitTypeLhs> && IntegralUnitType<UnitTypeLhs> && std::integral<T>)
 	constexpr traits::replace_underlying_t<UnitTypeLhs, std::common_type_t<typename UnitTypeLhs::underlying_type, T>> operator%(const UnitTypeLhs& lhs, const T& rhs) noexcept
 	{
 		using CommonUnit = decltype(lhs % rhs);
@@ -4842,21 +4867,21 @@ namespace units
 
 	// Modulos for ratio-like dimensionless units
 	template<RatioDimensionlessUnitType U>
-		requires(traits::has_linear_scale_v<U>)
+		requires(traits::has_linear_scale_v<U> && IntegralUnitType<U>)
 	constexpr U operator%(const U& lhs, const U& rhs) noexcept
 	{
 		return U(lhs.raw() % rhs.raw());
 	}
 
 	template<RatioDimensionlessUnitType U, ArithmeticType T>
-		requires(traits::has_linear_scale_v<U>)
+		requires(traits::has_linear_scale_v<U> && IntegralUnitType<U> && std::integral<T>)
 	constexpr U operator%(const U& lhs, T rhs) noexcept
 	{
 		return U(lhs.raw() % rhs);
 	}
 
 	template<RatioDimensionlessUnitType U, ArithmeticType T>
-		requires(traits::has_linear_scale_v<U>)
+		requires(traits::has_linear_scale_v<U> && IntegralUnitType<U> && std::integral<T>)
 	constexpr U operator%(T lhs, const U& rhs) noexcept
 	{
 		using Under = detail::floating_point_promotion_t<std::common_type_t<T, typename U::underlying_type>>;
@@ -5206,18 +5231,34 @@ namespace units
 
 	template<UnitType UnitTypeLhs, UnitType UnitTypeRhs>
 		requires(same_dimension<UnitTypeLhs, UnitTypeRhs>)
-	constexpr std::common_type_t<UnitTypeLhs, UnitTypeRhs> min(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs)
+	constexpr auto min(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs)
 	{
-		using CommonUnit = decltype(units::min(lhs, rhs));
-		return (lhs < rhs ? CommonUnit(lhs) : CommonUnit(rhs));
+		// The result unit is the left operand's when that is lossless (matching operator+/-), falling back to the
+		// common unit only when returning the left unit would truncate an integer -- never an anonymous common unit
+		// for otherwise-representable operands. Computed in the body so the trait is not instantiated for a non-unit
+		// the constraint already rejects. min/max select an operand, so the underlying is NOT floating-point promoted.
+		using ResultUnit = detail::lhs_result_unit_t<UnitTypeLhs, UnitTypeRhs>;
+		return (lhs < rhs ? ResultUnit(lhs) : ResultUnit(rhs));
 	}
 
 	template<UnitType UnitTypeLhs, UnitType UnitTypeRhs>
 		requires(same_dimension<UnitTypeLhs, UnitTypeRhs>)
-	constexpr std::common_type_t<UnitTypeLhs, UnitTypeRhs> max(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs)
+	constexpr auto max(const UnitTypeLhs& lhs, const UnitTypeRhs& rhs)
 	{
-		using CommonUnit = decltype(units::max(lhs, rhs));
-		return (lhs > rhs ? CommonUnit(lhs) : CommonUnit(rhs));
+		using ResultUnit = detail::lhs_result_unit_t<UnitTypeLhs, UnitTypeRhs>;
+		return (lhs > rhs ? ResultUnit(lhs) : ResultUnit(rhs));
+	}
+
+	/// Clamps a value to the range [lo, hi], in the value's own unit when that is lossless (matching min/max), else
+	/// the common unit. lo and hi must be the same dimension as the value; hi must not be less than lo.
+	template<UnitType UnitTypeValue, UnitType UnitTypeLo, UnitType UnitTypeHi>
+		requires(same_dimension<UnitTypeValue, UnitTypeLo> && same_dimension<UnitTypeValue, UnitTypeHi>)
+	constexpr auto clamp(const UnitTypeValue& value, const UnitTypeLo& lo, const UnitTypeHi& hi)
+	{
+		// Reconcile to the common unit of all three operands for a correct comparison, then express the result in the
+		// value's unit when lossless (as min/max do), never an anonymous unit for representable operands.
+		using ResultUnit = detail::lhs_result_unit_t<UnitTypeValue, std::common_type_t<UnitTypeLo, UnitTypeHi>>;
+		return (value < lo ? ResultUnit(lo) : (hi < value ? ResultUnit(hi) : ResultUnit(value)));
 	}
 
 	//----------------------------------

--- a/include/units/serialization.h
+++ b/include/units/serialization.h
@@ -692,17 +692,21 @@ namespace units
 
 				// Express the SI-base magnitude in the TARGET unit's scale, all in double so no lossy unit conversion is
 				// attempted: a double-underlying instance of the target unit converts from the canonical base cleanly.
-				using TargetAsDouble   = unit<traits::strong_t<ConversionFactor>, double, typename traits::unit_traits<Unit>::numerical_scale_type>;
-				const double as_double = TargetAsDouble(detail::canonical_unit_t<Dim>(m_base)).template to<double>();
+				// Take its point-scale value (raw), which is what the target unit's constructor expects -- for a
+				// ratio-scaled dimensionless unit (percent, parts-per-million) the point value (50) differs from the
+				// normalized value (0.5), and reconstructing from the normalized value would rescale by the unit's
+				// ratio. For a linear unit the two are identical, so this is a no-op there.
+				using TargetAsDouble = unit<traits::strong_t<ConversionFactor>, double, typename traits::unit_traits<Unit>::numerical_scale_type>;
+				const double as_raw  = TargetAsDouble(detail::canonical_unit_t<Dim>(m_base)).raw();
 
 				// Narrow to the target's underlying type. An integral target that cannot represent the value exactly is
 				// a lossy_target error rather than a silent truncation.
 				if constexpr (!std::is_floating_point_v<UnderlyingTarget>)
 				{
-					if (as_double != std::floor(as_double) || std::abs(as_double) > static_cast<double>(std::numeric_limits<UnderlyingTarget>::max()))
+					if (as_raw != std::floor(as_raw) || std::abs(as_raw) > static_cast<double>(std::numeric_limits<UnderlyingTarget>::max()))
 						return std::unexpected(deserialize_error::lossy_target);
 				}
-				return Unit(static_cast<UnderlyingTarget>(as_double));
+				return Unit(static_cast<UnderlyingTarget>(as_raw));
 			}
 			else
 			{

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -2682,6 +2682,63 @@ TEST_F(UnitType, unitTypeModulo)
 	EXPECT_EQ(vec[9], 100_pct);
 }
 
+// True iff `a % b` / `a %= b` are valid expressions. `%` is an integer count operation on point values, so it is
+// well-formed only when the operands share a tick scale and are integer-backed. These concepts let the contract be
+// asserted directly: a case that must NOT compile is a `static_assert(!Can...<...>)`.
+template<class A, class B>
+concept can_modulo = requires(A a, B b) { a % b; };
+template<class A, class B>
+concept can_modulo_assign = requires(A a, B b) { a %= b; };
+
+// The full modulo contract, proven exhaustively rather than by inference: which operand pairs `%`/`%=` accept and
+// which it rejects at compile time. Integer-backed operands of the SAME tick scale (or a ratio unit modulo a plain
+// dimensionless / bare integer) are accepted; two DIFFERENT ratio-scaled dimensionless units share no tick, and any
+// floating-point operand is not a count, so both are rejected -- a floating remainder is `fmod`'s job.
+TEST_F(UnitType, moduloContract)
+{
+	// Accepted: same tick scale, integer-backed.
+	static_assert(can_modulo<percent<int>, percent<int>>);
+	static_assert(can_modulo<parts_per_million<int>, parts_per_million<int>>);
+	static_assert(can_modulo<meters<int>, meters<int>>);
+	static_assert(can_modulo<meters<int>, kilometers<int>>);
+	static_assert(can_modulo<dimensionless<int>, dimensionless<int>>);
+
+	// Accepted: a ratio-scaled unit modulo a plain dimensionless or a bare integer (a pure count).
+	static_assert(can_modulo<percent<int>, dimensionless<int>>);
+	static_assert(can_modulo<dimensionless<int>, percent<int>>);
+	static_assert(can_modulo<percent<int>, int>);
+	static_assert(can_modulo<dimensionless<int>, int>);
+	static_assert(can_modulo<meters<int>, int>);
+
+	// Rejected: two DIFFERENT ratio-scaled dimensionless units share no tick scale, so the remainder of their point
+	// counts has no meaning.
+	static_assert(!can_modulo<percent<int>, parts_per_million<int>>);
+	static_assert(!can_modulo<parts_per_million<int>, percent<int>>);
+	static_assert(!can_modulo<percent<int>, parts_per_billion<int>>);
+	static_assert(!can_modulo<parts_per_million<int>, parts_per_billion<int>>);
+
+	// Rejected: `%` is integer-only. A floating-point operand is not a count; use `fmod` for a floating remainder.
+	static_assert(!can_modulo<percent<double>, percent<double>>);
+	static_assert(!can_modulo<meters<double>, meters<double>>);
+	static_assert(!can_modulo<dimensionless<double>, dimensionless<double>>);
+	static_assert(!can_modulo<percent<double>, dimensionless<double>>);
+	static_assert(!can_modulo<meters<double>, int>);
+	static_assert(!can_modulo<percent<int>, double>);
+
+	// `%=` follows the same contract.
+	static_assert(can_modulo_assign<percent<int>, percent<int>>);
+	static_assert(can_modulo_assign<meters<int>, meters<int>>);
+	static_assert(can_modulo_assign<percent<int>, dimensionless<int>>);
+	static_assert(!can_modulo_assign<percent<int>, parts_per_million<int>>);
+	static_assert(!can_modulo_assign<percent<double>, percent<double>>);
+	static_assert(!can_modulo_assign<meters<double>, meters<double>>);
+
+	// The accepted integer cases compute the expected count remainder.
+	EXPECT_EQ(2_pct, percent<int>(12) % percent<int>(5));
+	EXPECT_EQ(2_pct, percent<int>(12) % dimensionless<int>(5));
+	EXPECT_EQ(meters<int>(1), meters<int>(10) % meters<int>(3));
+}
+
 TEST_F(UnitType, compoundAssignmentAddition)
 {
 	// units
@@ -5250,6 +5307,57 @@ TEST_F(UnitMath, max)
 	EXPECT_EQ(e_cm, max(d_m, e_cm));
 }
 
+// min/max return the LEFT operand's named unit when that is lossless (both operands floating point, or the right
+// converts into the left without integer truncation), matching operator+/-. They select an operand, so they do NOT
+// floating-point promote: an integral same-unit min stays integral, and the integer-lossy fallback is the exact
+// std::common_type_t of the two units (unlike hypot/fmax, which promote). The floating-point cases return a NAMED
+// unit -- never an anonymous common unit for otherwise-representable operands: min(5m, 3ft) is meters<double>(0.9144),
+// not an anonymous 1/381-foot unit holding 1143. clamp mirrors this in the value's own unit.
+TEST_F(UnitMath, minMaxClampReturnLeftOperandUnit)
+{
+	// Return type: floating-point operands -> the LEFT operand's named unit, in either order (the anonymous common
+	// unit never leaks for representable floating-point operands).
+	static_assert(std::is_same_v<decltype(min(meters<double>(5), feet<double>(3))), meters<double>>);
+	static_assert(std::is_same_v<decltype(min(feet<double>(3), meters<double>(5))), feet<double>>);
+	static_assert(std::is_same_v<decltype(max(meters<double>(5), feet<double>(3))), meters<double>>);
+	static_assert(std::is_same_v<decltype(max(feet<double>(3), meters<double>(5))), feet<double>>);
+
+	// General across dimensions: the same left-operand-unit rule holds for time.
+	static_assert(std::is_same_v<decltype(min(seconds<double>(90), minutes<double>(1))), seconds<double>>);
+	static_assert(std::is_same_v<decltype(min(minutes<double>(1), seconds<double>(90))), minutes<double>>);
+	static_assert(std::is_same_v<decltype(max(seconds<double>(90), minutes<double>(1))), seconds<double>>);
+	static_assert(std::is_same_v<decltype(max(minutes<double>(1), seconds<double>(90))), minutes<double>>);
+
+	// Integer-lossy fallback: feet<int> does not convert into meters<int> without truncation, so the result is NOT the
+	// left int unit but the exact common unit -- min/max select an operand and do not promote, so no float wrapping.
+	static_assert(!std::is_same_v<decltype(min(meters<int>(5), feet<int>(3))), meters<int>>);
+	static_assert(std::is_same_v<decltype(min(meters<int>(5), feet<int>(3))), std::common_type_t<meters<int>, feet<int>>>);
+	static_assert(!std::is_same_v<decltype(max(meters<int>(5), feet<int>(3))), meters<int>>);
+	static_assert(std::is_same_v<decltype(max(meters<int>(5), feet<int>(3))), std::common_type_t<meters<int>, feet<int>>>);
+
+	// Same-unit integral stays integral -- no float promotion when both operands share the unit.
+	static_assert(std::is_same_v<decltype(min(meters<int>(5), meters<int>(3))), meters<int>>);
+	static_assert(std::is_same_v<decltype(max(meters<int>(5), meters<int>(3))), meters<int>>);
+
+	// clamp returns the value's own unit when lossless, including the cross-unit case (lo/hi in another named unit).
+	static_assert(std::is_same_v<decltype(clamp(meters<double>(2), feet<double>(1), meters<double>(3))), meters<double>>);
+	static_assert(std::is_same_v<decltype(clamp(feet<double>(0.5), feet<double>(1), feet<double>(3))), feet<double>>);
+
+	// Values: min/max carry the correct physical quantity in the left operand's unit.
+	EXPECT_NEAR(0.9144, min(meters<double>(5), feet<double>(3)).value(), 5.0e-9);   // 3 ft expressed in meters
+	EXPECT_DOUBLE_EQ(5.0, max(meters<double>(5), feet<double>(3)).value());
+	EXPECT_EQ(3, min(meters<int>(5), meters<int>(3)).value());
+
+	// clamp: above hi -> hi, below lo -> lo, in range -> value, each in the value's unit.
+	EXPECT_DOUBLE_EQ(3.0, clamp(meters<double>(5), meters<double>(1), meters<double>(3)).value());
+	EXPECT_DOUBLE_EQ(1.0, clamp(meters<double>(0.0), meters<double>(1), meters<double>(3)).value());
+	EXPECT_DOUBLE_EQ(2.0, clamp(meters<double>(2), meters<double>(1), meters<double>(3)).value());
+	EXPECT_DOUBLE_EQ(1.0, clamp(feet<double>(0.5), feet<double>(1), feet<double>(3)).value());
+
+	// Cross-unit clamp: value 2 m is within [1 ft, 3 m], returned in the value's unit (meters).
+	EXPECT_DOUBLE_EQ(2.0, clamp(meters<double>(2), feet<double>(1), meters<double>(3)).value());
+}
+
 // Regression for issue #394: fmax/fmin select the larger/smaller quantity and keep the result in the common
 // unit's raw scale, including for ratio-scaled dimensionless units. fmax(50%, 25%) is 50% (raw 50), not 0.5%.
 // The functions have a single evaluation path built on .raw() (not the normalized .value()), so the C++23
@@ -6589,6 +6697,38 @@ TEST_F(Serialization, roundTripCurrentAndCharge)
 	expectRoundTrip(units::milliamperes<double>(500.0));
 	expectRoundTrip(units::coulombs<double>(1.0));
 	expectRoundTrip(units::ampere_hours<double>(3.0));
+}
+
+// Ratio-scaled dimensionless units (percent, parts-per-million, ...) carry a scale ratio between their point value
+// and their physical value: 50 percent is the physical value 0.5. Reconstructing from the physical value rather than
+// the point value would rescale by that ratio, so serialize(50 percent) must read back as the physical value 0.5.
+TEST_F(Serialization, roundTripConcentration)
+{
+	expectRoundTrip(units::concentration::percent<double>(50.0));
+	expectRoundTrip(units::concentration::percent<double>(0.0));
+	expectRoundTrip(units::concentration::percent<double>(100.0));
+	expectRoundTrip(units::concentration::parts_per_million<double>(300000.0));
+	expectRoundTrip(units::concentration::parts_per_billion<double>(1.0));
+	expectRoundTrip(units::concentration::parts_per_trillion<double>(42.0));
+	expectRoundTrip(units::dimensionless<double>(0.5));
+
+	// Integer-backed ratio-scaled dimensionless units travel the integer narrowing path on decode; a percent whose
+	// point value is a whole number reconstructs exactly, agreeing with the floating-point representation.
+	expectRoundTrip(units::concentration::percent<int>(50));
+	expectRoundTrip(units::concentration::parts_per_million<int>(300000));
+	expectRoundTrip(units::dimensionless<int>(7));
+}
+
+// Physical constants exercise compound dimensions and extreme magnitudes (Boltzmann's constant near 1.4e-23,
+// Avogadro's number near 6e23) through the canonical-base conversion; each must recover its physical value.
+TEST_F(Serialization, roundTripPhysicalConstants)
+{
+	expectRoundTrip(units::constants::k_B);   // Boltzmann constant, joules per kelvin, ~1.38e-23
+	expectRoundTrip(units::constants::N_A);    // Avogadro's number, per mole, ~6.02e23
+	expectRoundTrip(units::constants::R);      // gas constant, joules per kelvin per mole
+	expectRoundTrip(units::constants::h);      // Planck constant, joule-seconds, ~6.63e-34
+	expectRoundTrip(units::constants::c);      // speed of light, meters per second
+	expectRoundTrip(units::constants::sigma);  // Stefan-Boltzmann constant, watts per square meter per kelvin^4
 }
 
 TEST_F(Serialization, roundTripSubstanceAndLuminous)


### PR DESCRIPTION
### #404 — serialization round-trip for ratio-scaled dimensionless units

`any_unit::to<Unit>()` reconstructed a ratio-scaled dimensionless value (percent, parts-per-million, …) from its **normalized** value rather than its **point** value, so `serialize(percent{50}).to<percent>()` came back as `0.5%` — a 100× error (ppm/ppb suffer larger factors). Fixed to reconstruct from the point (`.raw()`) value, which is what the unit's constructor expects. Linear units are unaffected (point value == normalized value there).

### #408 — modulo of two different ratio-scaled dimensionless units

`operator%` is an **integer count operation** on point values — meaningful only when the operands share a tick scale. `percent{50} % parts_per_million{300000}` counts in *different ticks*, so a modulo of their point counts has no meaning; neither `50` nor a rescaled `20%` is a well-defined answer. That mix is now **rejected at compile time** (a deleted overload also catches the implicit-conversion path that previously bound the same-unit overload and faulted at runtime). `percent % percent`, and a ratio unit modulo a plain `dimensionless` or a bare integer, remain well-defined. For a remainder on the physical values, `fmod` works across scales.

See the discussion note for the reasoning we'll post on #408.

### Modulo is integer-only (by constraint, not by accident)

Every `operator%` / `operator%=` overload is now constrained to an integral underlying type, so a floating-point modulo (`percent<double> % percent<double>`, `meters<double> % meters<double>`, …) is cleanly rejected at overload resolution instead of failing with a cryptic error deep in the body. `fmod` is the floating-point remainder.

### min/max no longer leak an anonymous unit; new clamp

`units::min`/`units::max` returned `std::common_type_t`, leaking an anonymous common unit even for floating-point operands where the left operand's named unit is lossless (`min(5m, 3ft)` came back in an unnamed 1/381-foot unit, `.value() == 1143`). They now return the left operand's unit when lossless — matching `operator+`/`operator-` and the recently-fixed `fmin`/`fmax`/`hypot` — falling back to the common unit only when returning the left unit would truncate an integer. A new `units::clamp` follows the same rule. (min/max/clamp select an operand, so they do not floating-point-promote.)

### Tests

- **Exhaustive compile-time modulo contract** (`UnitType.moduloContract`): every accepted and rejected operand pairing for `%` and `%=`, proven with `static_assert` on a `can_modulo` / `can_modulo_assign` concept — not by inference.
- **min/max/clamp** (`UnitMath.minMaxClampReturnLeftOperandUnit`): return-unit (including the integer-lossy fallback) and value cases.
- **Serialization round-trip battery**: π-ratio (angle), affine (temperature), ratio-scaled dimensionless (`roundTripConcentration`, double **and** integer underlying), and **physical constants** (`roundTripPhysicalConstants` — Boltzmann, Avogadro, Planck, gas constant, speed of light, Stefan-Boltzmann).

Full suite green on gcc-13, clang-19, and MSVC (`/std:c++latest /permissive-`).

Closes #404
Closes #408