### PR TITLE
docs: guide any_unit toward type-erasure boundaries; guard visit() dispatches a unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,15 @@ existing variable and returns whether it fit), `try_to<Unit>()` / `unit_cast<Uni
 (the canonical unit of the decoded dimension, no target named). `deserialize<Unit>(bytes)` is the typed fast
 path when the type is known.
 
+> **Prefer the strongly-typed `unit` types; reach for `any_unit` only where you genuinely need type erasure.**
+> `any_unit` trades compile-time dimension checking for a runtime-carried dimension, so it is the right tool at a
+> boundary that loses the static type — **serialization and deserialization**, wire transport, or a heterogeneous
+> stream whose dimension is not known until runtime. Everywhere the static type is available, the concrete `unit`
+> types are better: the dimension is checked at compile time and there is no runtime dispatch or throw. One
+> consequence to keep in mind: a dimensionless `any_unit` (a bare scalar, or a ratio such as `meters / meters`)
+> resolves under a default `visit()` to `dimensionless`, so a ratio-scale like `percent` cannot be recovered from
+> the erased form — name it explicitly (`to<percent<double>>()`) if you need that scale back.
+
 **It also drops into byte interfaces with no cast.** Away from a stream, an `any_unit` exposes a modern,
 type-safe byte view (`bytes()` → `std::span<const std::byte>`) and a C-interface pair (`data()` → `const char*`,
 `size()`) that feeds `std::fwrite`, a socket `send`, or `memcpy` directly:

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -7419,6 +7419,35 @@ TEST_F(Serialization, dimensionlessResolvesUnderDefaultVisitWithoutThrowing)
 	EXPECT_THROW(units::serialize(units::meters<double>(5.0)).visit<units::dimension::mass>([](const auto&) {}), std::runtime_error);
 }
 
+// The default visit() hands the visitor a unit type (dimensionless), never a raw arithmetic value, so a visitor is
+// uniform across every dimension. This matters for a visitor body that calls an overload set with both a unit and a
+// plain-arithmetic overload: the dimensionless quantity is an exact match for the unit overload, which is preferred
+// over its implicit conversion to the underlying type, so the call resolves unambiguously rather than failing to
+// compile. Guards against a future change dispatching a bare scalar (which would silently change overload selection
+// or introduce ambiguity).
+namespace
+{
+	template<units::UnitType U> constexpr int overloadTag(const U&) { return 1; } // unit overload
+	constexpr int overloadTag(double) { return 2; }                               // arithmetic overload
+} // namespace
+TEST_F(Serialization, dimensionlessVisitDispatchesUnitNotScalar)
+{
+	bool checked = false;
+	const auto blob = units::serialize(units::meters<double>(3.0) / units::meters<double>(4.0));
+	blob.visit([&](const auto& q) {
+		using Q = std::decay_t<decltype(q)>;
+		// The lambda body is instantiated for every candidate dimension; only the dimensionless instantiation runs,
+		// so the type checks are guarded so they hold for that instantiation without constraining the others.
+		static_assert(units::traits::is_unit_v<Q>, "visit() must dispatch a unit type, not a raw scalar");
+		if constexpr (std::is_same_v<Q, units::dimensionless<double>>)
+		{
+			EXPECT_EQ(1, overloadTag(q)); // the unit overload wins over the implicit-to-double conversion, no ambiguity
+			checked = true;
+		}
+	});
+	EXPECT_TRUE(checked);
+}
+
 // #395 recurrence guard: every dimension in serialization.h's builtin_dimensions tuple must resolve to a named
 // rendering. A dimension missing from the tuple degrades to the raw '#<hash>' fallback, which this fails on. When a
 // new dimension is added to the library, add its flagship unit line here; if this test then fails, the dimension was


### PR DESCRIPTION
Follow-up to #416 (angular units + dimensionless default visit).

### README guidance

Adds a note steering callers to the strongly-typed `unit` types by default, and to `any_unit` **only where type erasure is genuinely needed** — **serialization and deserialization**, wire transport, or a heterogeneous stream whose dimension is unknown until runtime. `any_unit` trades compile-time dimension checking for a runtime-carried dimension, so the concrete `unit` types are better wherever the static type is available (checked at compile time, no runtime dispatch or throw). The note also records the one consequence of the dimensionless default-visit behavior: a ratio scale like `percent` cannot be recovered from the erased form and must be named (`to<percent<double>>()`).

### Regression guard

Adds `Serialization.dimensionlessVisitDispatchesUnitNotScalar`: the default `visit()` hands the visitor a **unit** type (`dimensionless<double>`), never a raw arithmetic value. This matters for a visitor whose body calls an overload set with both a unit overload and a plain-arithmetic overload — the dimensionless quantity is an exact match for the unit overload, preferred over its implicit conversion to the underlying type, so the call resolves **unambiguously** rather than failing to compile or silently taking the scalar path. Guards against a future change dispatching a bare scalar.

Full suite green (495/495) on gcc, clang, and MSVC.