### PR TITLE
ci: bump actions/checkout to v5 (Node 24 runtime)

### DIFF
--- a/.github/workflows/clang-19.yaml
+++ b/.github/workflows/clang-19.yaml
@@ -36,7 +36,7 @@ jobs:
         run: sudo apt install -y libeigen3-dev
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/gcc-13.yaml
+++ b/.github/workflows/gcc-13.yaml
@@ -35,7 +35,7 @@ jobs:
         run: sudo apt install -y libeigen3-dev
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure CMake
         run: |
@@ -86,7 +86,7 @@ jobs:
         run: sudo apt install -y libeigen3-dev
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Build and run the suite under UBSan so any runtime undefined behavior (integer overflow in a conversion,
       # a bad cast, misaligned access) FAILS the build instead of silently returning a wrong value.

--- a/.github/workflows/msvc-2022.yaml
+++ b/.github/workflows/msvc-2022.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Set up the MSVC command-line environment FIRST (puts cl.exe on PATH). The "Visual Studio 17 2022"
       # generator's own VS discovery has been unreliable on recent windows-latest images ("could not find any

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Extract the CHANGELOG section for this version
         id: notes


### PR DESCRIPTION
`actions/checkout@v4` runs on the deprecated Node 20 runtime, so every build job logged:

> `Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4.`

`v5` is the Node 24 release and a drop-in (identical inputs). The docs workflow already used `@v5`; this bumps the remaining `clang-19`, `gcc-13`, `msvc-2022`, and `release` workflows to match, clearing the warning across the build jobs.

Two remaining Node-runtime warnings are upstream-owned and cannot be cleared by a version bump here:
- `ilammy/msvc-dev-cmd` — its latest release (v1.13.0) still declares `using: node20`; no Node-24 release exists yet.
- A `punycode` `DeprecationWarning` inside `actions/deploy-pages`' own Node code (Pages deploy only).