### PR TITLE
fix: harden deserialize against malformed input (#403, #398)

### DIFF
--- a/include/units/serialization.h
+++ b/include/units/serialization.h
@@ -37,6 +37,7 @@
 #ifndef units_serialization_h_
 #define units_serialization_h_
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <compare>
@@ -107,7 +108,8 @@ namespace units
 		bad_version,            ///< the stream's format version is not understood
 		dimension_mismatch,     ///< the stream's dimension does not match the requested target
 		unknown_base_dimension, ///< the stream names a base-dimension code this build does not know
-		lossy_target            ///< the value cannot be represented in the requested underlying type without loss
+		lossy_target,           ///< the value cannot be represented in the requested underlying type without loss
+		malformed               ///< the bytes are complete but encode an invalid record (e.g. a zero exponent denominator)
 	};
 
 	/// @brief	a decoded quantity whose concrete type was not known at the call site
@@ -964,8 +966,15 @@ namespace units
 		if (!detail::get_uvarint(cursor, end, count))
 			return std::unexpected(deserialize_error::truncated);
 
+		// Reserve only up to what the remaining bytes could actually hold, never the raw wire count: every term needs
+		// at least nine bytes (eight hash bytes plus a one-byte exponent numerator), so no more than (end - cursor)
+		// terms can follow. This keeps a huge count off untrusted input from throwing out of reserve() while leaving
+		// the classification to the loop below -- a count that overruns the buffer is reported as `truncated` there,
+		// exactly as a short buffer with an honest count is. A zero count is the valid dimensionless case.
 		unit_identity id;
-		id.terms.reserve(count);
+		id.terms.reserve(std::min<std::uint64_t>(count, static_cast<std::uint64_t>(end - cursor)));
+		bool          havePrevHash = false;
+		std::uint64_t prevHash     = 0;
 		for (std::uint64_t i = 0; i < count; ++i)
 		{
 			if (end - cursor < 8)
@@ -979,6 +988,16 @@ namespace units
 				return std::unexpected(deserialize_error::truncated);
 			if (fracExp && !detail::get_svarint(cursor, end, den))
 				return std::unexpected(deserialize_error::truncated);
+			// Each term must uphold the invariants the serializer always writes: a nonzero rational exponent (a zero
+			// denominator is the undefined num/0; a zero numerator is a phantom base the reducer never emits), and a
+			// strictly ascending hash (terms are stored sorted and unique so equality is order-independent). A
+			// complete stream that violates any of these is malformed input, not a valid quantity.
+			if (den == 0 || num == 0)
+				return std::unexpected(deserialize_error::malformed);
+			if (havePrevHash && hash <= prevHash)
+				return std::unexpected(deserialize_error::malformed);
+			prevHash     = hash;
+			havePrevHash = true;
 			id.terms.push_back(dimension_term{hash, num, den});
 		}
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -7105,6 +7105,68 @@ TEST_F(Serialization, errorPaths)
 		EXPECT_FALSE(r);
 		EXPECT_EQ(units::deserialize_error::dimension_mismatch, r.error());
 	}
+	// Malformed records: complete bytes that violate an invariant the serializer always upholds. A decoder that
+	// trusts untrusted input would accept these as valid any_units (or, for a huge count, throw an allocation
+	// exception instead of returning an error). The decoder must reject each as deserialize_error::malformed.
+	//
+	// Each stream begins with the valid version byte, then a header (kind:2 | fracExp:1 | reserved:5), a uvarint
+	// term count, then per term 8 hash bytes + a zig-zag num (+ a zig-zag den when fracExp), then the value.
+	const auto header = [](bool fracExp) { return std::byte{static_cast<std::uint8_t>(fracExp ? 0x04 : 0x00)}; }; // kind=ivarint
+	const auto hashBytes = [](std::vector<std::byte>& b, std::uint8_t fill) { for (int i = 0; i < 8; ++i) b.push_back(std::byte{fill}); };
+
+	// #403: a fractional-exponent term with a ZERO denominator encodes the undefined rational exponent num/0.
+	{
+		std::vector<std::byte> m{good[0], header(true), std::byte{0x01}};
+		hashBytes(m, 0xAB);
+		m.push_back(std::byte{0x02}); // num: zig-zag(1)
+		m.push_back(std::byte{0x00}); // den: zig-zag(0) = 0  <-- malformed
+		m.push_back(std::byte{0x54}); // value
+		const auto r = units::deserialize(m);
+		EXPECT_FALSE(r);
+		if (!r)
+			EXPECT_EQ(units::deserialize_error::malformed, r.error());
+	}
+	// #398: a huge term count must be rejected before reserving, not throw std::length_error out of deserialize.
+	{
+		std::vector<std::byte> m{good[0], header(false)};
+		for (int i = 0; i < 9; ++i)
+			m.push_back(std::byte{0xFF}); // count: a ~2^63 uvarint, far beyond the remaining bytes
+		m.push_back(std::byte{0x7F});
+		std::expected<units::any_unit, units::deserialize_error> r;
+		EXPECT_NO_THROW(r = units::deserialize(m));
+		EXPECT_FALSE(r);
+	}
+	// A zero-exponent term (num == 0) is a phantom dimension the serializer never emits (it writes only nonzero terms).
+	{
+		std::vector<std::byte> m{good[0], header(false), std::byte{0x01}};
+		hashBytes(m, 0x22);
+		m.push_back(std::byte{0x00}); // num: zig-zag(0) = 0  <-- malformed
+		m.push_back(std::byte{0x00}); // value
+		const auto r = units::deserialize(m);
+		EXPECT_FALSE(r);
+	}
+	// Duplicate terms (same hash twice) break the unique-terms invariant.
+	{
+		std::vector<std::byte> m{good[0], header(false), std::byte{0x02}};
+		hashBytes(m, 0xCD);
+		m.push_back(std::byte{0x02}); // term 1 num
+		hashBytes(m, 0xCD);
+		m.push_back(std::byte{0x02}); // term 2 num, same hash
+		m.push_back(std::byte{0x00}); // value
+		const auto r = units::deserialize(m);
+		EXPECT_FALSE(r);
+	}
+	// Unsorted terms (hashes not ascending) break the sorted-by-hash invariant equality relies on.
+	{
+		std::vector<std::byte> m{good[0], header(false), std::byte{0x02}};
+		hashBytes(m, 0xFF);
+		m.push_back(std::byte{0x02}); // term 1: high hash first
+		hashBytes(m, 0x11);
+		m.push_back(std::byte{0x02}); // term 2: lower hash after -> out of order
+		m.push_back(std::byte{0x00}); // value
+		const auto r = units::deserialize(m);
+		EXPECT_FALSE(r);
+	}
 }
 
 TEST_F(Serialization, userDefinedDimensionIsExtensible)


### PR DESCRIPTION
The `deserialize` decode path trusted several properties of the byte stream that the serializer always upholds but untrusted input (a file or socket) can violate. An audit of the term-decode loop found five, all now rejected (or, for a huge count, no longer allowed to throw):

| Malformed input | Before | After |
|---|---|---|
| huge term `count` | `reserve(count)` throws `std::length_error` out of `deserialize` (#398) | `reserve` capped at remaining bytes; the term loop reports `truncated` |
| exponent denominator `= 0` | accepted as the undefined `num/0` (#403) | `malformed` |
| exponent numerator `= 0` | accepted as a phantom `base^0` | `malformed` |
| duplicate term hash | accepted (two identical terms) | `malformed` |
| non-ascending term hashes | accepted (breaks the sorted-unique invariant equality relies on) | `malformed` |

The reducer never emits a `base^0` term (a canceled base leaves the term list entirely; `m/m` serializes as zero terms, not `length^0`), and `unit_identity` stores terms sorted and unique so equality is order-independent — so a well-formed stream always satisfies these, and only untrusted bytes trip them.

A new `deserialize_error::malformed` distinguishes a complete-but-invalid record from a `truncated` one. The valid **dimensionless** case (zero terms) is unaffected — the term loop and its checks never run for `count == 0`.

**Tests:** a hand-built byte stream for each of the five cases asserts rejection (the count case also asserts `deserialize` does not throw); the existing truncation and round-trip tests confirm short and valid streams still classify as before. Full suite green on gcc-13 (incl. UBSan and the errorMessages harness), clang-19, and MSVC.

Closes #403
Closes #398