### PR TITLE
fix: ignore separator contents when detecting the %b base flag (#401)

### DIFF
--- a/include/units/core.h
+++ b/include/units/core.h
@@ -6134,13 +6134,29 @@ struct std::formatter<U, char>
 		// stored-type formatter. Determine which is in play by scanning the unit-opts for 'b' before
 		// delegating the value-spec, so the value-spec is parsed into exactly the formatter that will emit
 		// it (parsing an integer spec such as `d` into a floating-point formatter would wrongly reject it).
+		// The scan skips over quoted separator literals (`'…'`, with `\` escapes) exactly as the unit-opts
+		// parser below does, so a 'b' inside a separator (e.g. `%'_b_'`) is separator text, not the base flag.
 		m_usesBaseFormatter = false;
-		for (auto scan = valueSpecEnd; scan != end && *scan != '}'; ++scan)
+		for (auto scan = valueSpecEnd; scan != end && *scan != '}';)
 		{
-			if (*scan == 'b')
+			if (*scan == '\'')
+			{
+				for (++scan; scan != end && *scan != '}' && *scan != '\''; ++scan)
+				{
+					if (*scan == '\\' && scan + 1 != end && *(scan + 1) != '}')
+						++scan;    // skip the escaped character so an escaped quote does not end the literal
+				}
+				if (scan != end && *scan == '\'')
+					++scan;        // consume the closing quote
+			}
+			else if (*scan == 'b')
 			{
 				m_usesBaseFormatter = true;
 				break;
+			}
+			else
+			{
+				++scan;
 			}
 		}
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -8325,6 +8325,17 @@ TEST(Format, separatorWithNameForm)
 	EXPECT_EQ(std::format("{:%n'_'}", 3.5_m), "3.5_meters");
 }
 
+// A separator literal that contains 'b' must not be mistaken for the %b base-conversion flag (issue #401): the
+// value stays as written and the label is the unit's own, the 'b' is just separator text.
+TEST(Format, separatorContainingBIsNotTheBaseFlag)
+{
+	EXPECT_EQ(std::format("{:%'_b_'}", units::length::feet<double>(6.0)), "6_b_ft");
+	EXPECT_EQ(std::format("{:%'b'}", 3.5_m), "3.5bm");
+	// the actual %b flag still base-converts, even alongside a 'b'-containing separator
+	EXPECT_EQ(std::format("{:%b}", units::length::feet<double>(6.0)), "1.8288 m");
+	EXPECT_EQ(std::format("{:%b'_b_'}", units::length::feet<double>(6.0)), "1.8288_b_m");
+}
+
 //-----------------------------
 //  FLAG-ORDER INDEPENDENCE
 //-----------------------------


### PR DESCRIPTION
The formatter's pre-scan that decides whether the base-SI value formatter is needed looked for a `b` **anywhere** in the unit-opts — including inside a quoted separator literal. A separator such as `%'_b_'` therefore selected the base formatter, while the actual unit-opts parser (which *does* understand `'…'` literals) left the label as the original unit. The result: `format("{:%'_b_'}", 6_ft)` emitted a default-initialized zero value with the feet label — **`"0_b_ft"`** instead of `"6_b_ft"`.

Make the pre-scan skip over quoted separator literals (respecting `\` escapes), exactly as the unit-opts parser does, so a `b` counts as the base flag only when it appears **outside** a separator. A real `%b` still base-converts, including alongside a `b`-containing separator (`%b'_b_'` → `1.8288_b_m`).

**Test:** `Format.separatorContainingBIsNotTheBaseFlag` — a `b`-containing separator keeps the value and the unit's own label; a bare-`b` separator (`%'b'`) does too; and `%b` (alone and with a `b`-separator) still base-converts. Full suite green on gcc-13 (incl. UBSan and the errorMessages harness), clang-19, and MSVC.

Closes #401