### PR TITLE
fix: preserve unsigned magnitude in rounded unit conversions (#400)

### DIFF
--- a/include/units/core.h
+++ b/include/units/core.h
@@ -5578,14 +5578,21 @@ namespace units
 
 			if constexpr (std::is_integral_v<FromRep>)
 			{
-				// Exact integer path: value (in From units) * num / den, rounded on the integer remainder.
+				// Exact integer path: value (in From units) * num / den, rounded on the integer remainder. The
+				// intermediate is the widest UNSIGNED integer when both source and target are unsigned, so an unsigned
+				// magnitude wider than the signed intermediate can hold (e.g. a uint64 near its maximum on a platform
+				// whose widest signed type is 64-bit) is not narrowed to a negative value before the conversion; any
+				// signed operand keeps the signed intermediate so negative sources and toward-negative rounding stay
+				// correct. A conversion ratio's num and den are always positive, so the quotient and remainder are
+				// non-negative on the unsigned path and the rounding modes behave as for a non-negative value.
 				using Ratio = std::ratio_divide<typename From::conversion_factor::conversion_ratio, typename To::conversion_factor::conversion_ratio>;
-				const widest_signed_int value   = static_cast<widest_signed_int>(x.raw());
-				const widest_signed_int product = value * static_cast<widest_signed_int>(Ratio::num);
-				const widest_signed_int den     = static_cast<widest_signed_int>(Ratio::den);
-				const widest_signed_int quotient  = product / den;
-				const widest_signed_int remainder = product % den;
-				const widest_signed_int rounded   = apply_integer_rounding(quotient, remainder, den, mode);
+				using Intermediate = std::conditional_t<std::is_unsigned_v<FromRep> && std::is_unsigned_v<ToRep>, widest_unsigned_int, widest_signed_int>;
+				const Intermediate value   = static_cast<Intermediate>(x.raw());
+				const Intermediate product = value * static_cast<Intermediate>(Ratio::num);
+				const Intermediate den     = static_cast<Intermediate>(Ratio::den);
+				const Intermediate quotient  = product / den;
+				const Intermediate remainder = product % den;
+				const Intermediate rounded   = apply_integer_rounding(quotient, remainder, den, mode);
 				return To(static_cast<ToRep>(rounded), linearized_value);
 			}
 			else

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -18,6 +18,7 @@
 #include <iomanip>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <locale>
 #include <ratio>
 #include <sstream>
@@ -3430,6 +3431,40 @@ TEST_F(UnitType, runtimeLossyRoundingConversion)
 	EXPECT_DOUBLE_EQ(4.0, units::ceil(meters<double>(3.7)).value());
 	EXPECT_DOUBLE_EQ(4.0, units::round(meters<double>(3.7)).value());
 	EXPECT_DOUBLE_EQ(3.0, units::trunc(meters<double>(3.7)).value());
+
+	// #400: an unsigned source whose magnitude exceeds the widest SIGNED integer must keep its value through the
+	// conversion, not be narrowed to a negative intermediate first. On a platform whose widest signed type is 64-bit
+	// (no __int128), casting UINT64_MAX to signed would wrap to -1 and yield 0; the unsigned intermediate preserves
+	// it. UINT64_MAX bits floored to bytes is UINT64_MAX / 8 = 2305843009213693951.
+	constexpr std::uint64_t maxBits = std::numeric_limits<std::uint64_t>::max();
+	EXPECT_EQ(2305843009213693951ULL, units::floor<bytes<std::uint64_t>>(bits<std::uint64_t>(maxBits)).value());
+	EXPECT_EQ(2305843009213693952ULL, units::ceil<bytes<std::uint64_t>>(bits<std::uint64_t>(maxBits)).value());
+	// UINT64_MAX = 8 * 2305843009213693951 + 7, so the remainder 7/8 rounds up to the next byte for nearest-half-away.
+	EXPECT_EQ(2305843009213693952ULL, units::round<bytes<std::uint64_t>>(bits<std::uint64_t>(maxBits)).value());
+	EXPECT_EQ(2305843009213693951ULL, units::trunc<bytes<std::uint64_t>>(bits<std::uint64_t>(maxBits)).value());
+	// An exact unsigned multiple near the top of the range converts exactly (no rounding).
+	EXPECT_EQ(maxBits / 8 - 1, units::floor<bytes<std::uint64_t>>(bits<std::uint64_t>((maxBits / 8 - 1) * 8)).value());
+}
+
+// #400, platform-independent guard: on a platform whose widest signed integer is 64-bit (MSVC without __int128) the
+// unsigned-intermediate selection is what keeps a huge unsigned source correct -- this box has __int128, which would
+// mask the bug, so this test replicates the conversion's integer path with the intermediate FORCED to 64-bit and
+// proves the unsigned intermediate preserves the value where a signed one wraps it to zero. It mirrors the selection
+// rule in detail::rounded_unit_cast without depending on the platform's actual widest-integer width.
+TEST_F(UnitType, unsignedRoundingIntermediateSurvivesNarrowSignedWidth)
+{
+	// The floor-of-a-nonnegative conversion value*num/den with a FORCED 64-bit intermediate (num=1, den=8: bits->bytes).
+	const auto floorWithIntermediate = [](auto intermediateTag, std::uint64_t raw) -> std::uint64_t {
+		using Intermediate = decltype(intermediateTag);
+		const Intermediate value    = static_cast<Intermediate>(raw);
+		const Intermediate quotient = (value * static_cast<Intermediate>(1)) / static_cast<Intermediate>(8);
+		return static_cast<std::uint64_t>(quotient);
+	};
+	const std::uint64_t maxBits = std::numeric_limits<std::uint64_t>::max();
+	// The unsigned 64-bit intermediate (what the fix selects for an unsigned source+target) preserves the magnitude.
+	EXPECT_EQ(2305843009213693951ULL, floorWithIntermediate(std::uint64_t{0}, maxBits));
+	// A signed 64-bit intermediate (the pre-fix path) wraps UINT64_MAX to -1 and yields 0 -- the defect this guards.
+	EXPECT_EQ(0ULL, floorWithIntermediate(std::int64_t{0}, maxBits));
 }
 
 #ifndef UNIT_LIB_DISABLE_IOSTREAM


### PR DESCRIPTION
The integer path of a rounded unit conversion (`floor`/`ceil`/`round`/`trunc<To>`) cast the source value to `widest_signed_int` before the mul/div/round. On a platform whose widest signed integer is 64-bit — **MSVC, which has no `__int128`** — an unsigned source near the top of its range wrapped to a negative value first, so:

```cpp
floor<bytes<uint64_t>>(bits<uint64_t>{UINT64_MAX})  // computed from -1 -> returned 0
                                                    //   should be 2305843009213693951
```

On a platform *with* `__int128` the 128-bit signed intermediate held the value, so the defect was **latent** there (it does not reproduce on gcc/clang here).

### Fix

Select the intermediate by signedness: `widest_unsigned_int` when **both** source and target underlying types are unsigned, `widest_signed_int` otherwise. A conversion ratio's numerator and denominator are always positive, so on the unsigned path the quotient and remainder are non-negative and the rounding modes behave as for a non-negative value. Any signed operand keeps the signed intermediate, so negative sources and toward-negative rounding are unchanged (the existing negative-source tests still pass).

### Validation

- The new `runtimeLossyRoundingConversion` cases convert `UINT64_MAX` bits across all four rounding modes. On this box (`__int128`) they pass regardless; **on the MSVC CI leg — which has no `__int128` — they exercise the real narrow-width path and prove the fix on the platform the bug targets.**
- A platform-independent guard (`unsignedRoundingIntermediateSurvivesNarrowSignedWidth`) replicates the conversion with the intermediate forced to 64-bit, showing the unsigned intermediate preserves the value where a signed one wraps it to zero.

Full suite green on gcc-13 (incl. UBSan + errorMessages harness), clang-19, and MSVC.

Closes #400