### PR TITLE
fix: read one record incrementally from a stream, not the whole remainder (#399)

### DIFF
--- a/include/units/serialization.h
+++ b/include/units/serialization.h
@@ -1078,12 +1078,34 @@ namespace units
 		if (start == std::istream::pos_type(-1))
 			return std::unexpected(deserialize_error::truncated); // not seekable: records can't be self-delimited here
 
-		const std::vector<char> buffer{std::istreambuf_iterator<char>(is), std::istreambuf_iterator<char>()};
-		is.clear(); // the drain set eofbit; clear it so a good decode leaves the stream usable
+		// Read one self-delimiting record incrementally instead of draining the whole remaining stream: grow a small
+		// buffer a chunk at a time and retry the span decoder until it either succeeds or fails for a reason other
+		// than running short of bytes. A record is small (tens of bytes) and has no ceiling, so grow-and-retry reads
+		// only about one record's worth per call -- reading N records is linear, not quadratic (which draining the
+		// remainder each call made it). On success the stream is left just past this record (the unused tail read
+		// while growing is seeked back), so the next read gets the following record.
+		std::vector<char>                        buffer;
+		std::size_t                              chunk = 64; // covers essentially every record in the first read
+		std::expected<any_unit, deserialize_error> decoded{std::unexpected(deserialize_error::truncated)};
+		while (true)
+		{
+			const std::size_t had = buffer.size();
+			buffer.resize(had + chunk);
+			is.read(buffer.data() + had, static_cast<std::streamsize>(chunk));
+			const std::streamsize got = is.gcount();
+			buffer.resize(had + static_cast<std::size_t>(got));
 
-		auto decoded = deserialize(std::span<const std::byte>(reinterpret_cast<const std::byte*>(buffer.data()), buffer.size()));
+			decoded = deserialize(std::span<const std::byte>(reinterpret_cast<const std::byte*>(buffer.data()), buffer.size()));
+			// A successful decode, or a genuine (non-truncation) error, is final. `truncated` with more bytes still
+			// available in the stream means the record spans past what has been read so far -- grow and retry.
+			if (decoded || decoded.error() != deserialize_error::truncated || got < static_cast<std::streamsize>(chunk))
+				break;
+			chunk *= 2; // the record is unusually large; widen the next read
+		}
+
+		is.clear(); // a short read set eofbit/failbit; clear so a good decode leaves the stream usable
 		if (decoded)
-			is.seekg(start + static_cast<std::istream::off_type>(decoded->size())); // rewind past exactly this record
+			is.seekg(start + static_cast<std::istream::off_type>(decoded->size())); // leave the stream just past this record
 		return decoded;
 	}
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -7957,6 +7957,36 @@ TEST_F(Serialization, streamOperatorsRoundTripBinary)
 	EXPECT_DOUBLE_EQ(7.0, target.to<units::meters<double>>()->value()); // unchanged
 }
 
+// #399: deserialize(istream) consumes exactly ONE record, not the whole remaining stream. Reading a record from a
+// long sequence must leave the get-position at that record's end (so N reads are linear, not a quadratic re-drain of
+// the remainder each call). This checks the position deterministically rather than timing, so it is not flaky.
+TEST_F(Serialization, streamDeserializeConsumesOneRecordNotTheRemainder)
+{
+	std::stringstream seq(std::ios::in | std::ios::out | std::ios::binary);
+	const units::any_unit r0 = units::serialize(units::meters<double>(1.0));
+	const units::any_unit r1 = units::serialize(units::seconds<double>(2.0));
+	const units::any_unit r2 = units::serialize(units::kilograms<double>(3.0));
+	seq << r0 << r1 << r2;
+	const std::streamoff total = static_cast<std::streamoff>(r0.size() + r1.size() + r2.size());
+
+	seq.seekg(0);
+	const auto d0 = units::deserialize(seq);
+	ASSERT_TRUE(d0.has_value());
+	// the position advanced by exactly the first record, NOT to end-of-stream (which a whole-remainder drain would do)
+	EXPECT_EQ(static_cast<std::streamoff>(r0.size()), static_cast<std::streamoff>(seq.tellg()));
+	EXPECT_LT(static_cast<std::streamoff>(seq.tellg()), total);
+
+	const auto d1 = units::deserialize(seq);
+	ASSERT_TRUE(d1.has_value());
+	EXPECT_EQ(static_cast<std::streamoff>(r0.size() + r1.size()), static_cast<std::streamoff>(seq.tellg()));
+	EXPECT_DOUBLE_EQ(2.0, d1->to<units::seconds<double>>()->value());
+
+	const auto d2 = units::deserialize(seq);
+	ASSERT_TRUE(d2.has_value());
+	EXPECT_EQ(total, static_cast<std::streamoff>(seq.tellg()));
+	EXPECT_DOUBLE_EQ(3.0, d2->to<units::kilograms<double>>()->value());
+}
+
 // deserialize<Unit>(istream) reads and collapses in one checked step (the front-page idiom).
 TEST_F(Serialization, typedDeserializeFromStream)
 {


### PR DESCRIPTION
`deserialize(std::istream&)` drained the **entire remaining stream** into a buffer on every call, decoded one record, then seeked back to just past it. Reading N records that way copies the whole remaining stream N times — **quadratic** total work, plus a temporary allocation of up to the whole file on each call.

### Fix

Read one self-delimiting record **incrementally**: grow a small buffer a chunk at a time and retry the span decoder until it succeeds (or fails for a reason other than truncation), then leave the stream just past the decoded record (seeking back only the unused tail read while growing). A record is small (tens of bytes) and has no fixed ceiling, so this reads ~one record's worth per call and reading N records is **linear**. The single span decoder is reused unchanged, so the wire format and error handling are untouched; `operator>>` and round-trip behavior are unchanged.

### Measured

| N records | before | after |
|---|---:|---:|
| 4000 | ~74 ms | ~0.4 ms |

Per-doubling time ratio fell from **~4× (quadratic)** to **~2× (linear)**.

### Tests

A **deterministic** guard (no flaky timing): `deserialize(istream)` advances the get-position by exactly one record's size — not to end-of-stream — proving it consumes one record rather than re-draining the remainder. The existing stream round-trip and back-to-back `operator>>` tests confirm behavior is unchanged.

Full suite green on gcc-13 (incl. UBSan + errorMessages harness), clang-19, and MSVC.

Closes #399