### PR TITLE
ci: pin the MSVC images so each leg builds the compiler it claims

### DIFF
--- a/.github/workflows/msvc-2022.yaml
+++ b/.github/workflows/msvc-2022.yaml
@@ -31,16 +31,20 @@ jobs:
         shell: bash
         run: vcpkg install eigen3:x64-windows
 
+      # VCPKG_APPLOCAL_DEPS=OFF is required, not a preference. The vcpkg toolchain otherwise appends a
+      # `vcpkg z-applocal` post-link step to EVERY executable, copying vcpkg's DLLs next to each one. Several
+      # executables in one directory link within milliseconds of each other, so those steps contend for the same
+      # destination files and one fails with "Access is denied" or "being used by another process" -- after link.exe
+      # has already succeeded. The only vcpkg dependency here is Eigen, which is header-only and has no DLL to copy,
+      # so the step has nothing to do and is pure risk.
       - name: Configure CMake
         run: |
-          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=cl -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=cl -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" -DVCPKG_APPLOCAL_DEPS=OFF -DX_VCPKG_APPLOCAL_DEPS_INSTALL=OFF
 
       - name: Build
-        # Build the main test binary first, then the rest. The vcpkg toolchain runs a `z-applocal` post-link step
-        # on every executable, copying the same vcpkg DLLs into build/test/; under a single fully-parallel build
-        # those applocal steps race on the shared DLL files ("cannot access the file because it is being used by
-        # another process"). Staggering the heavy target (unitLibTest) into its own pass keeps the compile parallel
-        # while the applocal steps no longer collide.
+        # Two passes: the heavy test binary alone, then everything else. ctest covers the examples and the lean
+        # (iostream/format/string-disabled) configurations, so all targets must exist or those cases report
+        # "Not Run" -- a red that says nothing about the code.
         run: |
           cmake --build build --parallel --target unitLibTest
           cmake --build build --parallel

--- a/.github/workflows/msvc-2022.yaml
+++ b/.github/workflows/msvc-2022.yaml
@@ -1,4 +1,6 @@
-name: msvc-2022
+# The file name is load-bearing: README.md's Windows badge points at this path. The workflow name and the job names
+# below are free to describe what actually runs.
+name: msvc
 
 on:
   push:
@@ -9,24 +11,47 @@ on:
 
 jobs:
   build-windows:
-    name: Build on Windows with Visual Studio 2022
-    runs-on: windows-latest
+    # PIN THE IMAGE, never `windows-latest`. That label migrated to Windows Server 2025 with Visual Studio 2026
+    # (VS 18, toolset 14.51), so a job asserting VS 2022 support was compiling with a toolchain three years newer
+    # than the one it claimed. MSVC changes overload resolution, concept evaluation and template instantiation order
+    # between toolsets, so the declared support floor has to be built by the compiler that defines it.
+    #
+    # Both legs gate. VS 2026 is what a user on a current toolchain gets, and it passes today, so a forward
+    # compatibility break should be a red build rather than a surprise at the next release.
+    name: ${{ matrix.label }}
+    runs-on: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: windows-2022
+            label: Visual Studio 2022 (the declared support floor)
+          - image: windows-2025
+            label: Visual Studio 2026 (forward compatibility)
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5
 
       # Set up the MSVC command-line environment FIRST (puts cl.exe on PATH). The "Visual Studio 17 2022"
-      # generator's own VS discovery has been unreliable on recent windows-latest images ("could not find any
-      # instance of Visual Studio"); configuring with Ninja against the dev-cmd-provided cl is robust and also
-      # provides cl for the error-message harness below.
+      # generator's own VS discovery has been unreliable on recent images ("could not find any instance of Visual
+      # Studio"); configuring with Ninja against the dev-cmd-provided cl is robust and also provides cl for the
+      # error-message harness below.
       - name: Set up MSVC command-line environment
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
 
+      # Record the toolset in every log. The image rolling forward under a `-latest` label is exactly how this job
+      # came to build VS 2026 while claiming VS 2022, and the only reason it was caught was an unrelated link
+      # failure that happened to print the compiler path.
+      - name: Report the compiler under test
+        run: |
+          cl 2>&1 | Select-Object -First 1
+          Write-Host "image: ${{ matrix.image }}"
+
       # Eigen enables the units/eigen.h interoperability tests (which self-guard on __has_include, so this is
-      # additive). windows-latest ships vcpkg at VCPKG_INSTALLATION_ROOT.
+      # additive). The Windows images ship vcpkg at VCPKG_INSTALLATION_ROOT.
       - name: Install Eigen (vcpkg)
         shell: bash
         run: vcpkg install eigen3:x64-windows

--- a/.github/workflows/msvc-2022.yaml
+++ b/.github/workflows/msvc-2022.yaml
@@ -1,5 +1,4 @@
-# The file name is load-bearing: README.md's Windows badge points at this path. The workflow name and the job names
-# below are free to describe what actually runs.
+# README.md's Windows badge points at this path, so the file name is load-bearing.
 name: msvc
 
 on:
@@ -11,13 +10,10 @@ on:
 
 jobs:
   build-windows:
-    # PIN THE IMAGE, never `windows-latest`. That label migrated to Windows Server 2025 with Visual Studio 2026
-    # (VS 18, toolset 14.51), so a job asserting VS 2022 support was compiling with a toolchain three years newer
-    # than the one it claimed. MSVC changes overload resolution, concept evaluation and template instantiation order
-    # between toolsets, so the declared support floor has to be built by the compiler that defines it.
-    #
-    # Both legs gate. VS 2026 is what a user on a current toolchain gets, and it passes today, so a forward
-    # compatibility break should be a red build rather than a surprise at the next release.
+    # Each leg names its image explicitly. `windows-latest` follows the runner image, which carries whichever
+    # Visual Studio that image ships; MSVC changes overload resolution, concept evaluation and template
+    # instantiation order between toolsets. `windows-2022` is the declared support floor and `windows-2025` carries
+    # Visual Studio 2026. Both gate a merge.
     name: ${{ matrix.label }}
     runs-on: ${{ matrix.image }}
     strategy:
@@ -33,43 +29,37 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v5
 
-      # Set up the MSVC command-line environment FIRST (puts cl.exe on PATH). The "Visual Studio 17 2022"
-      # generator's own VS discovery has been unreliable on recent images ("could not find any instance of Visual
-      # Studio"); configuring with Ninja against the dev-cmd-provided cl is robust and also provides cl for the
-      # error-message harness below.
+      # Puts cl.exe on PATH, for both the Ninja configure below and the error-message harness. The
+      # "Visual Studio 17 2022" generator's own discovery fails on some images with "could not find any instance of
+      # Visual Studio".
       - name: Set up MSVC command-line environment
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
 
-      # Record the toolset in every log. The image rolling forward under a `-latest` label is exactly how this job
-      # came to build VS 2026 while claiming VS 2022, and the only reason it was caught was an unrelated link
-      # failure that happened to print the compiler path.
+      # Records the toolset in the log, so a log states which compiler built the job.
       - name: Report the compiler under test
         run: |
           cl 2>&1 | Select-Object -First 1
           Write-Host "image: ${{ matrix.image }}"
 
-      # Eigen enables the units/eigen.h interoperability tests (which self-guard on __has_include, so this is
-      # additive). The Windows images ship vcpkg at VCPKG_INSTALLATION_ROOT.
+      # Eigen enables the units/eigen.h interoperability tests, which self-guard on __has_include. The Windows
+      # images ship vcpkg at VCPKG_INSTALLATION_ROOT.
       - name: Install Eigen (vcpkg)
         shell: bash
         run: vcpkg install eigen3:x64-windows
 
-      # VCPKG_APPLOCAL_DEPS=OFF is required, not a preference. The vcpkg toolchain otherwise appends a
-      # `vcpkg z-applocal` post-link step to EVERY executable, copying vcpkg's DLLs next to each one. Several
-      # executables in one directory link within milliseconds of each other, so those steps contend for the same
-      # destination files and one fails with "Access is denied" or "being used by another process" -- after link.exe
-      # has already succeeded. The only vcpkg dependency here is Eigen, which is header-only and has no DLL to copy,
-      # so the step has nothing to do and is pure risk.
+      # VCPKG_APPLOCAL_DEPS=OFF. The vcpkg toolchain otherwise appends a `vcpkg z-applocal` post-link step to every
+      # executable, copying vcpkg's DLLs beside it; executables in one directory link within milliseconds of each
+      # other and those steps contend for the same destination files, failing with "Access is denied" after link.exe
+      # has succeeded. The only vcpkg dependency here is Eigen, which is header-only.
       - name: Configure CMake
         run: |
           cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=cl -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" -DVCPKG_APPLOCAL_DEPS=OFF -DX_VCPKG_APPLOCAL_DEPS_INSTALL=OFF
 
       - name: Build
         # Two passes: the heavy test binary alone, then everything else. ctest covers the examples and the lean
-        # (iostream/format/string-disabled) configurations, so all targets must exist or those cases report
-        # "Not Run" -- a red that says nothing about the code.
+        # (iostream/format/string-disabled) configurations, so every target has to exist for those cases to run.
         run: |
           cmake --build build --parallel --target unitLibTest
           cmake --build build --parallel

--- a/.github/workflows/msvc-2022.yaml
+++ b/.github/workflows/msvc-2022.yaml
@@ -13,7 +13,10 @@ jobs:
     # Each leg names its image explicitly. `windows-latest` follows the runner image, which carries whichever
     # Visual Studio that image ships; MSVC changes overload resolution, concept evaluation and template
     # instantiation order between toolsets. `windows-2022` is the declared support floor and `windows-2025` carries
-    # Visual Studio 2026. Both gate a merge.
+    # Visual Studio 2026.
+    #
+    # The 2022 leg's name is the required status check on main, so it is spelled exactly as branch protection lists
+    # it. Adding the 2026 leg to that list is a repository setting, not a change here.
     name: ${{ matrix.label }}
     runs-on: ${{ matrix.image }}
     strategy:
@@ -21,9 +24,9 @@ jobs:
       matrix:
         include:
           - image: windows-2022
-            label: Visual Studio 2022 (the declared support floor)
+            label: Build on Windows with Visual Studio 2022
           - image: windows-2025
-            label: Visual Studio 2026 (forward compatibility)
+            label: Build on Windows with Visual Studio 2026
 
     steps:
       - name: Checkout Repository

--- a/README.md
+++ b/README.md
@@ -106,11 +106,16 @@ stays small and the code stays legible.
 
 `units` requires a **C++23** compiler. It is continuously tested on:
 
-| Compiler            | Version | Platform        |
-|---------------------|---------|-----------------|
-| GCC (`g++`)         | 13      | Ubuntu (latest) |
-| Clang (`clang++`)   | 19      | Ubuntu (latest) |
-| MSVC (Visual Studio)| 2022    | Windows (latest)|
+| Compiler            | Version   | Platform                    |
+|---------------------|-----------|-----------------------------|
+| GCC (`g++`)         | 13        | Ubuntu (latest)             |
+| Clang (`clang++`)   | 19        | Ubuntu (latest)             |
+| MSVC (Visual Studio)| 2022      | Windows Server 2022         |
+| MSVC (Visual Studio)| 2026      | Windows Server 2025         |
+
+The two MSVC rows are separate CI jobs on pinned images, and both gate a merge: 2022 is the declared floor, 2026 is
+the current toolchain. A `-latest` runner label is deliberately not used — it migrates between OS and Visual Studio
+versions, so a job on `windows-latest` silently stops testing the version it claims.
 
 Older toolchains are not supported by the 3.x line. The last release for the C++14 era is the 2.x
 series (see [Migrating from 2.x](docs/meta/migrate-v2-to-v3.md)).

--- a/README.md
+++ b/README.md
@@ -113,10 +113,6 @@ stays small and the code stays legible.
 | MSVC (Visual Studio)| 2022      | Windows Server 2022         |
 | MSVC (Visual Studio)| 2026      | Windows Server 2025         |
 
-The two MSVC rows are separate CI jobs on pinned images, and both gate a merge: 2022 is the declared floor, 2026 is
-the current toolchain. A `-latest` runner label is deliberately not used — it migrates between OS and Visual Studio
-versions, so a job on `windows-latest` silently stops testing the version it claims.
-
 Older toolchains are not supported by the 3.x line. The last release for the C++14 era is the 2.x
 series (see [Migrating from 2.x](docs/meta/migrate-v2-to-v3.md)).
 


### PR DESCRIPTION
Two independent CI fixes, split out of #424 so they can be reviewed on their own. No library code.

**Pin the runner images.** The `windows-latest` label migrated to Windows Server 2025 with Visual Studio 2026
(VS 18, toolset 14.51), so the job asserting VS 2022 support was compiling with a toolchain three years newer than
the one it claimed. MSVC changes overload resolution, concept evaluation and template instantiation order between
toolsets, so the declared support floor has to be built by the compiler that defines it. The job becomes a
two-entry matrix on pinned images — `windows-2022` (the floor) and `windows-2025` (forward compatibility) — with
`fail-fast: false` so one leg's failure does not hide the other's result, and a step that prints `cl`'s own version
line into every log. The README's compiler table gains the second MSVC row.

**Stop the vcpkg post-link race.** `VCPKG_APPLOCAL_DEPS=OFF` is required rather than preferred. The vcpkg toolchain
otherwise appends a `vcpkg z-applocal` post-link step to every executable, copying vcpkg's DLLs beside each one.
Several executables link within milliseconds of each other, so those steps contend for the same destination files
and one fails with "Access is denied" — after `link.exe` has already succeeded. The only vcpkg dependency here is
Eigen, which is header-only and has no DLL to copy, so the step has nothing to do and is pure risk.

Verified: the workflow parses, the matrix resolves to both images, and both MSVC legs pass on the branch this was
extracted from.