### PR TITLE
fix: assign a bare number to a decibel quantity as decibels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project adheres to semantic versioning.
 
+## [Unreleased]
+
+### Fixed
+- Assignment of a bare number to a decibel-scale quantity means decibels, as its value constructor does, so an
+  assign-then-read round trip holds. This reaches `units::decibels` and `dBi`.
+
 ## [3.6.1] - 2026-08-18
 
 ### Fixed

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -2888,8 +2888,18 @@ namespace units
 			requires traits::is_dimensionless_unit<Cf>::value
 		constexpr unit& operator=(const underlying_type& rhs) noexcept
 		{
-			unit<units::conversion_factor<std::ratio<1>, units::dimension::dimensionless>, underlying_type, linear_scale> dimensionlessRhs(rhs);
-			_linearized_value = units::convert<unit>(dimensionlessRhs)._linearized_value;
+			// A linear scale stores the number it is given; every other scale linearizes it through the value
+			// constructor, so the number means what it means there. (`has_linear_scale_v` is declared later in this
+			// header, hence the direct comparison.)
+			if constexpr (std::is_same_v<NumericalScale, linear_scale>)
+			{
+				unit<units::conversion_factor<std::ratio<1>, units::dimension::dimensionless>, underlying_type, linear_scale> dimensionlessRhs(rhs);
+				_linearized_value = units::convert<unit>(dimensionlessRhs)._linearized_value;
+			}
+			else
+			{
+				_linearized_value = unit(rhs)._linearized_value;
+			}
 			return *this;
 		}
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -8530,6 +8530,30 @@ TEST(Format, throwsOnMismatchedValueTypeSpec)
 	EXPECT_THROW((void)std::vformat("{:x}", std::make_format_args(md)), std::format_error);
 }
 
+// Assignment from a bare number means what the value constructor means, so an assign-then-read round trip holds on a
+// logarithmic scale: `g = 12.5` is 12.5 dB, as `decibels(12.5)` is.
+TEST_F(UnitType, nonLinearScaleStoresThroughItsScale)
+{
+	decibels<double> gain(3.25);
+	EXPECT_NEAR(3.25, gain.raw(), 5.0e-12);
+	EXPECT_NEAR(2.113489039, gain.to_linearized(), 5.0e-9);
+	gain = 12.5;
+	EXPECT_NEAR(12.5, gain.raw(), 5.0e-12);
+	EXPECT_EQ(decibels<double>(12.5), gain);
+	EXPECT_NEAR(12.5, static_cast<double>(gain), 5.0e-12);
+
+	// a ratio-scaled dimensionless is unaffected: a bare number there is the base-dimensionless fraction
+	concentration::percent<double> percentage(12.5);
+	percentage = 0.5;
+	EXPECT_NEAR(50.0, percentage.raw(), 5.0e-12);
+	EXPECT_NEAR(0.5, percentage.value(), 5.0e-12);
+	// and so is a plain dimensionless
+	dimensionless<double> plain(1.0);
+	plain = 3.25;
+	EXPECT_NEAR(3.25, plain.value(), 5.0e-12);
+}
+
+
 int main(int argc, char* argv[])
 {
 	::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
`operator=(const underlying_type&)` routes every dimensionless assignment through a linear dimensionless intermediate and `convert`, which writes the number as the *linearized* value. On a logarithmic scale that reads the number as the linear ratio rather than as decibels:

```cpp
units::decibels<double> g(3.25);
g.raw();        // 3.25 dB, as the value constructor means it

g = 3.25;
g.raw();        // 5.11883 before, 3.25 after
```

So `g = x` and `decibels(x)` disagreed, and an assign-then-read round trip did not hold.

A linear scale keeps the existing path. Every other scale now goes through the value constructor, which is what the number means to that scale. A ratio-scaled dimensionless (`percent`, `parts_per_million`) is unaffected — a bare number there is still the base-dimensionless fraction — and so is a plain `dimensionless`.

Reaches `units::decibels` and `dBi`.

### Verification

One test covering the round trip on `decibels`, plus the unchanged behavior of `percent` and plain `dimensionless`. 397 tests pass on gcc-13.