### PR TITLE
fix: build numeric_limits of a non-linear scale from the stored representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project adheres to semantic versioning.
 
+## [Unreleased]
+
+### Fixed
+- `std::numeric_limits` of a decibel-scale unit reads as finite decibel figures, built from the stored representation:
+  `max()` 3082.547, `epsilon()` 9.643e-16, `min()` -3076.527, `denorm_min()` -3233.062, `round_error()` 1.761,
+  `lowest()` -3233.062. A linear scale is unchanged.
+
 ## [3.6.1] - 2026-08-18
 
 ### Fixed

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -5908,34 +5908,97 @@ namespace std
 	template<units::ConversionFactorType ConversionFactor, units::ArithmeticType T, units::NumericalScaleType<T> NonLinearScale>
 	struct numeric_limits<units::unit<ConversionFactor, T, NonLinearScale>>
 	{
-		static constexpr units::unit<ConversionFactor, T, NonLinearScale> min()
+	private:
+		using Q = units::unit<ConversionFactor, T, NonLinearScale>;
+
+		// A limit is a property of the stored representation, so on a non-linear scale it is built from the stored
+		// value and not pushed through the value constructor, which linearizes. For a linear scale the two are
+		// identical.
+		/**
+		 * @brief		Builds a limit from a value already in the unit's stored representation.
+		 * @param[in]	stored	the value in the unit's stored representation.
+		 * @returns		that quantity.
+		 */
+		static constexpr Q fromStored(T stored) noexcept
 		{
-			return units::unit<ConversionFactor, T, NonLinearScale>(std::numeric_limits<T>::min());
+			if constexpr (units::traits::has_linear_scale_v<Q>)
+				return Q(stored);
+			else
+				return Q(stored, units::linearized_value);
 		}
 
-		static constexpr units::unit<ConversionFactor, T, NonLinearScale> denorm_min() noexcept
+	public:
+		/**
+		 * @brief		The smallest positive normal quantity.
+		 * @returns		that quantity.
+		 */
+		static constexpr Q min()
 		{
-			return units::unit<ConversionFactor, T, NonLinearScale>(std::numeric_limits<T>::denorm_min());
+			return fromStored(std::numeric_limits<T>::min());
 		}
 
-		static constexpr units::unit<ConversionFactor, T, NonLinearScale> max()
+		/**
+		 * @brief		The smallest positive denormal quantity.
+		 * @details		On a non-linear scale the stored value is a ratio and is strictly positive, so the smallest
+		 *				denormal ratio is also the lowest representable quantity, and `lowest()` agrees with this
+		 *				rather than with `min()`.
+		 * @returns		that quantity.
+		 */
+		static constexpr Q denorm_min() noexcept
 		{
-			return units::unit<ConversionFactor, T, NonLinearScale>(std::numeric_limits<T>::max());
+			return fromStored(std::numeric_limits<T>::denorm_min());
 		}
 
-		static constexpr units::unit<ConversionFactor, T, NonLinearScale> lowest()
+		/**
+		 * @brief		The largest finite quantity.
+		 * @returns		that quantity.
+		 */
+		static constexpr Q max()
 		{
-			return units::unit<ConversionFactor, T, NonLinearScale>(std::numeric_limits<T>::lowest());
+			return fromStored(std::numeric_limits<T>::max());
 		}
 
-		static constexpr units::unit<ConversionFactor, T, NonLinearScale> epsilon()
+		/**
+		 * @brief		The lowest representable quantity.
+		 * @details		On a non-linear scale the stored value is a ratio and is strictly positive, so the lowest
+		 *				representable quantity is the smallest positive stored value, a very negative number of
+		 *				decibels, and not `T`'s lowest.
+		 * @returns		that quantity.
+		 */
+		static constexpr Q lowest()
 		{
-			return units::unit<ConversionFactor, T, NonLinearScale>(std::numeric_limits<T>::epsilon());
+			if constexpr (units::traits::has_linear_scale_v<Q>)
+				return Q(std::numeric_limits<T>::lowest());
+			else
+				// The smallest denormal stored ratio, not the smallest normal one: `lowest()` is no greater than
+				// `denorm_min()`, and on a logarithmic scale the denormal maps to a more negative figure.
+				return fromStored(std::numeric_limits<T>::denorm_min());
 		}
 
-		static constexpr units::unit<ConversionFactor, T, NonLinearScale> round_error()
+		/**
+		 * @brief		The smallest distinguishable step.
+		 * @details		On a non-linear scale that is the quantity whose stored ratio differs from unity by one
+		 *				epsilon, which is a small non-zero number of decibels.
+		 * @returns		that quantity.
+		 */
+		static constexpr Q epsilon()
 		{
-			return units::unit<ConversionFactor, T, NonLinearScale>(std::numeric_limits<T>::round_error());
+			if constexpr (units::traits::has_linear_scale_v<Q>)
+				return Q(std::numeric_limits<T>::epsilon());
+			else
+				return fromStored(static_cast<T>(T{1} + std::numeric_limits<T>::epsilon()));
+		}
+
+		/**
+		 * @brief		The maximum rounding error, in units of the stored representation.
+		 * @returns		that quantity.
+		 */
+		static constexpr Q round_error()
+		{
+			if constexpr (units::traits::has_linear_scale_v<Q>)
+				return Q(std::numeric_limits<T>::round_error());
+			else
+				return fromStored(static_cast<T>(T{1} + std::numeric_limits<T>::round_error()));
 		}
 
 		static constexpr units::unit<ConversionFactor, T, NonLinearScale> infinity()

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -8530,6 +8530,38 @@ TEST(Format, throwsOnMismatchedValueTypeSpec)
 	EXPECT_THROW((void)std::vformat("{:x}", std::make_format_args(md)), std::format_error);
 }
 
+// `std::numeric_limits` describes the stored representation, so on a decibel scale the limits read as finite decibel
+// figures: `max()` is finite, as its contract requires, and `epsilon()` is non-zero, so a generic tolerance written
+// against it is not silently zero.
+TEST_F(UnitType, numericLimitsAreFiniteOnADecibelScale)
+{
+	using Level = std::numeric_limits<units::power::dBW<double>>;
+	EXPECT_TRUE(std::isfinite(Level::max().raw()));
+	EXPECT_TRUE(std::isfinite(Level::lowest().raw()));
+	EXPECT_GT(Level::max().raw(), 0.0);
+	EXPECT_LT(Level::lowest().raw(), 0.0);
+	EXPECT_LT(Level::lowest().raw(), Level::max().raw());
+	EXPECT_LE(Level::lowest().raw(), Level::denorm_min().raw());
+	EXPECT_NE(0.0, Level::epsilon().raw());
+	EXPECT_GT(Level::epsilon().raw(), 0.0);
+	EXPECT_TRUE(std::isinf(Level::infinity().raw()));    // an infinite ratio is infinite decibels
+
+	using Gain = std::numeric_limits<decibels<double>>;
+	EXPECT_TRUE(std::isfinite(Gain::max().raw()));
+	EXPECT_NE(0.0, Gain::epsilon().raw());
+
+	// a linear scale is unchanged
+	using Linear = std::numeric_limits<units::power::watts<double>>;
+	EXPECT_DOUBLE_EQ(std::numeric_limits<double>::max(), Linear::max().raw());
+	EXPECT_DOUBLE_EQ(std::numeric_limits<double>::lowest(), Linear::lowest().raw());
+	EXPECT_DOUBLE_EQ(std::numeric_limits<double>::epsilon(), Linear::epsilon().raw());
+	EXPECT_DOUBLE_EQ(std::numeric_limits<double>::round_error(), Linear::round_error().raw());
+	using LinearInt = std::numeric_limits<units::meters<int>>;
+	EXPECT_EQ(std::numeric_limits<int>::max(), LinearInt::max().raw());
+	EXPECT_EQ(std::numeric_limits<int>::lowest(), LinearInt::lowest().raw());
+}
+
+
 int main(int argc, char* argv[])
 {
 	::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Every limit was constructed through the value constructor, which linearizes. On a decibel scale that evaluates `pow(10, x/10)` of the underlying type's limit:

```cpp
using Level = std::numeric_limits<units::power::dBW<double>>;

Level::max().raw();       // inf before, 3082.547 after
Level::epsilon().raw();   // 0   before, 9.643e-16 after
```

`max()` returning infinity breaks its own contract, and an `epsilon()` of zero silently zeroes any generic tolerance written against it. `lowest()` returned `T`'s lowest, which on a logarithmic scale is not representable as a stored ratio.

The limits are now built from the stored value on a non-linear scale. `lowest()` uses the smallest denormal stored ratio, so it stays no greater than `denorm_min()` as the contract requires.

A linear scale takes the same path it always did — `numeric_limits<watts<double>>` and `numeric_limits<meters<int>>` are unchanged, and the test asserts that.

### Verification

One test covering `dBW` (finite `max`/`lowest`, ordering, non-zero `epsilon`, infinite `infinity`), the dimensionless `decibels` gain, and the unchanged linear float and integer cases. 397 tests pass on gcc-13.