### PR TITLE
fix: give an Eigen difference of readings the amount type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project adheres to semantic versioning.
 
+## [Unreleased]
+
+### Fixed
+- A coefficient-wise Eigen difference of two readings measured from an arbitrary origin is an offset-free amount, as
+  the scalar difference is, so `(v - w).eval()` on a matrix of equal `celsius` readings is 0. An ordinary quantity
+  keeps Eigen's own result type.
+
 ## [3.6.1] - 2026-08-18
 
 ### Fixed

--- a/include/units/eigen.h
+++ b/include/units/eigen.h
@@ -126,6 +126,22 @@ namespace Eigen
 	{
 		using ReturnType = U; ///< dividing by a dimensionless factor preserves the unit's dimension
 	};
+
+	/**
+	 * @brief		Result-type trait for a coefficient-wise difference whose result is not the operand type.
+	 * @details		Eigen otherwise assumes `op(T,T) -> T` for a coefficient-wise binary operation. For a quantity
+	 *				measured from an arbitrary origin the scalar difference of two readings is an offset-free amount,
+	 *				and assigning it back into the reading type re-applies the datum. Naming the amount type here makes
+	 *				the matrix difference agree with the scalar one. Specialized only where the two types differ, so an
+	 *				ordinary quantity keeps Eigen's own result type.
+	 * @tparam		U a units type whose difference with itself is a different type.
+	 */
+	template<units::UnitType U>
+		requires(!std::is_same_v<U, decltype(std::declval<U>() - std::declval<U>())>)
+	struct ScalarBinaryOpTraits<U, U, internal::scalar_difference_op<U, U>>
+	{
+		using ReturnType = decltype(std::declval<U>() - std::declval<U>()); ///< a difference of readings is an amount
+	};
 } // namespace Eigen
 
 namespace units

--- a/test/eigenInterop.cpp
+++ b/test/eigenInterop.cpp
@@ -413,6 +413,44 @@ namespace
 		EXPECT_NEAR(std::sqrt(2.0), n.value(), 1e-12);
 		static_assert(std::is_floating_point_v<decltype(n)::underlying_type>);
 	}
+
+	// A coefficient-wise difference of two readings measured from an arbitrary origin is an offset-free amount, as the
+	// scalar difference is. Eigen otherwise assumes op(T,T) -> T and assigns the amount back into the reading type,
+	// which applies the datum: the difference of two equal celsius readings then reads -273.15 rather than 0.
+	TEST_F(EigenInterop, coefficientWiseDifferenceOfReadingsIsAnAmount)
+	{
+		using celsius = units::temperature::celsius<double>;
+		Eigen::Matrix<celsius, 3, 1> v, w;
+		v << celsius(20.0), celsius(21.0), celsius(22.0);
+		w << celsius(20.0), celsius(21.0), celsius(22.0);
+
+		const auto same = (v - w).eval();
+		EXPECT_DOUBLE_EQ(0.0, same[0].raw());
+		EXPECT_DOUBLE_EQ(0.0, same[1].raw());
+		EXPECT_DOUBLE_EQ(0.0, same[2].raw());
+		static_assert(!units::traits::is_affine_unit_v<std::decay_t<decltype(same[0])>>,
+			"the difference of two readings carries no datum");
+
+		// and it agrees with the scalar difference, coefficient by coefficient
+		Eigen::Matrix<celsius, 2, 1> warmer, cooler;
+		warmer << celsius(30.0), celsius(25.0);
+		cooler << celsius(10.0), celsius(20.0);
+		const auto change = (warmer - cooler).eval();
+		EXPECT_DOUBLE_EQ((celsius(30.0) - celsius(10.0)).raw(), change[0].raw());
+		EXPECT_DOUBLE_EQ((celsius(25.0) - celsius(20.0)).raw(), change[1].raw());
+		EXPECT_DOUBLE_EQ(20.0, change[0].raw());
+		EXPECT_DOUBLE_EQ(5.0, change[1].raw());
+
+		// an ordinary quantity keeps Eigen's own result type: a length difference is a length
+		Vector3m a, b;
+		a << 3.0_m, 4.0_m, 0.0_m;
+		b << 1.0_m, 1.0_m, 0.0_m;
+		const auto span = (a - b).eval();
+		static_assert(std::is_same_v<std::decay_t<decltype(span[0])>, meters<double>>);
+		EXPECT_DOUBLE_EQ(2.0, span[0].value());
+		EXPECT_DOUBLE_EQ(3.0, span[1].value());
+	}
+
 }
 
 #endif // UNITS_HAVE_EIGEN


### PR DESCRIPTION
Eigen assumes `op(T,T) -> T` for a coefficient-wise binary operation, so a matrix difference of two affine readings is assigned back into the reading type. Storing an amount as a reading applies the datum:

```cpp
Eigen::Matrix<units::temperature::celsius<double>, 3, 1> v, w;
// v and w hold the same three temperatures

(v - w).eval()[0].raw();   // -273.15 before, 0 after
```

The scalar `celsius(20) - celsius(20)` already gave 0, so the matrix and the scalar disagreed.

A `ScalarBinaryOpTraits` specialization for `scalar_difference_op` names the difference type the scalar operator produces. It is constrained to the case where that type differs from the operand type, so an ordinary quantity keeps Eigen's own result type — a `meters` difference is still `meters`, and the test asserts that.

### Verification

One test: three equal readings difference to zero and the result carries no datum, a non-trivial difference agrees coefficient-by-coefficient with the scalar operator, and a `meters` difference keeps its type and value. 424 tests pass on gcc-13 with Eigen present.