### PR TITLE
fix: apply the datum when rounding into an integral affine target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project adheres to semantic versioning.
 
+## [Unreleased]
+
+### Fixed
+- A rounding conversion into an integral affine target applies the datum: `round<celsius<int>>(kelvin<int>(300))` is 27
+  and `ceil<kelvin<int>>(celsius<int>(20))` is 294. An ordinary datum-free narrowing is unchanged.
+
 ## [3.6.1] - 2026-08-18
 
 ### Fixed

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -5576,7 +5576,7 @@ namespace units
 			using ToRep   = typename To::underlying_type;
 			using FromRep = typename From::underlying_type;
 
-			if constexpr (std::is_integral_v<FromRep>)
+			if constexpr (std::is_integral_v<FromRep> && !traits::is_affine_unit_v<From> && !traits::is_affine_unit_v<To>)
 			{
 				// Exact integer path: value (in From units) * num / den, rounded on the integer remainder. The
 				// intermediate is the widest UNSIGNED integer when both source and target are unsigned, so an unsigned
@@ -5597,7 +5597,8 @@ namespace units
 			}
 			else
 			{
-				// A floating-point source: express in the target unit and apply the matching std:: rounding.
+				// A floating-point source, or any affine conversion: express in the target unit, which is a full
+				// conversion and so applies the datum, and apply the matching std:: rounding.
 				using Promoted = unit<typename To::conversion_factor, floating_point_promotion_t<ToRep>, typename To::numerical_scale_type>;
 				const auto inTarget = Promoted(x).to_linearized();
 				const auto rounded  = mode == rounding_mode::toward_neg_infinity ? std::floor(inTarget)
@@ -5608,14 +5609,24 @@ namespace units
 			}
 		}
 
+		/// Whether the source and target carry different datums. `is_losslessly_convertible_unit` judges losslessness
+		/// on the conversion ratio alone, so it calls kelvin -> celsius lossless because both ratios are 1, and the
+		/// fractional 273.15 between them is what needs rounding.
+		template<class To, class From>
+		inline constexpr bool differing_datum_v =
+			!std::ratio_equal_v<typename traits::unit_traits<From>::conversion_factor::translation_ratio,
+				typename traits::unit_traits<To>::conversion_factor::translation_ratio>;
+
 		/// Whether a run-time rounding conversion from `From` to `To` is meaningful: same dimension, an integral
 		/// target, and a source not already losslessly convertible into the target (a lossless conversion needs no
-		/// rounding and the ordinary converting constructor serves it). Gating the target-unit rounding overloads on
-		/// this keeps them from shadowing the deduced-argument `round`/`floor`/`ceil`/`trunc` math functions.
+		/// rounding and the ordinary converting constructor serves it), or an affine pair whose datums differ.
+		/// Gating the target-unit rounding overloads on this keeps them from shadowing the deduced-argument
+		/// `round`/`floor`/`ceil`/`trunc` math functions.
 		template<class To, class From>
 		inline constexpr bool is_roundable_unit_conversion =
 			traits::is_unit_v<To> && traits::is_unit_v<From> && same_dimension<From, To> &&
-			std::is_integral_v<typename To::underlying_type> && !is_losslessly_convertible_unit<From, To>;
+			std::is_integral_v<typename To::underlying_type> &&
+			(!is_losslessly_convertible_unit<From, To> || differing_datum_v<To, From>);
 	} // namespace detail
 	/** @endcond */ // END DOXYGEN IGNORE
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -8530,6 +8530,45 @@ TEST(Format, throwsOnMismatchedValueTypeSpec)
 	EXPECT_THROW((void)std::vformat("{:x}", std::make_format_args(md)), std::format_error);
 }
 
+// A rounding conversion into an integral affine target expresses the source in the target unit, which applies the
+// datum: 300 K is 26.85 degC.
+TEST(RoundingIntoAnAffineTarget, roundingIntoAnIntegerAffineTargetAppliesTheDatum)
+{
+	EXPECT_EQ(27, units::round<celsius<int>>(kelvin<int>(300)).raw());
+	EXPECT_EQ(294, units::ceil<kelvin<int>>(celsius<int>(20)).raw());
+	EXPECT_EQ(530, units::round<rankine<int>>(fahrenheit<int>(70)).raw());
+
+	// the whole family agrees on the same fractional value, 26.85 degC
+	EXPECT_EQ(26, units::floor<celsius<int>>(kelvin<int>(300)).raw());
+	EXPECT_EQ(27, units::ceil<celsius<int>>(kelvin<int>(300)).raw());
+	EXPECT_EQ(26, units::trunc<celsius<int>>(kelvin<int>(300)).raw());
+	EXPECT_EQ(293, units::floor<kelvin<int>>(celsius<int>(20)).raw());
+	static_assert(std::is_same_v<celsius<int>, std::decay_t<decltype(units::round<celsius<int>>(kelvin<int>(300)))>>,
+		"the rounding conversion returns the requested target");
+
+	// a pair whose ratios differ: 54 degF is (54 - 32) * 5/9 == 110/9 == 12.222222222222221 degC, so round and floor
+	// give 12 and ceil gives 13; 8 degRe is 8 * 5/4 == 10 degC exactly
+	EXPECT_EQ(12, units::round<celsius<int>>(fahrenheit<int>(54)).raw());
+	EXPECT_EQ(12, units::floor<celsius<int>>(fahrenheit<int>(54)).raw());
+	EXPECT_EQ(13, units::ceil<celsius<int>>(fahrenheit<int>(54)).raw());
+	EXPECT_EQ(10, units::round<celsius<int>>(reaumur<int>(8)).raw());
+
+	// a floating-point source reaches the same answers, and the deduced-argument `round` rounds the reading in its own
+	// scale rather than converting: 300.4 K rounds to 300 K, and 26.85 degC to 27 degC
+	EXPECT_EQ(27, units::round<celsius<int>>(kelvin<double>(300.0)).raw());
+	EXPECT_EQ(294, units::ceil<kelvin<int>>(celsius<double>(20.0)).raw());
+	EXPECT_EQ(530, units::round<rankine<int>>(fahrenheit<double>(70.0)).raw());
+	EXPECT_DOUBLE_EQ(300.0, units::round(kelvin<double>(300.4)).raw());
+	EXPECT_DOUBLE_EQ(27.0, units::round(celsius<double>(26.85)).raw());
+
+	// an ordinary (datum-free) narrowing is untouched: 1234 cm is 1234 / 100 == 12.34 m
+	EXPECT_EQ(12, units::round<meters<int>>(centimeters<int>(1234)).raw());
+	EXPECT_EQ(12, units::floor<meters<int>>(centimeters<int>(1234)).raw());
+	EXPECT_EQ(13, units::ceil<meters<int>>(centimeters<int>(1234)).raw());
+	EXPECT_EQ(12, units::trunc<meters<int>>(centimeters<int>(1234)).raw());
+}
+
+
 int main(int argc, char* argv[])
 {
 	::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
```cpp
units::round<celsius<int>>(kelvin<int>(300)).raw();   // 26 before, 27 after   (300 K is 26.85 degC)
units::ceil<kelvin<int>>(celsius<int>(20)).raw();     // 293 before, 294 after (20 degC is 293.15 K)
```

Two paths dropped the datum:

- **`rounded_unit_cast`'s exact-integer path** applies only the conversion ratio, and a datum lives in the conversion factor's *translation*, so an affine conversion through it lost the datum entirely. Exactness is unreachable for such a conversion in any case, the translation being fractional. An affine source or target now takes the floating-point path, which expresses the value in the target unit and so applies the datum.

- **`is_roundable_unit_conversion`** gated the target-unit overloads on `!is_losslessly_convertible_unit`, which judges losslessness on the conversion ratio alone. Kelvin and celsius both have a ratio of 1, so it called the conversion lossless and the call fell through to the deduced-argument `round` — which acts on an already-truncated integer. An affine pair whose datums differ now qualifies.

An ordinary datum-free narrowing keeps the exact-integer path: `round<meters<int>>(centimeters<int>(1234))` is still 12, and the test asserts the whole `floor`/`ceil`/`round`/`trunc` family for it.

### Verification

One test covering the family on kelvin↔celsius and fahrenheit↔rankine, a ratio-differing pair (`fahrenheit`→`celsius`, `reaumur`→`celsius`), a floating-point source reaching the same answers, the deduced-argument `round` still rounding in the reading's own scale, and the unchanged datum-free narrowing. 397 tests pass on gcc-13.