### PR TITLE
test: pin the round-trip identity at the call site

### DIFF
--- a/test/main.cpp
+++ b/test/main.cpp
@@ -8781,6 +8781,27 @@ TEST(UnitComparison, aWideIntegralOperandOrdersExactly)
 	EXPECT_TRUE(meters<double>(5.0) < kilometers<double>(3.0));
 	EXPECT_TRUE(meters<int>(1000) == kilometers<int>(1));
 }
+// The type algebra closes at the level a caller writes: `detail::rewrap_to_named_t` puts an operation's result back
+// into the named unit, so a product of two lengths IS `square_meters<double>` and the root of it IS `meters<double>`.
+// The round trip is an identity of type as well as value, and needs no annotation to store.
+TEST(DatumFreeManipulators, theRoundTripIsAnIdentityAtTheCallSite)
+{
+	static_assert(std::is_same_v<units::area::square_meters<double>,
+					  std::decay_t<decltype(meters<double>(2.0) * meters<double>(3.0))>>,
+		"a product of two lengths is the named area unit");
+	static_assert(std::is_same_v<meters<double>, decltype(units::sqrt(meters<double>(2.0) * meters<double>(2.0)))>,
+		"the root of a squared length is the named length unit");
+
+	EXPECT_DOUBLE_EQ(6.0, (meters<double>(2.0) * meters<double>(3.0)).value());
+	EXPECT_DOUBLE_EQ(2.0, units::sqrt(meters<double>(2.0) * meters<double>(2.0)).value());
+	EXPECT_EQ(meters<double>(2.0), units::sqrt(meters<double>(2.0) * meters<double>(2.0)));
+
+	// a unit whose ratio is not one, and one carrying a pi exponent, round-trip by value and comparison
+	EXPECT_DOUBLE_EQ(3.0, units::sqrt(feet<double>(3.0) * feet<double>(3.0)).value());
+	EXPECT_EQ(feet<double>(3.0), units::sqrt(feet<double>(3.0) * feet<double>(3.0)));
+	EXPECT_DOUBLE_EQ(90.0, units::sqrt(units::angle::degrees<double>(90.0) * units::angle::degrees<double>(90.0)).value());
+}
+
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
Follow-up to #435, which merged while this was being written.

`detail::rewrap_to_named_t` puts an operation's result back into the named unit, so at the level a caller writes, the type algebra closes for an SI base unit:

```cpp
static_assert(std::is_same_v<units::area::square_meters<double>,
    std::decay_t<decltype(meters<double>(2.0) * meters<double>(3.0))>>);
static_assert(std::is_same_v<meters<double>,
    decltype(units::sqrt(meters<double>(2.0) * meters<double>(2.0)))>);
```

Nothing pinned that, so nothing would notice it breaking.

For a unit whose factor is spelled relative to a parent rather than to the dimension — `feet` is `conversion_factor<ratio<381, 1250>, meters<>>`, and `degrees` is `conversion_factor<ratio<1, 180>, radians<>, ratio<1>>` — the round trip returns by value and by comparison but **not** by name. The test asserts what holds rather than what one would prefer; #440 tracks closing it by name.

405 tests pass on gcc-13.