### PR TITLE
feat: ask whether two units are equivalent by the library's own definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- `units::traits::is_same_unit`, `units::traits::is_same_conversion_factor` and the `units::same_unit` concept, which
+  ask whether two types are one unit by the library's definition -- the same conversion factor and numerical scale --
+  where `std::is_same_v` reports a named unit and the `unit<...>` an operation builds for it as different types.
+
 ### Fixed
 - `squared`, `cubed` and `square_root` drop the datum, as their documentation states and as `operator*` already did, so
   the manipulator spelling and the product of two readings are one type and a value carries between the two spellings of

--- a/docs/reference/concepts.md
+++ b/docs/reference/concepts.md
@@ -22,6 +22,7 @@ using namespace units;
 | `DimensionedUnitType<T>` | a unit that **has** a dimension (excludes dimensionless) | `is_unit_v && !is_dimensionless_unit` (`DimensionedUnitType` in `include/units/core.h`) |
 | `DimensionlessUnitType<T>` | a **dimensionless** unit (`dimensionless`, `percent`, angle ratios, …) | `is_unit_v && is_dimensionless_unit` (`DimensionlessUnitType` in `include/units/core.h`) |
 | `same_dimension<UnitTo, UnitFrom>` | two units of the **same dimension** (mutually convertible, e.g. `meters` and `feet`) | `traits::is_same_dimension_unit` (`same_dimension` in `include/units/core.h`) |
+| `same_unit<UnitTo, UnitFrom>` | two types which are the **same unit** — the same conversion factor and numerical scale, so a value converts between them unchanged | `traits::is_same_unit` (`same_unit` in `include/units/core.h`) |
 | `RatioDimensionlessUnitType<U>` | a dimensionless unit whose conversion ratio is **not** 1 — `percent`, `ppm`, `ppb`, … | `traits::is_ratio_dimensionless_cf_v` (`RatioDimensionlessUnitType` in `include/units/core.h`) |
 | `OrdinaryDimensionlessUnitType<U>` | a dimensionless unit whose ratio **is** 1 — plain `dimensionless` (the complement of `RatioDimensionlessUnitType`) | (`OrdinaryDimensionlessUnitType` in `include/units/core.h`) |
 

--- a/docs/reference/type-traits.md
+++ b/docs/reference/type-traits.md
@@ -40,6 +40,8 @@ Predicates on a unit's *dimension* — which physical quantity it measures, and 
 | Trait (`_v` form) | Meaning |
 |---|---|
 | `is_same_dimension_unit<U1, U2>` / `is_same_dimension_unit_v<U1, U2>` | `U1` and `U2` are units of the same dimension (mutually convertible). (`is_same_dimension_unit` in `include/units/core.h`) |
+| `is_same_conversion_factor<Cf1, Cf2>` / `is_same_conversion_factor_v<Cf1, Cf2>` | `Cf1` and `Cf2` are the same conversion factor: the same dimension, conversion ratio, pi exponent and datum. (`is_same_conversion_factor` in `include/units/core.h`) |
+| `is_same_unit<U1, U2>` / `is_same_unit_v<U1, U2>` | `U1` and `U2` are the same unit: the same conversion factor and the same numerical scale, so a value converts between them unchanged. The representation is not part of a unit's identity. (`is_same_unit` in `include/units/core.h`) |
 | `is_dimensionless_unit<T>` / `is_dimensionless_unit_v<T>` | `T` is a dimensionless unit (`dimensionless`, `percent`, an angle ratio, …). |
 | `is_<dimension>_unit<T>` / `is_<dimension>_unit_v<T>` | `T` is a unit of the named dimension — one member of a generated family (see below). (`UNIT_ADD_DIMENSION_TRAIT` in `include/units/core.h`) |
 

--- a/include/units/core.h
+++ b/include/units/core.h
@@ -1049,6 +1049,9 @@ namespace units
 		// forward declaration
 		template<UnitType U1, UnitType U2>
 		struct is_same_dimension_unit;
+
+		template<UnitType U1, UnitType U2>
+		struct is_same_unit;
 	} // namespace traits
 
 	/**
@@ -1057,6 +1060,14 @@ namespace units
 	 */
 	template<typename UnitTo, typename UnitFrom>
 	concept same_dimension = traits::is_same_dimension_unit<UnitFrom, UnitTo>::value;
+
+	/**
+	 * @ingroup		Concepts
+	 * @brief		Concept for two types which are the same unit -- the same conversion factor and the same
+	 *				numerical scale, so a value converts between them unchanged. See `traits::is_same_unit`.
+	 */
+	template<typename UnitTo, typename UnitFrom>
+	concept same_unit = traits::is_same_unit<UnitFrom, UnitTo>::value;
 
 	//------------------------------
 	//	STRONG UNIT TYPES
@@ -2063,6 +2074,34 @@ namespace units
 		inline constexpr bool is_same_dimension_conversion_factor_v = is_same_dimension_conversion_factor<Cf1, Cf2>::value;
 
 		/**
+		 * @ingroup		TypeTraits
+		 * @brief		`BinaryTypeTrait` for querying whether `Cf1` and `Cf2` are the same conversion factor.
+		 * @details		The base characteristic is a specialization of the template `std::bool_constant`. Two
+		 *				conversion factors are the same when they agree on all four parts a conversion is built
+		 *				from -- the dimension, the conversion ratio, the pi exponent and the datum translation --
+		 *				so a value expressed through either reads the same number.
+		 *
+		 *				This is the library's definition of sameness, and it is what generic code and tests should
+		 *				ask, not `std::is_same_v`. A conversion factor has a named spelling and a structural one --
+		 *				`units::area::square_meters_` and the factor `squared<units::length::meters_>` builds are
+		 *				one conversion factor written two ways -- and `std::is_same_v` reports those as different.
+		 * @tparam		Cf1 Conversion factor to query.
+		 * @tparam		Cf2 Conversion factor to query.
+		 * @sa			is_same_unit
+		 */
+		template<ConversionFactorType Cf1, ConversionFactorType Cf2>
+		struct is_same_conversion_factor
+		  : std::bool_constant<is_same_dimension_conversion_factor<Cf1, Cf2>::value &&
+				std::ratio_equal_v<typename conversion_factor_traits<Cf1>::conversion_ratio, typename conversion_factor_traits<Cf2>::conversion_ratio> &&
+				std::ratio_equal_v<typename conversion_factor_traits<Cf1>::pi_exponent_ratio, typename conversion_factor_traits<Cf2>::pi_exponent_ratio> &&
+				std::ratio_equal_v<typename conversion_factor_traits<Cf1>::translation_ratio, typename conversion_factor_traits<Cf2>::translation_ratio>>
+		{
+		};
+
+		template<ConversionFactorType Cf1, ConversionFactorType Cf2>
+		inline constexpr bool is_same_conversion_factor_v = is_same_conversion_factor<Cf1, Cf2>::value;
+
+		/**
 		 * @brief		`true` when a conversion factor carries a non-zero datum offset — i.e. it is AFFINE, not
 		 *				a pure scale (the archetype is temperature: degrees Celsius/Fahrenheit have an offset to
 		 *				the Kelvin datum). Absolute affine quantities do not add meaningfully, and their
@@ -2591,6 +2630,36 @@ namespace units
 
 		template<UnitType U1, UnitType U2>
 		inline constexpr bool is_same_dimension_unit_v = is_same_dimension_unit<U1, U2>::value;
+
+		/**
+		 * @ingroup		TypeTraits
+		 * @brief		`BinaryTypeTrait` for querying whether `U1` and `U2` are the same unit.
+		 * @details		The base characteristic is a specialization of the template `std::bool_constant`. Two units
+		 *				are the same when their conversion factors are the same (`is_same_conversion_factor`) and
+		 *				they carry the same numerical scale, so a value converts between them unchanged in both
+		 *				directions.
+		 *
+		 *				The numerical scale is part of a unit's identity: `UNIT_ADD_DECIBEL` builds `dBW` from
+		 *				`watts`'s conversion factor, so the two share every part of that factor and are still not
+		 *				the same unit -- three of one is not three of the other.
+		 *
+		 *				The REPRESENTATION is not part of a unit's identity, so `meters<double>` and `meters<int>`
+		 *				are the same unit. Nor is the spelling: a named unit is a class deriving from its
+		 *				`unit<...>`, so `std::is_same_v` reports a named unit and the `unit<...>` an operation
+		 *				builds for it as different types where this reports them the same.
+		 * @tparam		U1 Unit to query.
+		 * @tparam		U2 Unit to query.
+		 * @sa			is_same_conversion_factor
+		 */
+		template<UnitType U1, UnitType U2>
+		struct is_same_unit
+		  : std::bool_constant<is_same_conversion_factor<typename unit_traits<U1>::conversion_factor, typename unit_traits<U2>::conversion_factor>::value &&
+				std::is_same_v<typename unit_traits<U1>::numerical_scale_type, typename unit_traits<U2>::numerical_scale_type>>
+		{
+		};
+
+		template<UnitType U1, UnitType U2>
+		inline constexpr bool is_same_unit_v = is_same_unit<U1, U2>::value;
 	} // namespace traits
 
 	//----------------------------------

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -8782,6 +8782,76 @@ TEST(UnitComparison, aWideIntegralOperandOrdersExactly)
 	EXPECT_TRUE(meters<int>(1000) == kilometers<int>(1));
 }
 
+// `traits::is_same_unit` is the library's own definition of two types being one unit, which `std::is_same_v` does not
+// answer: a named unit is a class deriving from its `unit<...>`, and a conversion factor has a named spelling and a
+// structural one, so `std::is_same_v` reports one unit written two ways as two types.
+TEST(SameUnit, oneUnitWrittenTwoWaysIsOneUnit)
+{
+	// the same unit spelled by name and through the plain template
+	static_assert(traits::is_same_unit_v<meters<double>, unit<units::length::meters_, double>>);
+	static_assert(!std::is_same_v<meters<double>, unit<units::length::meters_, double>>,
+		"which std::is_same_v does not see, a named unit being a class deriving from its unit<...>");
+
+	// the representation is not part of a unit's identity
+	static_assert(traits::is_same_unit_v<meters<double>, meters<int>>);
+	static_assert(traits::is_same_unit_v<meters<float>, meters<long double>>);
+
+	// a product and the manipulator spelling of it are one unit
+	static_assert(traits::is_same_unit_v<std::decay_t<decltype(meters<double>(2.0) * meters<double>(3.0))>,
+		unit<squared<units::length::meters_>, double>>);
+	static_assert(traits::is_same_unit_v<units::area::square_meters<double>, unit<squared<units::length::meters_>, double>>);
+
+	// and the round trip through squared and back is the unit it started from, for every unit -- which is the
+	// contract, whether or not the result is spelled as the named type
+	static_assert(traits::is_same_unit_v<meters<double>, unit<square_root<squared<units::length::meters_>>, double>>);
+	static_assert(traits::is_same_unit_v<feet<double>, unit<square_root<squared<units::length::feet_>>, double>>);
+	static_assert(traits::is_same_unit_v<units::angle::degrees<double>,
+		unit<square_root<squared<units::angle::degrees_>>, double>>);
+	static_assert(traits::is_same_unit_v<kelvin<double>, unit<square_root<squared<units::temperature::kelvin_>>, double>>);
+}
+
+// What it must answer no to. Each of the four parts of a conversion factor, and the numerical scale, is part of a
+// unit's identity.
+TEST(SameUnit, aDifferenceInAnyPartIsADifferentUnit)
+{
+	// a different dimension
+	static_assert(!traits::is_same_unit_v<meters<double>, units::time::seconds<double>>);
+	// a different conversion ratio
+	static_assert(!traits::is_same_unit_v<meters<double>, feet<double>>);
+	static_assert(!traits::is_same_unit_v<meters<double>, kilometers<double>>);
+	// a different pi exponent: a degree carries one, a radian does not
+	static_assert(!traits::is_same_unit_v<units::angle::degrees<double>, units::angle::radians<double>>);
+	// a different datum: celsius and kelvin share a ratio and differ only by 273.15
+	static_assert(!traits::is_same_unit_v<celsius<double>, kelvin<double>>);
+	static_assert(traits::is_same_dimension_unit_v<celsius<double>, kelvin<double>>,
+		"the same dimension, which is why the dimension test alone is not enough");
+	// a different numerical scale: dBW is built from watts's conversion factor and is not the same unit
+	static_assert(traits::is_same_conversion_factor_v<units::power::dBW<double>::conversion_factor,
+					  units::power::watts<double>::conversion_factor>,
+		"dBW and watts share every part of the conversion factor");
+	static_assert(!traits::is_same_unit_v<units::power::dBW<double>, units::power::watts<double>>,
+		"and are still not the same unit, because the numerical scale differs");
+}
+
+// The concept form, for constraining generic code.
+TEST(SameUnit, theConceptConstrainsOnTheSameContract)
+{
+	static_assert(same_unit<meters<double>, unit<units::length::meters_, double>>);
+	static_assert(same_unit<meters<double>, meters<int>>);
+	static_assert(!same_unit<meters<double>, feet<double>>);
+	static_assert(!same_unit<celsius<double>, kelvin<double>>);
+	static_assert(!same_unit<units::power::dBW<double>, units::power::watts<double>>);
+
+	// and it agrees with what conversion actually does: a value crosses between two same units unchanged
+	using plainMetre = unit<units::length::meters_, double>;
+	using rootMetre  = unit<square_root<squared<units::length::meters_>>, double>;
+	using rootFoot   = unit<square_root<squared<units::length::feet_>>, double>;
+	EXPECT_DOUBLE_EQ(2.0, plainMetre(meters<double>(2.0)).value());
+	EXPECT_DOUBLE_EQ(2.0, rootMetre(meters<double>(2.0)).value());
+	EXPECT_DOUBLE_EQ(3.0, rootFoot(feet<double>(3.0)).value());
+}
+
+
 int main(int argc, char* argv[])
 {
 	::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
`std::is_same_v` is the wrong question for a unit, and the tests in #435 and #441 had to work around it by hand — asserting the conversion ratio, the dimension, the pi exponent, the datum and convertibility one at a time, because no single trait said "these are one unit."

A named unit is a class deriving from its `unit<...>`, and a conversion factor has a named spelling and a structural one, so one unit written two ways reports as two types:

```cpp
static_assert(!std::is_same_v<meters<double>, unit<units::length::meters_, double>>);       // two types
static_assert(traits::is_same_unit_v<meters<double>, unit<units::length::meters_, double>>); // one unit
```

That is also what makes the round trip through `squared` look broken when it isn't:

```cpp
static_assert(traits::is_same_unit_v<feet<double>, unit<square_root<squared<units::length::feet_>>, double>>);
static_assert(traits::is_same_unit_v<units::angle::degrees<double>,
    unit<square_root<squared<units::angle::degrees_>>, double>>);
```

### What it adds

- `traits::is_same_conversion_factor<Cf1, Cf2>` / `_v` — the four parts a conversion is built from: dimension, conversion ratio, pi exponent, datum.
- `traits::is_same_unit<U1, U2>` / `_v` — the above plus the numerical scale.
- `units::same_unit<UnitTo, UnitFrom>` — the concept form.

Mirrors the existing `is_same_dimension_conversion_factor` / `is_same_dimension_unit` pair and the `same_dimension` concept beside them, in the same style and the same places.

### What is and is not part of a unit's identity

The **numerical scale is**. `UNIT_ADD_DECIBEL` builds `dBW` from `watts`'s conversion factor, so those two share every part of that factor and are still not the same unit — three of one is not three of the other:

```cpp
static_assert(traits::is_same_conversion_factor_v<units::power::dBW<double>::conversion_factor,
                                                 units::power::watts<double>::conversion_factor>);
static_assert(!traits::is_same_unit_v<units::power::dBW<double>, units::power::watts<double>>);
```

The **representation is not**: `meters<double>` and `meters<int>` are the same unit.

### Verification

Three tests. One unit written two ways answers yes, including the round trip for a metre, a foot, a degree and a kelvin. A difference in any one of the five parts answers no — a different dimension, ratio, pi exponent, datum (celsius against kelvin, which share a dimension *and* a ratio and differ only by 273.15) or scale. And the concept agrees with what conversion actually does.

407 tests pass on gcc-13 and clang-19, warning-free. 77/77 diagnostic cases. Doxygen clean. Reference docs for both traits and the concept, and one changelog bullet.